### PR TITLE
improving URL parsing, tool descriptions/schemas, branch in url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8] - 2025-04-10
+
+### Fixed
+- Fixed bug in flaky test detection where pipelineNumber was incorrectly used instead of projectSlug when URL not provided
+
+### Improvements
+- Consolidated project slug detection functions into a single `getPipelineNumberFromURL` function with enhanced test coverage
+- Simplified build logs tool to use only `projectURL` parameter instead of separate pipeline and job URLs
+- Updated tool descriptions to provide clearer guidance on accepted URL formats
+- Removed redundant error handling wrapper
+
 ## [0.1.7] - 2025-04-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/circleci-tools.ts
+++ b/src/circleci-tools.ts
@@ -19,31 +19,7 @@ type ToolHandlers = {
   [K in CCIToolName]: ToolHandler<K>;
 };
 
-// Higher-order function to wrap handlers with error handling
-// Ensures any thrown errors are handled in an MCP friendly manner
-const withErrorHandling = <T extends CCIToolName>(
-  handler: ToolHandler<T>,
-): ToolHandler<T> => {
-  return async (args, server) => {
-    try {
-      return await handler(args, server);
-    } catch (error) {
-      console.error('Tool execution failed:', error);
-
-      return {
-        isError: true,
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error executing tool: ${error instanceof Error ? error.message : 'An unknown error occurred'}. Please check your inputs and try again.`,
-          },
-        ],
-      };
-    }
-  };
-};
-
 export const CCI_HANDLERS = {
-  get_build_failure_logs: withErrorHandling(getBuildFailureLogs),
-  find_flaky_tests: withErrorHandling(getFlakyTestLogs),
+  get_build_failure_logs: getBuildFailureLogs,
+  find_flaky_tests: getFlakyTestLogs,
 } satisfies ToolHandlers;

--- a/src/lib/mcpErrorOutput.ts
+++ b/src/lib/mcpErrorOutput.ts
@@ -1,6 +1,6 @@
 export default function mcpErrorOutput(text: string) {
   return {
-    isError: true,
+    isError: true as const,
     content: [
       {
         type: 'text' as const,

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -83,6 +83,11 @@ describe('getProjectSlugFromURL', () => {
       url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',
       expected: 'circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',
     },
+    // Project URL with query parameters
+    {
+      url: 'https://app.circleci.com/pipelines/github/CircleCI-Public/hungry-panda?branch=splitting',
+      expected: 'github/CircleCI-Public/hungry-panda',
+    },
   ])('extracts project slug $expected from URL', ({ url, expected }) => {
     expect(getProjectSlugFromURL(url)).toBe(expected);
   });

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -13,8 +13,27 @@ describe('getPipelineNumberFromURL', () => {
       url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
       expected: 123,
     },
+    // Project URL (no pipeline number)
+    {
+      url: 'https://app.circleci.com/pipelines/gh/organization/project',
+      expected: undefined,
+    },
   ])('extracts pipeline number $expected from URL', ({ url, expected }) => {
     expect(getPipelineNumberFromURL(url)).toBe(expected);
+  });
+
+  it('throws error for invalid CircleCI URL format', () => {
+    expect(() =>
+      getPipelineNumberFromURL('https://app.circleci.com/invalid/url'),
+    ).toThrow('Invalid CircleCI URL format');
+  });
+
+  it('throws error when pipeline number is not a valid number', () => {
+    expect(() =>
+      getPipelineNumberFromURL(
+        'https://app.circleci.com/pipelines/gh/organization/project/abc/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
+      ),
+    ).toThrow('Pipeline number in URL is not a valid number');
   });
 });
 

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -5,11 +5,11 @@ describe('getPipelineNumberFromURL', () => {
   it.each([
     {
       url: 'https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
-      expected: '2',
+      expected: 2,
     },
     {
       url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
-      expected: '123',
+      expected: 123,
     },
   ])('extracts pipeline number $expected from URL', ({ url, expected }) => {
     expect(getPipelineNumberFromURL(url)).toBe(expected);
@@ -23,10 +23,30 @@ describe('getProjectSlugFromURL', () => {
       expected: 'gh/organization/project',
     },
     {
-      url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv  ',
+      url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
+      expected: 'circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',
+    },
+    {
+      url: 'https://app.circleci.com/pipelines/gh/organization/project',
+      expected: 'gh/organization/project',
+    },
+    {
+      url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',
       expected: 'circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',
     },
   ])('extracts project slug $expected from URL', ({ url, expected }) => {
     expect(getProjectSlugFromURL(url)).toBe(expected);
+  });
+
+  it('throws error for invalid CircleCI URL format', () => {
+    expect(() =>
+      getProjectSlugFromURL('https://app.circleci.com/invalid/url'),
+    ).toThrow('Invalid CircleCI URL format');
+  });
+
+  it('throws error when project information is incomplete', () => {
+    expect(() =>
+      getProjectSlugFromURL('https://app.circleci.com/pipelines/gh'),
+    ).toThrow('Unable to extract project information from URL');
   });
 });

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -3,10 +3,12 @@ import { describe, it, expect } from 'vitest';
 
 describe('getPipelineNumberFromURL', () => {
   it.each([
+    // Workflow URL
     {
       url: 'https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
       expected: 2,
     },
+    // Workflow URL
     {
       url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
       expected: 123,
@@ -18,18 +20,42 @@ describe('getPipelineNumberFromURL', () => {
 
 describe('getProjectSlugFromURL', () => {
   it.each([
+    // Workflow URL
     {
       url: 'https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
       expected: 'gh/organization/project',
     },
+    // Workflow URL
     {
       url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
       expected: 'circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',
     },
+    // Pipeline URL
+    {
+      url: 'https://app.circleci.com/pipelines/gh/organization/project/123',
+      expected: 'gh/organization/project',
+    },
+    // Pipeline URL
+    {
+      url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/456',
+      expected: 'circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',
+    },
+    // Job URL
+    {
+      url: 'https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv/jobs/xyz789',
+      expected: 'gh/organization/project',
+    },
+    // Job URL
+    {
+      url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv/jobs/def456',
+      expected: 'circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',
+    },
+    // Project URL
     {
       url: 'https://app.circleci.com/pipelines/gh/organization/project',
       expected: 'gh/organization/project',
     },
+    // Project URL
     {
       url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',
       expected: 'circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -1,4 +1,8 @@
-import { getPipelineNumberFromURL, getProjectSlugFromURL } from './index.js';
+import {
+  getPipelineNumberFromURL,
+  getProjectSlugFromURL,
+  getBranchFromURL,
+} from './index.js';
 import { describe, it, expect } from 'vitest';
 
 describe('getPipelineNumberFromURL', () => {
@@ -93,5 +97,38 @@ describe('getProjectSlugFromURL', () => {
     expect(() =>
       getProjectSlugFromURL('https://app.circleci.com/pipelines/gh'),
     ).toThrow('Unable to extract project information from URL');
+  });
+});
+
+describe('getBranchFromURL', () => {
+  it.each([
+    // URL with branch parameter
+    {
+      url: 'https://app.circleci.com/pipelines/gh/organization/project?branch=feature-branch',
+      expected: 'feature-branch',
+    },
+    // URL with branch parameter and other params
+    {
+      url: 'https://app.circleci.com/pipelines/gh/organization/project?branch=fix%2Fbug-123&filter=mine',
+      expected: 'fix/bug-123',
+    },
+    // URL without branch parameter
+    {
+      url: 'https://app.circleci.com/pipelines/gh/organization/project',
+      expected: undefined,
+    },
+    // URL with other parameters but no branch
+    {
+      url: 'https://app.circleci.com/pipelines/gh/organization/project?filter=mine',
+      expected: undefined,
+    },
+  ])('extracts branch $expected from URL', ({ url, expected }) => {
+    expect(getBranchFromURL(url)).toBe(expected);
+  });
+
+  it('throws error for invalid CircleCI URL format', () => {
+    expect(() => getBranchFromURL('not-a-url')).toThrow(
+      'Invalid CircleCI URL format',
+    );
   });
 });

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -86,12 +86,13 @@ export const getPipelineNumberFromURL = (url: string): number | undefined => {
  * // returns 'gh/organization/project'
  *
  * @example
- * // Simple project URL
- * getProjectSlugFromURL('https://app.circleci.com/pipelines/gh/organization/project')
+ * // Simple project URL with query parameters
+ * getProjectSlugFromURL('https://app.circleci.com/pipelines/gh/organization/project?branch=main')
  * // returns 'gh/organization/project'
  */
 export const getProjectSlugFromURL = (url: string) => {
-  const parts = url.split('/');
+  const urlWithoutQuery = url.split('?')[0];
+  const parts = urlWithoutQuery.split('/');
   const pipelineIndex = parts.indexOf('pipelines');
   if (pipelineIndex === -1) {
     throw new Error('Invalid CircleCI URL format');

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -56,7 +56,7 @@ export const identifyProjectSlug = async ({
  * getPipelineNumberFromURL('https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv')
  * // returns 123
  */
-export const getPipelineNumberFromURL = (url: string): number => {
+export const getPipelineNumberFromURL = (url: string): number | undefined => {
   const parts = url.split('/');
   const pipelineIndex = parts.indexOf('pipelines');
   if (pipelineIndex === -1) {
@@ -65,7 +65,7 @@ export const getPipelineNumberFromURL = (url: string): number => {
   const pipelineNumber = parts[pipelineIndex + 4];
 
   if (!pipelineNumber) {
-    throw new Error('Unable to extract pipeline number from URL');
+    return undefined;
   }
 
   const parsedNumber = Number(pipelineNumber);

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -44,34 +44,57 @@ export const identifyProjectSlug = async ({
 
 /**
  * Get the pipeline number from the URL
- * @param {string} url - eg: https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv
- * @returns {string} pipeline number - eg: 2
+ * @param {string} url - CircleCI pipeline URL
+ * @returns {number} The pipeline number
+ * @example
+ * // Standard pipeline URL
+ * getPipelineNumberFromURL('https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv')
+ * // returns 2
+ *
+ * @example
+ * // Pipeline URL with complex project path
+ * getPipelineNumberFromURL('https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv')
+ * // returns 123
  */
-export const getPipelineNumberFromURL = (url: string) => {
-  const parts = url.split('/');
-  return parts[7];
-};
-
-/**
- * Get the project slug from the URL
- * @param {string} url - eg: https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv
- * @returns {string} project slug - eg: gh/organization/project
- */
-export const getProjectSlugFromURL = (url: string) => {
-  const parts = url.split('/');
-  return `${parts[4]}/${parts[5]}/${parts[6]}`;
-};
-
-/**
- * Get the project slug from the URL
- * @param {string} url - eg: https://app.circleci.com/pipelines/gh/organization/project
- * @returns {string} project slug - eg: gh/organization/project
- */
-export const getProjectSlugFromProjectURL = (url: string) => {
+export const getPipelineNumberFromURL = (url: string): number => {
   const parts = url.split('/');
   const pipelineIndex = parts.indexOf('pipelines');
   if (pipelineIndex === -1) {
-    throw new Error('Invalid CircleCI project URL format');
+    throw new Error('Invalid CircleCI URL format');
+  }
+  const pipelineNumber = parts[pipelineIndex + 4];
+
+  if (!pipelineNumber) {
+    throw new Error('Unable to extract pipeline number from URL');
+  }
+
+  const parsedNumber = Number(pipelineNumber);
+  if (isNaN(parsedNumber)) {
+    throw new Error('Pipeline number in URL is not a valid number');
+  }
+
+  return parsedNumber;
+};
+
+/**
+ * Get the project slug from the URL
+ * @param {string} url - CircleCI pipeline or project URL
+ * @returns {string} project slug - eg: gh/organization/project
+ * @example
+ * // Pipeline URL with workflow
+ * getProjectSlugFromURL('https://app.circleci.com/pipelines/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv')
+ * // returns 'gh/organization/project'
+ *
+ * @example
+ * // Simple project URL
+ * getProjectSlugFromURL('https://app.circleci.com/pipelines/gh/organization/project')
+ * // returns 'gh/organization/project'
+ */
+export const getProjectSlugFromURL = (url: string) => {
+  const parts = url.split('/');
+  const pipelineIndex = parts.indexOf('pipelines');
+  if (pipelineIndex === -1) {
+    throw new Error('Invalid CircleCI URL format');
   }
   const vcs = parts[pipelineIndex + 1];
   const org = parts[pipelineIndex + 2];

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -20,7 +20,7 @@ export const identifyProjectSlug = async ({
 
   const parsedGitURL = gitUrlParse(gitRemoteURL);
   if (!parsedGitURL?.host) {
-    return null;
+    return undefined;
   }
 
   const vcs = getVCSFromHost(parsedGitURL.host);
@@ -105,4 +105,27 @@ export const getProjectSlugFromURL = (url: string) => {
   }
 
   return `${vcs}/${org}/${project}`;
+};
+
+/**
+ * Get the branch name from the URL's query parameters
+ * @param {string} url - CircleCI pipeline URL
+ * @returns {string | undefined} The branch name if present in the URL
+ * @example
+ * // URL with branch parameter
+ * getBranchFromURL('https://app.circleci.com/pipelines/gh/organization/project?branch=feature-branch')
+ * // returns 'feature-branch'
+ *
+ * @example
+ * // URL without branch parameter
+ * getBranchFromURL('https://app.circleci.com/pipelines/gh/organization/project')
+ * // returns undefined
+ */
+export const getBranchFromURL = (url: string): string | undefined => {
+  try {
+    const urlObj = new URL(url);
+    return urlObj.searchParams.get('branch') || undefined;
+  } catch {
+    throw new Error('Invalid CircleCI URL format');
+  }
 };

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -2,6 +2,7 @@ import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
   getPipelineNumberFromURL,
   getProjectSlugFromURL,
+  getBranchFromURL,
   identifyProjectSlug,
 } from '../../lib/project-detection/index.js';
 import { getBuildFailureOutputInputSchema } from './inputSchema.js';
@@ -19,12 +20,14 @@ export const getBuildFailureLogs: ToolCallback<{
   }
 
   const token = process.env.CIRCLECI_TOKEN;
-  let projectSlug: string | null | undefined;
+  let projectSlug: string | undefined;
   let pipelineNumber: number | undefined;
+  let branchFromURL: string | undefined;
 
   if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);
     pipelineNumber = getPipelineNumberFromURL(projectURL);
+    branchFromURL = getBranchFromURL(projectURL);
   } else if (workspaceRoot && gitRemoteURL && branch) {
     projectSlug = await identifyProjectSlug({
       token,
@@ -48,7 +51,7 @@ export const getBuildFailureLogs: ToolCallback<{
 
   const logs = await getPipelineJobLogs({
     projectSlug,
-    branch,
+    branch: branchFromURL || branch,
     pipelineNumber,
   });
 

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -7,17 +7,12 @@ import {
 import { getBuildFailureOutputInputSchema } from './inputSchema.js';
 import getPipelineJobLogs from '../../lib/pipeline-job-logs/getPipelineJobLogs.js';
 import { formatJobLogs } from '../../lib/pipeline-job-logs/getJobLogs.js';
+import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
 
 export const getBuildFailureLogs: ToolCallback<{
   params: typeof getBuildFailureOutputInputSchema;
 }> = async (args) => {
-  const {
-    workspaceRoot,
-    gitRemoteURL,
-    branch,
-    failedPipelineURL,
-    failedJobURL,
-  } = args.params;
+  const { workspaceRoot, gitRemoteURL, branch, projectURL } = args.params;
 
   if (!process.env.CIRCLECI_TOKEN) {
     throw new Error('CIRCLECI_TOKEN is not set');
@@ -27,43 +22,32 @@ export const getBuildFailureLogs: ToolCallback<{
   let projectSlug: string | null | undefined;
   let pipelineNumber: number | undefined;
 
-  if (failedPipelineURL || failedJobURL) {
-    const failedURL = (failedPipelineURL ?? failedJobURL)!;
-    projectSlug = getProjectSlugFromURL(failedURL);
-    pipelineNumber = parseInt(getPipelineNumberFromURL(failedURL));
+  if (projectURL) {
+    projectSlug = getProjectSlugFromURL(projectURL);
+    try {
+      pipelineNumber = getPipelineNumberFromURL(projectURL);
+    } catch {
+      pipelineNumber = undefined;
+    }
   } else if (workspaceRoot && gitRemoteURL && branch) {
     projectSlug = await identifyProjectSlug({
       token,
       gitRemoteURL,
     });
   } else {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text' as const,
-          text: 'No inputs provided. Ask the user to provide the inputs user can provide based on the tool description.',
-        },
-      ],
-    };
+    return mcpErrorOutput(
+      'No inputs provided. Ask the user to provide the inputs user can provide based on the tool description.',
+    );
   }
 
   if (!projectSlug) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: 'text' as const,
-          text: `
+    return mcpErrorOutput(`
           Project not found. Ask the user to provide the inputs user can provide based on the tool description.
 
           Project slug: ${projectSlug}
           Git remote URL: ${gitRemoteURL}
           Branch: ${branch}
-          `,
-        },
-      ],
-    };
+          `);
   }
 
   const logs = await getPipelineJobLogs({

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -24,11 +24,7 @@ export const getBuildFailureLogs: ToolCallback<{
 
   if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);
-    try {
-      pipelineNumber = getPipelineNumberFromURL(projectURL);
-    } catch {
-      pipelineNumber = undefined;
-    }
+    pipelineNumber = getPipelineNumberFromURL(projectURL);
   } else if (workspaceRoot && gitRemoteURL && branch) {
     projectSlug = await identifyProjectSlug({
       token,

--- a/src/tools/getBuildFailureLogs/inputSchema.ts
+++ b/src/tools/getBuildFailureLogs/inputSchema.ts
@@ -28,7 +28,7 @@ export const getBuildFailureOutputInputSchema = z.object({
     .string()
     .describe(
       'The URL of the CircleCI project. Can be any of these formats:\n' +
-        '- Project URL: https://app.circleci.com/pipelines/gh/organization/project\n' +
+        '- Project URL with branch: https://app.circleci.com/pipelines/gh/organization/project?branch=feature-branch\n' +
         '- Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123\n' +
         '- Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def\n' +
         '- Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz',

--- a/src/tools/getBuildFailureLogs/inputSchema.ts
+++ b/src/tools/getBuildFailureLogs/inputSchema.ts
@@ -24,16 +24,14 @@ export const getBuildFailureOutputInputSchema = z.object({
         'For example: "feature/my-branch", "bugfix/123", "main", "master" etc.',
     )
     .optional(),
-  failedPipelineURL: z
+  projectURL: z
     .string()
     .describe(
-      'The URL of the failed CircleCI pipeline. This should be a link to the pipeline in the CircleCI web app.',
-    )
-    .optional(),
-  failedJobURL: z
-    .string()
-    .describe(
-      'The URL of the failed CircleCI job. This should be a link to the job in the CircleCI web app.',
+      'The URL of the CircleCI project. Can be any of these formats:\n' +
+        '- Project URL: https://app.circleci.com/pipelines/gh/organization/project\n' +
+        '- Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123\n' +
+        '- Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def\n' +
+        '- Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz',
     )
     .optional(),
 });

--- a/src/tools/getBuildFailureLogs/tool.ts
+++ b/src/tools/getBuildFailureLogs/tool.ts
@@ -8,8 +8,11 @@ export const getBuildFailureLogsTool = {
     Input options (EXACTLY ONE of these two options must be used):
 
     Option 1 - Direct URL (provide ONE of these):
-    - failedJobURL: The URL of the failed CircleCI job (must be provided by the user)
-    - failedPipelineURL: The URL of the failed CircleCI pipeline (must be provided by the user)
+    - projectURL: The URL of the CircleCI project in any of these formats:
+      * Project URL: https://app.circleci.com/pipelines/gh/organization/project
+      * Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123
+      * Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def
+      * Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz
 
     Option 2 - Project Detection (ALL of these must be provided together):
     - workspaceRoot: The absolute path to the workspace root

--- a/src/tools/getFlakyTests/handler.ts
+++ b/src/tools/getFlakyTests/handler.ts
@@ -1,6 +1,6 @@
 import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
-  getProjectSlugFromProjectURL,
+  getProjectSlugFromURL,
   identifyProjectSlug,
 } from '../../lib/project-detection/index.js';
 import { getFlakyTestLogsInputSchema } from './inputSchema.js';
@@ -22,7 +22,7 @@ export const getFlakyTestLogs: ToolCallback<{
   let projectSlug: string | null | undefined;
 
   if (projectURL) {
-    projectSlug = getProjectSlugFromProjectURL(projectURL);
+    projectSlug = getProjectSlugFromURL(projectURL);
   } else if (workspaceRoot && gitRemoteURL) {
     projectSlug = await identifyProjectSlug({
       token,

--- a/src/tools/getFlakyTests/inputSchema.ts
+++ b/src/tools/getFlakyTests/inputSchema.ts
@@ -21,6 +21,7 @@ export const getFlakyTestLogsInputSchema = z.object({
     .describe(
       'The URL of the CircleCI project. Can be any of these formats:\n' +
         '- Project URL: https://app.circleci.com/pipelines/gh/organization/project\n' +
+        '- Project URL with branch: https://app.circleci.com/pipelines/gh/organization/project?branch=feature-branch\n' +
         '- Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123\n' +
         '- Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def\n' +
         '- Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz',

--- a/src/tools/getFlakyTests/inputSchema.ts
+++ b/src/tools/getFlakyTests/inputSchema.ts
@@ -19,7 +19,11 @@ export const getFlakyTestLogsInputSchema = z.object({
   projectURL: z
     .string()
     .describe(
-      'The URL of the CircleCI project. This should be a link to the project in the CircleCI web app.',
+      'The URL of the CircleCI project. Can be any of these formats:\n' +
+        '- Project URL: https://app.circleci.com/pipelines/gh/organization/project\n' +
+        '- Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123\n' +
+        '- Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def\n' +
+        '- Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz',
     )
     .optional(),
 });

--- a/src/tools/getFlakyTests/tool.ts
+++ b/src/tools/getFlakyTests/tool.ts
@@ -9,8 +9,12 @@ export const getFlakyTestLogsTool = {
 
     Input options (EXACTLY ONE of these two options must be used):
 
-    Option 1 - Direct URL:
-    - projectURL: The URL of the CircleCI project (must be provided by the user)
+    Option 1 - Direct URL (provide ONE of these):
+    - projectURL: The URL of the CircleCI project in any of these formats:
+      * Project URL: https://app.circleci.com/pipelines/gh/organization/project
+      * Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123
+      * Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def
+      * Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz
 
     Option 2 - Project Detection (ALL of these must be provided together):
     - workspaceRoot: The absolute path to the workspace root


### PR DESCRIPTION
Some bug fixes and improvements:

- fixed bug where `?branch=some-branch` in the projectURL was being considered part of the projectSlug


- consolidated both projectSlug detection functions down to just `getPipelineNumberFromURL`. added extra test cases
- changed get build logs tool to only use `projectURL` instead of `failedPipelineURL` or `failedJobURL`
- updated the tool descriptions to better describe the accepted urls
- removed now unneeded error handling wrapper


- build logs tool will now use the `?branch=somebranch` query param to find the branch if given in the url

video of the branch in url support:

https://github.com/user-attachments/assets/2598395a-453f-4198-b4f9-52e7029c5576


