### PR TITLE
feat(project): add VCS and pipeline URL detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.8.0",
+    "parse-github-url": "^1.0.3",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.3"
   },
   "devDependencies": {
-    "@types/node": "^22",
     "@eslint/js": "^9.21.0",
+    "@types/node": "^22",
+    "@types/parse-github-url": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^8.25.0",
     "@typescript-eslint/parser": "^8.25.0",
     "eslint": "^9.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.8.0
         version: 1.8.0
+      parse-github-url:
+        specifier: ^1.0.3
+        version: 1.0.3
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -24,6 +27,9 @@ importers:
       '@types/node':
         specifier: ^22
         version: 22.13.13
+      '@types/parse-github-url':
+        specifier: ^1.0.3
+        version: 1.0.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.25.0
         version: 8.29.0(@typescript-eslint/parser@8.29.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)
@@ -406,6 +412,9 @@ packages:
 
   '@types/node@22.13.13':
     resolution: {integrity: sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==}
+
+  '@types/parse-github-url@1.0.3':
+    resolution: {integrity: sha512-7sTbCVmSVzK/iAsHGIxoqiyAnqix9opZm68lOvaU6DBx9EQ9kHMSp0y7Criu2OCsZ9wDllEyCRU+LU4hPRxXUA==}
 
   '@typescript-eslint/eslint-plugin@8.29.0':
     resolution: {integrity: sha512-PAIpk/U7NIS6H7TEtN45SPGLQaHNgB7wSjsQV/8+KYokAb2T/gloOA/Bee2yd4/yKVhPKe5LlaUGhAZk5zmSaQ==}
@@ -1111,6 +1120,11 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-github-url@1.0.3:
+    resolution: {integrity: sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -1781,6 +1795,10 @@ snapshots:
   '@types/node@22.13.13':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/parse-github-url@1.0.3':
+    dependencies:
+      '@types/node': 22.13.13
 
   '@typescript-eslint/eslint-plugin@8.29.0(@typescript-eslint/parser@8.29.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)':
     dependencies:
@@ -2560,6 +2578,8 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-github-url@1.0.3: {}
 
   parseurl@1.3.3: {}
 

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -1,0 +1,32 @@
+import { getPipelineNumberFromURL, getProjectSlugFromURL } from './index.js';
+import { describe, it, expect } from 'vitest';
+
+describe('getPipelineNumberFromURL', () => {
+  it.each([
+    {
+      url: 'https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
+      expected: '2',
+    },
+    {
+      url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
+      expected: '123',
+    },
+  ])('extracts pipeline number $expected from URL', ({ url, expected }) => {
+    expect(getPipelineNumberFromURL(url)).toBe(expected);
+  });
+});
+
+describe('getProjectSlugFromURL', () => {
+  it.each([
+    {
+      url: 'https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
+      expected: 'gh/organization/project',
+    },
+    {
+      url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv  ',
+      expected: 'circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',
+    },
+  ])('extracts project slug $expected from URL', ({ url, expected }) => {
+    expect(getProjectSlugFromURL(url)).toBe(expected);
+  });
+});

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -1,0 +1,67 @@
+import { CircleCIPrivateClients } from '../../clients/circleci-private/index.js';
+import { getVCSFromHost } from './vcsTool.js';
+import gitUrlParse from 'parse-github-url';
+
+/**
+ * Identify the project slug from the git remote URL
+ * @param {string} gitRemoteURL - eg: https://github.com/organization/project.git
+ * @returns {string} project slug - eg: gh/organization/project
+ */
+export const identifyProjectSlug = async ({
+  token,
+  gitRemoteURL,
+}: {
+  token: string;
+  gitRemoteURL: string;
+}) => {
+  const cciPrivateClients = new CircleCIPrivateClients({
+    token,
+  });
+
+  const parsedGitURL = gitUrlParse(gitRemoteURL);
+  if (!parsedGitURL?.host) {
+    return null;
+  }
+
+  const vcs = getVCSFromHost(parsedGitURL.host);
+  if (!vcs) {
+    throw new Error(`VCS with host ${parsedGitURL.host} is not handled`);
+  }
+
+  const followedProjects = await cciPrivateClients.me.getFollowedProjects();
+  if (!followedProjects.success) {
+    throw new Error('Failed to get followed projects');
+  }
+
+  const project = followedProjects.data.items.find(
+    (followedProject) =>
+      followedProject.name === parsedGitURL.name &&
+      followedProject.vcs_type === vcs.name,
+  );
+
+  if (!project) {
+    return null;
+  }
+
+  return project.slug;
+};
+
+/**
+ * Get the pipeline number from the URL
+ * @param {string} url - eg: https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv
+ * @returns {string} pipeline number - eg: 2
+ */
+export const getPipelineNumberFromURL = (url: string) => {
+  const parts = url.split('/');
+  return parts[7];
+};
+
+/**
+ * Get the project slug from the URL
+ * @param {string} url - eg: https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv
+ * @returns {string} project slug - eg: gh/organization/project
+ */
+export const getProjectSlugFromURL = (url: string) => {
+  const parts = url.split('/');
+  return `${parts[4]}/${parts[5]}/${parts[6]}`;
+};

--- a/src/lib/project-detection/vcsTool.ts
+++ b/src/lib/project-detection/vcsTool.ts
@@ -1,0 +1,76 @@
+export type VCSDefinition = {
+  host: 'github.com' | 'bitbucket.org' | 'circleci.com';
+  name: 'github' | 'bitbucket' | 'circleci';
+  short: 'gh' | 'bb' | 'circleci';
+};
+
+/**
+ * Gitlab is not compatible with this representation
+ * https://circleci.atlassian.net/browse/DEVEX-175
+ */
+export const vcses: VCSDefinition[] = [
+  {
+    host: 'github.com',
+    name: 'github',
+    short: 'gh',
+  },
+  {
+    host: 'bitbucket.org',
+    name: 'bitbucket',
+    short: 'bb',
+  },
+  {
+    host: 'circleci.com',
+    name: 'circleci',
+    short: 'circleci',
+  },
+];
+
+export class UnhandledVCS extends Error {
+  constructor(vcs: string) {
+    super(`VCS ${vcs} is not handled at the moment`);
+  }
+}
+
+export function getVCSFromHost(host: string): VCSDefinition | undefined {
+  return vcses.find(({ host: vcsHost }) => host === vcsHost);
+}
+
+export function mustGetVCSFromHost(host: string): VCSDefinition {
+  const vcs = getVCSFromHost(host);
+
+  if (vcs === undefined) {
+    throw new UnhandledVCS(host);
+  }
+  return vcs;
+}
+
+export function getVCSFromName(name: string): VCSDefinition | undefined {
+  return vcses.find(({ name: vcsName }) => name === vcsName);
+}
+
+export function mustGetVCSFromName(name: string): VCSDefinition {
+  const vcs = getVCSFromName(name);
+
+  if (vcs === undefined) {
+    throw new UnhandledVCS(name);
+  }
+  return vcs;
+}
+
+export function getVCSFromShort(short: string): VCSDefinition | undefined {
+  return vcses.find(({ short: vcsShort }) => short === vcsShort);
+}
+
+export function mustGetVCSFromShort(short: string): VCSDefinition {
+  const vcs = getVCSFromShort(short);
+
+  if (vcs === undefined) {
+    throw new UnhandledVCS(short);
+  }
+  return vcs;
+}
+
+export function isLegacyProject(projectSlug: string) {
+  return ['gh', 'bb'].includes(projectSlug.split('/')[0]);
+}


### PR DESCRIPTION
• Parse project slugs from git remote URLs (gh/org/repo format)
• Handle GitHub, Bitbucket, and CircleCI VCS providers
• Extract pipeline numbers and project slugs from CircleCI URLs
• Add type-safe VCS definitions with host/name/short mappings