### PR TITLE
fix: more permissive JobSchema, filter to only retrieve job when we can

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2024-04-04
+
+### Fixed
+
+- Handle missing job numbers in CircleCI API responses by making job_number optional in schema
+- Skip jobs without job numbers when fetching job logs instead of failing
+
 ## [0.1.3] - 2024-04-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/clients/schemas.ts
+++ b/src/clients/schemas.ts
@@ -17,7 +17,7 @@ const WorkflowSchema = z.object({
 });
 
 const JobSchema = z.object({
-  job_number: z.number(),
+  job_number: z.number().optional(),
   id: z.string(),
 });
 

--- a/src/lib/job-logs/getJobLogs.ts
+++ b/src/lib/job-logs/getJobLogs.ts
@@ -58,12 +58,17 @@ const getJobLogs = async ({
   ).flat();
 
   const jobsDetails = await Promise.all(
-    jobs.map(async (job) => {
-      return await circleci.jobsV1.getJobDetails({
-        projectSlug,
-        jobNumber: job.job_number,
-      });
-    }),
+    jobs
+      .filter(
+        (job): job is typeof job & { job_number: number } =>
+          job.job_number != null,
+      )
+      .map(async (job) => {
+        return await circleci.jobsV1.getJobDetails({
+          projectSlug,
+          jobNumber: job.job_number,
+        });
+      }),
   );
 
   const allLogs = await Promise.all(


### PR DESCRIPTION
Found a case where `job_number` was not present. Rather than failing validation we can filter those cases out.