### PR TITLE
feat: add latest pipeline status tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-04-30
+
+### Added
+
+- Added `get_latest_pipeline_status` tool to get the latest pipeline status
+  - Support for both project URL and local git repository context
+  - Displays all workflows within the latest pipeline
+  - Provides formatted details including pipeline number, workflow status, duration, and timestamps
+
 ## [0.2.0] - 2025-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -192,6 +192,52 @@ https://docs.windsurf.com/windsurf/mcp
   - Get detailed context about test failures
   - Make data-driven decisions about test improvements
 
+- `get_latest_pipeline_status`
+
+  Retrieves the status of the latest pipeline for a given branch. This tool can be used in two ways:
+
+  1. Using CircleCI Project URL:
+
+     - Provide the project URL directly from CircleCI
+     - Example: "Get the status of the latest pipeline for https://app.circleci.com/pipelines/github/org/repo"
+
+  2. Using Local Project Context:
+     - Works from your local workspace by providing:
+       - Workspace root path
+       - Git remote URL
+       - Branch name
+     - Example: "Get the status of the latest pipeline for my current project"
+
+  The tool returns a formatted status of the latest pipeline:
+
+  - Workflow names and their current status
+  - Duration of each workflow
+  - Creation and completion timestamps
+  - Overall pipeline health
+
+  Example output:
+
+  ```
+  ---
+  Workflow: build
+  Status: success
+  Duration: 5 minutes
+  Created: 4/20/2025, 10:15:30 AM
+  Stopped: 4/20/2025, 10:20:45 AM
+  ---
+  Workflow: test
+  Status: running
+  Duration: unknown
+  Created: 4/20/2025, 10:21:00 AM
+  Stopped: in progress
+  ```
+
+  This is particularly useful for:
+
+  - Checking the status of the latest pipeline
+  - Getting the status of the latest pipeline for a specific branch
+  - Quickly checking the status of the latest pipeline without leaving your IDE
+
 - `config_helper`
 
   Assists with CircleCI configuration tasks by providing guidance and validation. This tool helps you:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/circleci-tools.ts
+++ b/src/circleci-tools.ts
@@ -3,6 +3,8 @@ import { getBuildFailureLogsTool } from './tools/getBuildFailureLogs/tool.js';
 import { getBuildFailureLogs } from './tools/getBuildFailureLogs/handler.js';
 import { getFlakyTestLogsTool } from './tools/getFlakyTests/tool.js';
 import { getFlakyTestLogs } from './tools/getFlakyTests/handler.js';
+import { getLatestPipelineStatusTool } from './tools/getLatestPipelineStatus/tool.js';
+import { getLatestPipelineStatus } from './tools/getLatestPipelineStatus/handler.js';
 import { configHelper } from './tools/configHelper/handler.js';
 import { configHelperTool } from './tools/configHelper/tool.js';
 
@@ -10,6 +12,7 @@ import { configHelperTool } from './tools/configHelper/tool.js';
 export const CCI_TOOLS = [
   getBuildFailureLogsTool,
   getFlakyTestLogsTool,
+  getLatestPipelineStatusTool,
   configHelperTool,
 ];
 
