### PR TITLE
feat: Add configurable CircleCI base URL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,26 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.5] - 2024-04-04
+## [0.1.5] - 2025-04-08
 
 ### Added
 
 - Support for configurable CircleCI base URL through `CIRCLECI_BASE_URL` environment variable
 
-## [0.1.4] - 2024-04-04
+## [0.1.4] - 2025-04-08
 
 ### Fixed
 
 - Handle missing job numbers in CircleCI API responses by making job_number optional in schema
 - Skip jobs without job numbers when fetching job logs instead of failing
 
-## [0.1.3] - 2024-04-04
+## [0.1.3] - 2025-04-04
 
 ### Added
 
 - Improved schema validation and output formatting for job information
 
-## [0.1.2] - 2024-04-04
+## [0.1.2] - 2025-04-04
 
 ### Fixed
 
@@ -36,13 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated documentation around package publishing
 - Removed note about package not being published
 
-## [0.1.1] - 2024-04-04
+## [0.1.1] - 2025-04-04
 
 ### Fixed
 
 - Non functional fixes
 
-## [0.1.0] - 2024-04-04
+## [0.1.0] - 2025-04-04
 
 Initial release of the CircleCI MCP Server, enabling natural language interactions with CircleCI functionality through MCP-enabled clients.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2024-04-04
+
+### Added
+
+- Support for configurable CircleCI base URL through `CIRCLECI_BASE_URL` environment variable
+
 ## [0.1.4] - 2024-04-04
 
 ### Fixed
@@ -74,4 +80,3 @@ Initial release of the CircleCI MCP Server, enabling natural language interactio
 - Secure handling of CircleCI API tokens
 - Masked sensitive data in log outputs
 - Proper error handling to prevent information leakage
-

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Model Context Protocol (MCP) is a [new, standardized protocol](https://modelcont
 This lets you use Cursor IDE, or any MCP Client, to use natural language to accomplish things with CircleCI, e.g.:
 
 - `Find the latest failed pipeline on my branch and get logs`
-https://github.com/CircleCI-Public/mcp-server-circleci/wiki#circleci-mcp-server-with-cursor-ide
+  https://github.com/CircleCI-Public/mcp-server-circleci/wiki#circleci-mcp-server-with-cursor-ide
 
 https://github.com/user-attachments/assets/3c765985-8827-442a-a8dc-5069e01edb74
 
@@ -32,7 +32,8 @@ Add the following to your cursor MCP config:
       "command": "npx",
       "args": ["-y", "@circleci/mcp-server-circleci"],
       "env": {
-        "CIRCLECI_TOKEN": "your-circleci-token"
+        "CIRCLECI_TOKEN": "your-circleci-token",
+        "CIRCLECI_BASE_URL": "https://circleci.com"
       }
     }
   }
@@ -115,6 +116,7 @@ The easiest way to iterate on the MCP Server is using the MCP inspector. You can
 3. Configure the environment:
    - Add your `CIRCLECI_TOKEN` to the Environment Variables section in the inspector UI
    - The token needs read access to your CircleCI projects
+   - Optionally you can set your CircleCI Base URL. Defaults to `https//circleci.com`
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/clients/circleci-private/index.ts
+++ b/src/clients/circleci-private/index.ts
@@ -10,25 +10,13 @@ import { MeAPI } from './me.js';
  * @param options.baseURL Base URL for the CircleCI API private
  * @returns HTTP client for CircleCI API private
  */
