### PR TITLE
refactor: `recommendPromptTemplateTests` handler for greater file output consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.2] - 2025-05-06
+## [0.4.2] - 2025-05-08
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2025-05-06
+
+### Improvements
+
+- Enhanced prompt template file structure and organization for consistency
+  - Added standardized file naming convention for prompt templates
+  - Implemented structured JSON format with required fields (name, description, version, template, contextSchema, tests, sampleInputs, etc.)
+  - Added support for test case naming in Title Case format
+  - Improved documentation requirements for prompt templates
+
 ## [0.4.0] - 2025-04-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/tools/recommendPromptTemplateTests/handler.ts
+++ b/src/tools/recommendPromptTemplateTests/handler.ts
@@ -21,13 +21,28 @@ export const recommendPromptTemplateTests: ToolCallback<{
 
 NEXT STEP:
 - Immediately save the \`promptTemplate\`, \`contextSchema\`, and \`recommendedTests\` to a single file containing the prompt template, context schema, and tests in a simple structured format (e.g. JSON, YAML, or whatever is most appropriate for the language of the current repository).
+  - The file should be named in the format 'prompt_<relevant-name>.json' (e.g. 'prompt_bedtime-story-generator.json', 'prompt_plant-care-assistant.json', 'prompt_customer-support-chatbot.json', etc.)
+  - The file should have the following keys:
+    - \`name\`: string (the name of the prompt template)
+    - \`description\`: string (a description of the prompt template)
+    - \`version\`: string (the semantic version of the prompt template, eg "1.0.0")
+    - \`template\`: string (the prompt template)
+    - \`contextSchema\`: object (the \`contextSchema\`)
+    - \`tests\`: array of objects (based on the \`recommendedTests\`)
+      - \`name\`: string (a relevant "Title Case" name for the test, based on the content of the \`recommendedTests\` array item)
+      - \`description\`: string (taken directly from string array item in \`recommendedTests\`)
+    - \`sampleInputs\`: object[] (the sample inputs for the \`promptTemplate\` and any tests within \`recommendedTests\`)
 
 RULES FOR SAVING FILES:
 - Files should be written in the preferred language of the current repository.
 - The file should be documented with a README description of what it does, and how it works.
+  - If a README already exists, update it with the new information.
+  - If a README does not exist, create one.
 - The file should be formatted using the user's preferred conventions.
 - The file should be saved in the '.circleci/ai/prompts' directory.
-- The file should be named in the format 'prompt_<relevant-name>.json' (e.g. 'prompt_bedtime-story-generator.json', 'prompt_plant-care-assistant.json', 'prompt_customer-support-chatbot.json', etc.)
+- Only save the following files (and nothing else):
+  - \`prompt_<relevant-name>.json\`
+  - \`README.md\`
 `,
       },
     ],


### PR DESCRIPTION
# Rationale

We must achieve a high level of consistency in the output of Circlet MCP tool calls to reliably run prompt eval/test pipelines on ANY given prompt temaplate. The prompt engineering in this PR is solely focused on achieving that consistency.

# DEMO 🎥 (from a pre-existing AI-enabled application w. multiple prompts) [CircleCI-Public/hungry-panda#8](https://github.com/CircleCI-Public/hungry-panda/pull/8/files)

### https://github.com/CircleCI-Public/hungry-panda/pull/8/commits/71854781b85848b0ce63025bafce51fd78800ecf - add 100% test coverage to an AI-enabled application with multiple pre-existing prompts...

`Please find all of the AI prompts in this application and recommend tests for them.`

https://github.com/user-attachments/assets/fd2edde5-288f-4cfb-aaeb-167ff1968f95

# DEMO 🎥 (from a blank-page) [CircleCI-Public/hungry-panda#7](https://github.com/CircleCI-Public/hungry-panda/pull/7/files)

## https://github.com/CircleCI-Public/hungry-panda/pull/7/commits/0f4af91c2f94c4cc6aee43716945a9d881219c50 - create 2 testable prompts...

https://github.com/user-attachments/assets/59921a82-299c-4367-a595-619476d84504

## https://github.com/CircleCI-Public/hungry-panda/pull/7/commits/67777c12770f106d767765481fbff196986b2f3c - create a 3rd testable prompt for good measure...

https://github.com/user-attachments/assets/dcc46a55-04aa-462b-9475-b8bd3ef83dc4


# Changes
- [refactored `recommendPromptTemplateTests` handler](https://github.com/CircleCI-Public/mcp-server-circleci/commit/4ba177be0ce5f9ea1347d6846652ec59e1a51f55) to achieve a greater level of consistency in Circlet MCP tool call file output.