### PR TITLE
feat: add User-Agent header to CircleCI API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2025-04-09
+
+### Added
+
+- Added User-Agent header to CircleCI API requests
+
 ## [0.1.5] - 2025-04-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/clients/circleci/index.ts
+++ b/src/clients/circleci/index.ts
@@ -48,9 +48,7 @@ const defaultV2HTTPClient = (options: { token: string }) => {
     throw new Error('Token is required');
   }
 
-  const headers = createCircleCIHeaders({
-    token: options.token,
-  });
+  const headers = createCircleCIHeaders({ token: options.token });
   return new HTTPClient('/api/v2', headers);
 };
 

--- a/src/clients/circleci/index.ts
+++ b/src/clients/circleci/index.ts
@@ -30,6 +30,7 @@ export function createCircleCIHeaders({
   Object.assign(headers, {
     'Circle-Token': token,
     'Content-Type': 'application/json',
+    'User-Agent': 'CircleCI-MCP-Server/0.1',
   });
 
   return headers;
@@ -47,7 +48,9 @@ const defaultV2HTTPClient = (options: { token: string }) => {
     throw new Error('Token is required');
   }
 
-  const headers = createCircleCIHeaders({ token: options.token });
+  const headers = createCircleCIHeaders({
+    token: options.token,
+  });
   return new HTTPClient('/api/v2', headers);
 };
 


### PR DESCRIPTION
- Add User-Agent header 'CircleCI-MCP-Server/0.1' to identify client requests
- Bump version from 0.1.5 to 0.1.6