### PR TITLE
fix: paginate followed projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2025-05-05
+
+### Added
+
+- Update project detection to correctly paginate the followed projects
+
 ## [0.4.0] - 2025-04-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/clients/circleci-private/me.ts
+++ b/src/clients/circleci-private/me.ts
@@ -1,13 +1,12 @@
 import { z } from 'zod';
 import { HTTPClient } from '../circleci/httpClient.js';
 import { FollowedProject } from '../schemas.js';
+import { defaultPaginationOptions } from '../circleci/index.js';
 
 const FollowedProjectResponseSchema = z.object({
   items: z.array(FollowedProject),
   next_page_token: z.string().nullable(),
 });
-
-type FollowedProjectResponse = z.infer<typeof FollowedProjectResponseSchema>;
 
 export class MeAPI {
   protected client: HTTPClient;
@@ -17,13 +16,52 @@ export class MeAPI {
   }
 
   /**
-   * Get the projects that the user is following
-   * @returns The projects that the user is following
+   * Get the projects that the user is following with pagination support
+   * @param options Optional configuration for pagination limits
+   * @param options.maxPages Maximum number of pages to fetch (default: 5)
+   * @param options.timeoutMs Timeout in milliseconds (default: 10000)
+   * @returns All followed projects
+   * @throws Error if timeout or max pages reached
    */
-  async getFollowedProjects() {
-    const result = await this.client.get<FollowedProjectResponse>(
-      '/me/followed-projects',
-    );
-    return FollowedProjectResponseSchema.safeParse(result);
+  async getFollowedProjects(
+    options: {
+      maxPages?: number;
+      timeoutMs?: number;
+    } = {},
+  ): Promise<FollowedProject[]> {
+    const { maxPages = 20, timeoutMs = defaultPaginationOptions.timeoutMs } =
+      options;
+
+    const startTime = Date.now();
+    const allProjects: FollowedProject[] = [];
+    let nextPageToken: string | null = null;
+    let pageCount = 0;
+
+    do {
+      // Check timeout
+      if (Date.now() - startTime > timeoutMs) {
+        throw new Error(`Timeout reached after ${timeoutMs}ms`);
+      }
+
+      // Check page limit
+      if (pageCount >= maxPages) {
+        throw new Error(`Maximum number of pages (${maxPages}) reached`);
+      }
+
+      const params = nextPageToken ? { next_page_token: nextPageToken } : {};
+      const rawResult = await this.client.get<unknown>(
+        '/me/followed-projects',
+        params,
+      );
+
+      // Validate the response against our schema
+      const result = FollowedProjectResponseSchema.parse(rawResult);
+
+      pageCount++;
+      allProjects.push(...result.items);
+      nextPageToken = result.next_page_token;
+    } while (nextPageToken);
+
+    return allProjects;
   }
 }

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -25,11 +25,11 @@ export const identifyProjectSlug = async ({
   }
 
   const followedProjects = await cciPrivateClients.me.getFollowedProjects();
-  if (!followedProjects.success) {
+  if (!followedProjects) {
     throw new Error('Failed to get followed projects');
   }
 
-  const project = followedProjects.data.items.find(
+  const project = followedProjects.find(
     (followedProject) =>
       followedProject.name === parsedGitURL.name &&
       followedProject.vcs_type === vcs.name,


### PR DESCRIPTION
found an issue with our project detection logic, we were not paginating the followed projects. so if the target project was not on the first page it would be missed