-const defaultPrivateHTTPClient = (options: {
-  token: string;
-  baseURL?: string;
-}) => {
+const defaultPrivateHTTPClient = (options: { token: string }) => {
   if (!options.token) {
     throw new Error('Token is required');
   }
 
-  let baseURL = options.baseURL || process.env.CIRCLECI_BASE_URL;
-  if (!baseURL) {
-    throw new Error('Base URL is required');
-  }
-
-  // Remove trailing slash from baseURL
-  baseURL = baseURL.replace(/\/$/, '');
-  baseURL = `${baseURL}/api/private`;
-
   return new HTTPClient(
-    baseURL,
+    '/api/private',
     createCircleCIHeaders({ token: options.token }),
   );
 };
@@ -38,14 +26,11 @@ export class CircleCIPrivateClients {
   public jobs: JobsPrivate;
   constructor({
     token,
-    baseURL,
     privateHTTPClient = defaultPrivateHTTPClient({
       token,
-      baseURL,
     }),
   }: {
     token: string;
-    baseURL?: string;
     privateHTTPClient?: HTTPClient;
   }) {
     this.me = new MeAPI(privateHTTPClient);

--- a/src/clients/circleci/httpClient.test.ts
+++ b/src/clients/circleci/httpClient.test.ts
@@ -3,11 +3,12 @@ import { expect, vi, describe, it, beforeEach, afterEach } from 'vitest';
 
 describe('HTTPClient', () => {
   let client: HTTPClient;
-  const baseURL = 'https://api.example.com';
+  const apiPath = '/api/v2';
   const headers = { 'Content-Type': 'application/json' };
+  const baseURL = 'https://circleci.com' + apiPath;
 
   beforeEach(() => {
-    client = new HTTPClient(baseURL, headers);
+    client = new HTTPClient(apiPath, headers);
     global.fetch = vi.fn();
   });
 

--- a/src/clients/circleci/httpClient.test.ts
+++ b/src/clients/circleci/httpClient.test.ts
@@ -5,15 +5,35 @@ describe('HTTPClient', () => {
   let client: HTTPClient;
   const apiPath = '/api/v2';
   const headers = { 'Content-Type': 'application/json' };
-  const baseURL = 'https://circleci.com' + apiPath;
+  const defaultBaseURL = 'https://circleci.com';
+  const baseURL = defaultBaseURL + apiPath;
 
   beforeEach(() => {
+    // Clear any environment variables before each test
+    delete process.env.CIRCLECI_BASE_URL;
     client = new HTTPClient(apiPath, headers);
     global.fetch = vi.fn();
   });
 
   afterEach(() => {
     vi.resetAllMocks();
+    // Clean up environment variables
+    delete process.env.CIRCLECI_BASE_URL;
+  });
+
+  describe('constructor', () => {
+    it('should use default base URL when CIRCLECI_BASE_URL is not set', () => {
+      const url = (client as any).buildURL('/test');
+      expect(url.toString()).toBe(`${defaultBaseURL}${apiPath}/test`);
+    });
+
+    it('should use CIRCLECI_BASE_URL when set', () => {
+      const customBaseURL = 'https://custom-circleci.example.com';
+      process.env.CIRCLECI_BASE_URL = customBaseURL;
+      const customClient = new HTTPClient(apiPath, headers);
+      const url = (customClient as any).buildURL('/test');
+      expect(url.toString()).toBe(`${customBaseURL}${apiPath}/test`);
+    });
   });
 
   describe('buildURL', () => {

--- a/src/clients/circleci/httpClient.ts
+++ b/src/clients/circleci/httpClient.ts
@@ -2,8 +2,10 @@ export class HTTPClient {
   protected baseURL: string;
   protected headers: HeadersInit;
 
-  constructor(baseURL: string, headers?: HeadersInit) {
-    this.baseURL = baseURL;
+  constructor(apiPath: string, headers?: HeadersInit) {
+    this.baseURL =
+      (process.env.CIRCLECI_BASE_URL || 'https://circleci.com') + apiPath;
+
     if (headers) {
       this.headers = headers;
     } else {

--- a/src/clients/circleci/index.ts
+++ b/src/clients/circleci/index.ts
@@ -37,30 +37,58 @@ export function createCircleCIHeaders({
 
 /**
  * Creates a default HTTP client for the CircleCI API v2
- * @param token CircleCI API token
+ * @param options Configuration parameters
+ * @param options.token CircleCI API token
+ * @param options.baseURL Base URL for the CircleCI API v2
  * @returns HTTP client for CircleCI API v2
  */
-const defaultV2HTTPClient = (token: string) => {
-  if (!token) {
+const defaultV2HTTPClient = (options: { token: string; baseURL?: string }) => {
+  if (!options.token) {
     throw new Error('Token is required');
   }
-  const headers = createCircleCIHeaders({ token });
-  return new HTTPClient('https://circleci.com/api/v2', headers);
+  let baseURL = options.baseURL || process.env.CIRCLECI_BASE_URL;
+  if (!baseURL) {
+    throw new Error('Base URL is required');
+  }
+
+  // Remove trailing slash from baseURL
+  baseURL = baseURL.replace(/\/$/, '');
+  baseURL = `${baseURL}/api/v2`;
+
+  const headers = createCircleCIHeaders({ token: options.token });
+  return new HTTPClient(baseURL, headers);
 };
 
 /**
  * Creates a default HTTP client for the CircleCI API v1
- * @param token CircleCI API token
+ * @param options Configuration parameters
+ * @param options.token CircleCI API token
+ * @param options.baseURL Base URL for the CircleCI API v1
  * @returns HTTP client for CircleCI API v1
  */
-const defaultV1HTTPClient = (token: string) => {
-  if (!token) {
+const defaultV1HTTPClient = (options: { token: string; baseURL?: string }) => {
+  if (!options.token) {
     throw new Error('Token is required');
   }
-  const headers = createCircleCIHeaders({ token });
-  return new HTTPClient('https://circleci.com/api/v1.1', headers);
+  let baseURL = options.baseURL || process.env.CIRCLECI_BASE_URL;
+  if (!baseURL) {
+    throw new Error('Base URL is required');
+  }
+
+  // Remove trailing slash from baseURL
+  baseURL = baseURL.replace(/\/$/, '');
+  baseURL = `${baseURL}/api/v1.1`;
+
+  const headers = createCircleCIHeaders({ token: options.token });
+  return new HTTPClient(baseURL, headers);
 };
 
+/**
+ * Creates a default HTTP client for the CircleCI API v2
+ * @param options Configuration parameters
+ * @param options.token CircleCI API token
+ * @param options.baseURL Base URL for the CircleCI API v2
+ */
 export class CircleCIClients {
   public jobs: JobsAPI;
   public pipelines: PipelinesAPI;
@@ -69,10 +97,18 @@ export class CircleCIClients {
 
   constructor({
     token,
-    v2httpClient = defaultV2HTTPClient(token),
-    v1httpClient = defaultV1HTTPClient(token),
+    baseURL,
+    v2httpClient = defaultV2HTTPClient({
+      token,
+      baseURL,
+    }),
+    v1httpClient = defaultV1HTTPClient({
+      token,
+      baseURL,
+    }),
   }: {
     token: string;
+    baseURL?: string;
     v2httpClient?: HTTPClient;
     v1httpClient?: HTTPClient;
   }) {

--- a/src/clients/circleci/index.ts
+++ b/src/clients/circleci/index.ts
@@ -42,21 +42,13 @@ export function createCircleCIHeaders({
  * @param options.baseURL Base URL for the CircleCI API v2
  * @returns HTTP client for CircleCI API v2
  */
-const defaultV2HTTPClient = (options: { token: string; baseURL?: string }) => {
+const defaultV2HTTPClient = (options: { token: string }) => {
   if (!options.token) {
     throw new Error('Token is required');
   }
-  let baseURL = options.baseURL || process.env.CIRCLECI_BASE_URL;
-  if (!baseURL) {
-    throw new Error('Base URL is required');
-  }
-
-  // Remove trailing slash from baseURL
-  baseURL = baseURL.replace(/\/$/, '');
-  baseURL = `${baseURL}/api/v2`;
 
   const headers = createCircleCIHeaders({ token: options.token });
-  return new HTTPClient(baseURL, headers);
+  return new HTTPClient('/api/v2', headers);
 };
 
 /**
@@ -70,17 +62,9 @@ const defaultV1HTTPClient = (options: { token: string; baseURL?: string }) => {
   if (!options.token) {
     throw new Error('Token is required');
   }
-  let baseURL = options.baseURL || process.env.CIRCLECI_BASE_URL;
-  if (!baseURL) {
-    throw new Error('Base URL is required');
-  }
-
-  // Remove trailing slash from baseURL
-  baseURL = baseURL.replace(/\/$/, '');
-  baseURL = `${baseURL}/api/v1.1`;
 
   const headers = createCircleCIHeaders({ token: options.token });
-  return new HTTPClient(baseURL, headers);
+  return new HTTPClient('/api/v1.1', headers);
 };
 
 /**
@@ -90,6 +74,9 @@ const defaultV1HTTPClient = (options: { token: string; baseURL?: string }) => {
  * @param options.baseURL Base URL for the CircleCI API v2
  */
 export class CircleCIClients {
+  protected apiPathV2 = '/api/v2';
+  protected apiPathV1 = '/api/v1.1';
+
   public jobs: JobsAPI;
   public pipelines: PipelinesAPI;
   public workflows: WorkflowsAPI;
@@ -97,14 +84,11 @@ export class CircleCIClients {
 
   constructor({
     token,
-    baseURL,
     v2httpClient = defaultV2HTTPClient({
       token,
-      baseURL,
     }),
     v1httpClient = defaultV1HTTPClient({
       token,
-      baseURL,
     }),
   }: {
     token: string;

--- a/src/lib/job-logs/getJobLogs.ts
+++ b/src/lib/job-logs/getJobLogs.ts
@@ -4,23 +4,27 @@ import { CircleCIPrivateClients } from '../../clients/circleci-private/index.js'
 
 export type GetJobLogsParams = {
   projectSlug: string;
+  baseURL?: string;
   branch?: string;
   pipelineNumber?: number; // if provided, always use this to fetch the pipeline instead of the branch
 };
 
-const circleci = new CircleCIClients({
-  token: process.env.CIRCLECI_TOKEN || '',
-});
-
-const circleciPrivate = new CircleCIPrivateClients({
-  token: process.env.CIRCLECI_TOKEN || '',
-});
-
 const getJobLogs = async ({
   projectSlug,
+  baseURL,
   branch,
   pipelineNumber,
 }: GetJobLogsParams) => {
+  const circleci = new CircleCIClients({
+    token: process.env.CIRCLECI_TOKEN || '',
+    baseURL,
+  });
+
+  const circleciPrivate = new CircleCIPrivateClients({
+    token: process.env.CIRCLECI_TOKEN || '',
+    baseURL,
+  });
+
   let pipeline: Pipeline | undefined;
 
   if (pipelineNumber) {

--- a/src/lib/job-logs/getJobLogs.ts
+++ b/src/lib/job-logs/getJobLogs.ts
@@ -4,25 +4,21 @@ import { CircleCIPrivateClients } from '../../clients/circleci-private/index.js'
 
 export type GetJobLogsParams = {
   projectSlug: string;
-  baseURL?: string;
   branch?: string;
   pipelineNumber?: number; // if provided, always use this to fetch the pipeline instead of the branch
 };
 
 const getJobLogs = async ({
   projectSlug,
-  baseURL,
   branch,
   pipelineNumber,
 }: GetJobLogsParams) => {
   const circleci = new CircleCIClients({
     token: process.env.CIRCLECI_TOKEN || '',
-    baseURL,
   });
 
   const circleciPrivate = new CircleCIPrivateClients({
     token: process.env.CIRCLECI_TOKEN || '',
-    baseURL,
   });
 
   let pipeline: Pipeline | undefined;

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -22,6 +22,8 @@ export const getBuildFailureLogs: ToolCallback<{
     throw new Error('CIRCLECI_TOKEN is not set');
   }
 
+  const baseURL = process.env.CIRCLECI_BASE_URL;
+
   const token = process.env.CIRCLECI_TOKEN;
   let projectSlug: string | null | undefined;
   let pipelineNumber: number | undefined;
@@ -67,6 +69,7 @@ export const getBuildFailureLogs: ToolCallback<{
 
   const logs = await getJobLogs({
     projectSlug,
+    baseURL,
     branch,
     pipelineNumber,
   });

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -22,8 +22,6 @@ export const getBuildFailureLogs: ToolCallback<{
     throw new Error('CIRCLECI_TOKEN is not set');
   }
 
-  const baseURL = process.env.CIRCLECI_BASE_URL;
-
   const token = process.env.CIRCLECI_TOKEN;
   let projectSlug: string | null | undefined;
   let pipelineNumber: number | undefined;
@@ -69,7 +67,6 @@ export const getBuildFailureLogs: ToolCallback<{
 
   const logs = await getJobLogs({
     projectSlug,
-    baseURL,
     branch,
     pipelineNumber,
   });


### PR DESCRIPTION
This change enables users to configure custom CircleCI base URLs for API requests, making the client more flexible for different CircleCI deployments.

Changes:
- Add `CIRCLECI_BASE_URL` environment variable support (defaults to https://circleci.com)
- Update API clients (v1, v2, private) to accept custom base URLs
- Enhance type definitions and documentation for better developer experience
- Update README with new configuration options

Breaking changes: None
The default behaviour remains unchanged when no base URL is provided.

Documentation:
- Added base URL configuration example in README
- Updated API client documentation with new options
- Added type definitions for new configuration parameters