@@ -28,5 +31,6 @@ type ToolHandlers = {
 export const CCI_HANDLERS = {
   get_build_failure_logs: getBuildFailureLogs,
   find_flaky_tests: getFlakyTestLogs,
+  get_latest_pipeline_status: getLatestPipelineStatus,
   config_helper: configHelper,
 } satisfies ToolHandlers;

--- a/src/clients/circleci/pipelines.ts
+++ b/src/clients/circleci/pipelines.ts
@@ -22,13 +22,13 @@ export class PipelinesAPI {
    * @returns Filtered pipelines until the stop condition is met
    * @throws Error if timeout or max pages reached
    */
-  async getPipelinesByBranch({
+  async getPipelines({
     projectSlug,
     branch,
     options = {},
   }: {
     projectSlug: string;
-    branch: string;
+    branch?: string;
     options?: {
       maxPages?: number;
       timeoutMs?: number;

--- a/src/clients/schemas.ts
+++ b/src/clients/schemas.ts
@@ -14,6 +14,10 @@ const PipelineSchema = z.object({
 
 const WorkflowSchema = z.object({
   id: z.string(),
+  name: z.string(),
+  status: z.string().nullable(),
+  created_at: z.string(),
+  stopped_at: z.string().nullable().optional(),
 });
 
 const JobSchema = z.object({

--- a/src/clients/schemas.ts
+++ b/src/clients/schemas.ts
@@ -18,6 +18,7 @@ const WorkflowSchema = z.object({
   status: z.string().nullable(),
   created_at: z.string(),
   stopped_at: z.string().nullable().optional(),
+  pipeline_number: z.number(),
 });
 
 const JobSchema = z.object({

--- a/src/lib/latest-pipeline/formatLatestPipelineStatus.ts
+++ b/src/lib/latest-pipeline/formatLatestPipelineStatus.ts
@@ -33,6 +33,7 @@ export const formatLatestPipelineStatus = (workflows: Workflow[]) => {
         : 'in progress';
 
       const fields = [
+        `Pipeline Number: ${workflow.pipeline_number}`,
         `Workflow: ${workflow.name}`,
         `Status: ${workflow.status}`,
         `Duration: ${duration}`,

--- a/src/lib/latest-pipeline/formatLatestPipelineStatus.ts
+++ b/src/lib/latest-pipeline/formatLatestPipelineStatus.ts
@@ -1,0 +1,48 @@
+import { Workflow } from '../../clients/schemas.js';
+import outputTextTruncated, { SEPARATOR } from '../outputTextTruncated.js';
+
+export const formatLatestPipelineStatus = (workflows: Workflow[]) => {
+  if (!workflows || workflows.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: 'No workflows found',
+        },
+      ],
+    };
+  }
+
+  const outputText = workflows
+    .map((workflow) => {
+      let duration = 'unknown';
+
+      // Calculate duration from timestamps if duration field is not available
+      if (workflow.created_at && workflow.stopped_at) {
+        const startTime = new Date(workflow.created_at).getTime();
+        const endTime = new Date(workflow.stopped_at).getTime();
+        const durationInMinutes = Math.round(
+          (endTime - startTime) / (1000 * 60),
+        );
+        duration = `${durationInMinutes} minutes`;
+      }
+
+      const createdAt = new Date(workflow.created_at).toLocaleString();
+      const stoppedAt = workflow.stopped_at
+        ? new Date(workflow.stopped_at).toLocaleString()
+        : 'in progress';
+
+      const fields = [
+        `Workflow: ${workflow.name}`,
+        `Status: ${workflow.status}`,
+        `Duration: ${duration}`,
+        `Created: ${createdAt}`,
+        `Stopped: ${stoppedAt}`,
+      ].filter(Boolean);
+
+      return `${SEPARATOR}${fields.join('\n')}`;
+    })
+    .join('\n');
+
+  return outputTextTruncated(outputText);
+};

--- a/src/lib/latest-pipeline/getLatestPipelineWorkflows.ts
+++ b/src/lib/latest-pipeline/getLatestPipelineWorkflows.ts
@@ -1,0 +1,30 @@
+import { getCircleCIClient } from '../../clients/client.js';
+
+export type GetLatestPipelineWorkflowsParams = {
+  projectSlug: string;
+  branch?: string;
+};
+
+export const getLatestPipelineWorkflows = async ({
+  projectSlug,
+  branch,
+}: GetLatestPipelineWorkflowsParams) => {
+  const circleci = getCircleCIClient();
+
+  const pipelines = await circleci.pipelines.getPipelines({
+    projectSlug,
+    branch,
+  });
+
+  const latestPipeline = pipelines?.[0];
+
+  if (!latestPipeline) {
+    throw new Error('Latest pipeline not found');
+  }
+
+  const workflows = await circleci.workflows.getPipelineWorkflows({
+    pipelineId: latestPipeline.id,
+  });
+
+  return workflows;
+};

--- a/src/lib/pipeline-job-logs/getPipelineJobLogs.ts
+++ b/src/lib/pipeline-job-logs/getPipelineJobLogs.ts
@@ -22,7 +22,7 @@ const getPipelineJobLogs = async ({
       pipelineNumber,
     });
   } else if (branch) {
-    const pipelines = await circleci.pipelines.getPipelinesByBranch({
+    const pipelines = await circleci.pipelines.getPipelines({
       projectSlug,
       branch,
     });

--- a/src/tools/getLatestPipelineStatus/handler.test.ts
+++ b/src/tools/getLatestPipelineStatus/handler.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getLatestPipelineStatus } from './handler.js';
+import * as projectDetection from '../../lib/project-detection/index.js';
+import * as getLatestPipelineWorkflowsModule from '../../lib/latest-pipeline/getLatestPipelineWorkflows.js';
+import * as formatLatestPipelineStatusModule from '../../lib/latest-pipeline/formatLatestPipelineStatus.js';
+import { McpSuccessResponse } from '../../lib/mcpResponse.js';
+
+// Mock dependencies
+vi.mock('../../lib/project-detection/index.js');
+vi.mock('../../lib/latest-pipeline/getLatestPipelineWorkflows.js');
+vi.mock('../../lib/latest-pipeline/formatLatestPipelineStatus.js');
+
+describe('getLatestPipelineStatus handler', () => {
+  const mockWorkflows = [
+    {
+      id: 'workflow-id-1',
+      name: 'build-and-test',
+      status: 'success',
+      created_at: '2023-01-01T12:00:00Z',
+      stopped_at: '2023-01-01T12:05:00Z',
+      pipeline_number: 123,
+      project_slug: 'gh/circleci/project',
+    },
+  ];
+
+  const mockFormattedResponse: McpSuccessResponse = {
+    content: [
+      {
+        type: 'text' as const,
+        text: 'Formatted pipeline status',
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Setup default mocks
+    vi.mocked(projectDetection.getProjectSlugFromURL).mockReturnValue(
+      'gh/circleci/project',
+    );
+    vi.mocked(projectDetection.getBranchFromURL).mockReturnValue('main');
+    vi.mocked(projectDetection.identifyProjectSlug).mockResolvedValue(
+      'gh/circleci/project',
+    );
+    vi.mocked(
+      getLatestPipelineWorkflowsModule.getLatestPipelineWorkflows,
+    ).mockResolvedValue(mockWorkflows);
+    vi.mocked(
+      formatLatestPipelineStatusModule.formatLatestPipelineStatus,
+    ).mockReturnValue(mockFormattedResponse);
+  });
+
+  it('should get latest pipeline status using projectURL', async () => {
+    const args = {
+      params: {
+        projectURL:
+          'https://app.circleci.com/pipelines/github/circleci/project',
+      },
+    };
+
+    const controller = new AbortController();
+    const response = await getLatestPipelineStatus(args as any, {
+      signal: controller.signal,
+    });
+
+    expect(projectDetection.getProjectSlugFromURL).toHaveBeenCalledWith(
+      args.params.projectURL,
+    );
+    expect(projectDetection.getBranchFromURL).toHaveBeenCalledWith(
+      args.params.projectURL,
+    );
+    expect(
+      getLatestPipelineWorkflowsModule.getLatestPipelineWorkflows,
+    ).toHaveBeenCalledWith({
+      projectSlug: 'gh/circleci/project',
+      branch: 'main',
+    });
+    expect(
+      formatLatestPipelineStatusModule.formatLatestPipelineStatus,
+    ).toHaveBeenCalledWith(mockWorkflows);
+    expect(response).toEqual(mockFormattedResponse);
+  });
+
+  it('should get latest pipeline status using workspace and git info', async () => {
+    const args = {
+      params: {
+        workspaceRoot: '/path/to/workspace',
+        gitRemoteURL: 'https://github.com/circleci/project.git',
+        branch: 'feature/branch',
+      },
+    };
+
+    const controller = new AbortController();
+    const response = await getLatestPipelineStatus(args as any, {
+      signal: controller.signal,
+    });
+
+    expect(projectDetection.identifyProjectSlug).toHaveBeenCalledWith({
+      gitRemoteURL: args.params.gitRemoteURL,
+    });
+    expect(
+      getLatestPipelineWorkflowsModule.getLatestPipelineWorkflows,
+    ).toHaveBeenCalledWith({
+      projectSlug: 'gh/circleci/project',
+      branch: 'feature/branch',
+    });
+    expect(
+      formatLatestPipelineStatusModule.formatLatestPipelineStatus,
+    ).toHaveBeenCalledWith(mockWorkflows);
+    expect(response).toEqual(mockFormattedResponse);
+  });
+
+  it('should return error when no valid inputs are provided', async () => {
+    const args = {
+      params: {},
+    };
+
+    const controller = new AbortController();
+    const response = await getLatestPipelineStatus(args as any, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(response.content[0].text).toContain('No inputs provided');
+  });
+
+  it('should return error when project slug cannot be identified', async () => {
+    // Return null to simulate project not found
+    vi.mocked(projectDetection.identifyProjectSlug).mockResolvedValue(
+      null as unknown as string,
+    );
+
+    const args = {
+      params: {
+        workspaceRoot: '/path/to/workspace',
+        gitRemoteURL: 'https://github.com/circleci/project.git',
+        branch: 'feature/branch',
+      },
+    };
+
+    const controller = new AbortController();
+    const response = await getLatestPipelineStatus(args as any, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(response.content[0].text).toContain('Project not found');
+  });
+
+  it('should get pipeline status when branch is provided from URL but not in params', async () => {
+    const args = {
+      params: {
+        projectURL:
+          'https://app.circleci.com/pipelines/github/circleci/project?branch=develop',
+      },
+    };
+
+    const controller = new AbortController();
+    const response = await getLatestPipelineStatus(args as any, {
+      signal: controller.signal,
+    });
+
+    expect(
+      getLatestPipelineWorkflowsModule.getLatestPipelineWorkflows,
+    ).toHaveBeenCalledWith({
+      projectSlug: 'gh/circleci/project',
+      branch: 'main', // This is what our mock returns
+    });
+    expect(response).toEqual(mockFormattedResponse);
+  });
+
+  it('should handle errors from getLatestPipelineWorkflows', async () => {
+    vi.mocked(
+      getLatestPipelineWorkflowsModule.getLatestPipelineWorkflows,
+    ).mockRejectedValue(new Error('Failed to fetch workflows'));
+
+    const args = {
+      params: {
+        projectURL:
+          'https://app.circleci.com/pipelines/github/circleci/project',
+      },
+    };
+
+    // We expect the handler to throw the error so we can catch it
+    const controller = new AbortController();
+    await expect(
+      getLatestPipelineStatus(args as any, { signal: controller.signal }),
+    ).rejects.toThrow('Failed to fetch workflows');
+  });
+});

--- a/src/tools/getLatestPipelineStatus/handler.ts
+++ b/src/tools/getLatestPipelineStatus/handler.ts
@@ -1,6 +1,9 @@
 import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getLatestPipelineStatusInputSchema } from './inputSchema.js';
-import { getProjectSlugFromURL } from '../../lib/project-detection/index.js';
+import {
+  getBranchFromURL,
+  getProjectSlugFromURL,
+} from '../../lib/project-detection/index.js';
 import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
 import { identifyProjectSlug } from '../../lib/project-detection/index.js';
 import { getLatestPipelineWorkflows } from '../../lib/latest-pipeline/getLatestPipelineWorkflows.js';
@@ -12,9 +15,11 @@ export const getLatestPipelineStatus: ToolCallback<{
   const { workspaceRoot, gitRemoteURL, branch, projectURL } = args.params;
 
   let projectSlug: string | null | undefined;
+  let branchFromURL: string | null | undefined;
 
   if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);
+    branchFromURL = getBranchFromURL(projectURL);
   } else if (workspaceRoot && gitRemoteURL) {
     projectSlug = await identifyProjectSlug({
       gitRemoteURL,
@@ -37,7 +42,7 @@ export const getLatestPipelineStatus: ToolCallback<{
 
   const latestPipelineWorkflows = await getLatestPipelineWorkflows({
     projectSlug,
-    branch,
+    branch: branchFromURL ?? branch,
   });
 
   return formatLatestPipelineStatus(latestPipelineWorkflows);

--- a/src/tools/getLatestPipelineStatus/handler.ts
+++ b/src/tools/getLatestPipelineStatus/handler.ts
@@ -1,0 +1,44 @@
+import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getLatestPipelineStatusInputSchema } from './inputSchema.js';
+import { getProjectSlugFromURL } from '../../lib/project-detection/index.js';
+import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
+import { identifyProjectSlug } from '../../lib/project-detection/index.js';
+import { getLatestPipelineWorkflows } from '../../lib/latest-pipeline/getLatestPipelineWorkflows.js';
+import { formatLatestPipelineStatus } from '../../lib/latest-pipeline/formatLatestPipelineStatus.js';
+
+export const getLatestPipelineStatus: ToolCallback<{
+  params: typeof getLatestPipelineStatusInputSchema;
+}> = async (args) => {
+  const { workspaceRoot, gitRemoteURL, branch, projectURL } = args.params;
+
+  let projectSlug: string | null | undefined;
+
+  if (projectURL) {
+    projectSlug = getProjectSlugFromURL(projectURL);
+  } else if (workspaceRoot && gitRemoteURL) {
+    projectSlug = await identifyProjectSlug({
+      gitRemoteURL,
+    });
+  } else {
+    return mcpErrorOutput(
+      'No inputs provided. Ask the user to provide the inputs user can provide based on the tool description.',
+    );
+  }
+
+  if (!projectSlug) {
+    return mcpErrorOutput(`
+          Project not found. Ask the user to provide the inputs user can provide based on the tool description.
+
+          Project slug: ${projectSlug}
+          Git remote URL: ${gitRemoteURL}
+          Branch: ${branch}
+          `);
+  }
+
+  const latestPipelineWorkflows = await getLatestPipelineWorkflows({
+    projectSlug,
+    branch,
+  });
+
+  return formatLatestPipelineStatus(latestPipelineWorkflows);
+};

--- a/src/tools/getLatestPipelineStatus/inputSchema.ts
+++ b/src/tools/getLatestPipelineStatus/inputSchema.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+export const getLatestPipelineStatusInputSchema = z.object({
+  workspaceRoot: z
+    .string()
+    .describe(
+      'The absolute path to the root directory of your project workspace. ' +
+        'This should be the top-level folder containing your source code, configuration files, and dependencies. ' +
+        'For example: "/home/user/my-project" or "C:\\Users\\user\\my-project"',
+    )
+    .optional(),
+  gitRemoteURL: z
+    .string()
+    .describe(
+      'The URL of the remote git repository. This should be the URL of the repository that you cloned to your local workspace. ' +
+        'For example: "https://github.com/user/my-project.git"',
+    )
+    .optional(),
+  branch: z
+    .string()
+    .describe(
+      'The name of the branch currently checked out in local workspace. ' +
+        'This should match local git branch. ' +
+        'For example: "feature/my-branch", "bugfix/123", "main", "master" etc.',
+    )
+    .optional(),
+  projectURL: z
+    .string()
+    .describe(
+      'The URL of the CircleCI project. Can be any of these formats:\n' +
+        '- Project URL with branch: https://app.circleci.com/pipelines/gh/organization/project?branch=feature-branch\n' +
+        '- Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123\n' +
+        '- Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def\n' +
+        '- Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz',
+    )
+    .optional(),
+});

--- a/src/tools/getLatestPipelineStatus/tool.ts
+++ b/src/tools/getLatestPipelineStatus/tool.ts
@@ -1,0 +1,36 @@
+import { getLatestPipelineStatusInputSchema } from './inputSchema.js';
+
+export const getLatestPipelineStatusTool = {
+  name: 'get_latest_pipeline_status' as const,
+  description: `
+    This tool retrieves the status of the latest pipeline for a CircleCI project. It can be used to check pipeline status, get latest build status, or view current pipeline state.
+
+    Common use cases:
+    - Check latest pipeline status
+    - Get current build status
+    - View pipeline state
+    - Check build progress
+    - Get pipeline information
+
+    Input options (EXACTLY ONE of these two options must be used):
+
+    Option 1 - Direct URL (provide ONE of these):
+    - projectURL: The URL of the CircleCI project in any of these formats:
+      * Project URL: https://app.circleci.com/pipelines/gh/organization/project
+      * Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123
+      * Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def
+      * Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz
+
+    Option 2 - Project Detection (ALL of these must be provided together):
+    - workspaceRoot: The absolute path to the workspace root
+    - gitRemoteURL: The URL of the git remote repository
+    - branch: The name of the current branch
+
+    Additional Requirements:
+    - Never call this tool with incomplete parameters
+    - If using Option 1, the URLs MUST be provided by the user - do not attempt to construct or guess URLs
+    - If using Option 2, ALL THREE parameters (workspaceRoot, gitRemoteURL, branch) must be provided
+    - If neither option can be fully satisfied, ask the user for the missing information before making the tool call
+  `,
+  inputSchema: getLatestPipelineStatusInputSchema,
+};


### PR DESCRIPTION
- Added a tool to get the latest pipeline status
- Renamed the `getPipelinesByBranch` function in the circleci client to `getPipelines` since branch was optional
- Releasing v0.3.0



https://github.com/user-attachments/assets/5874c427-121c-493d-8b19-f0722305b953




