### PR TITLE
fix: #51 update CircleCI URL handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "build": "rm -rf dist && tsc && shx chmod +x dist/*.js",
     "watch": "nodemon --watch . --ext ts,json --exec pnpm run build",
-    "inspector": "npx @modelcontextprotocol/inspector node ./dist/index.js",
-    "build:inspector": "pnpm run build && npx @modelcontextprotocol/inspector node ./dist/index.js",
+    "inspector": "npx @modelcontextprotocol/inspector@0.9 node ./dist/index.js",
+    "build:inspector": "pnpm run build && pnpm run inspector",
     "tsx": "tsx",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -30,7 +30,9 @@ describe('getPipelineNumberFromURL', () => {
   it('throws error for invalid CircleCI URL format', () => {
     expect(() =>
       getPipelineNumberFromURL('https://app.circleci.com/invalid/url'),
-    ).toThrow('Invalid CircleCI URL format');
+    ).toThrow(
+      'Error getting pipeline number from URL: Invalid CircleCI URL format',
+    );
   });
 
   it('throws error when pipeline number is not a valid number', () => {
@@ -58,6 +60,31 @@ describe('getProjectSlugFromURL', () => {
     {
       url: 'https://app.circleci.com/pipelines/gh/organization/project/123',
       expected: 'gh/organization/project',
+    },
+    // Legacy Pipeline URL for gh
+    {
+      url: 'https://circleci.com/gh/organization/project/123',
+      expected: 'gh/organization/project',
+    },
+    // Legacy Pipeline URL for Github
+    {
+      url: 'https://circleci.com/github/organization/project/123',
+      expected: 'github/organization/project',
+    },
+    // Legacy Pipeline URL for bb
+    {
+      url: 'https://circleci.com/bb/organization/project/123',
+      expected: 'bb/organization/project',
+    },
+    // Legacy Pipeline URL for Bitbucket
+    {
+      url: 'https://circleci.com/bitbucket/organization/project/123',
+      expected: 'bitbucket/organization/project',
+    },
+    // Legacy Pipeline URL for CircleCI
+    {
+      url: 'https://circleci.com/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/456',
+      expected: 'circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ',
     },
     // Pipeline URL
     {
@@ -96,7 +123,9 @@ describe('getProjectSlugFromURL', () => {
   it('throws error for invalid CircleCI URL format', () => {
     expect(() =>
       getProjectSlugFromURL('https://app.circleci.com/invalid/url'),
-    ).toThrow('Invalid CircleCI URL format');
+    ).toThrow(
+      'Error getting project slug from URL: Invalid CircleCI URL format',
+    );
   });
 
   it('throws error when project information is incomplete', () => {
@@ -134,7 +163,7 @@ describe('getBranchFromURL', () => {
 
   it('throws error for invalid CircleCI URL format', () => {
     expect(() => getBranchFromURL('not-a-url')).toThrow(
-      'Invalid CircleCI URL format',
+      'Error getting branch from URL: Invalid CircleCI URL format',
     );
   });
 });

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -1,5 +1,5 @@
 import { getCircleCIPrivateClient } from '../../clients/client.js';
-import { getVCSFromHost } from './vcsTool.js';
+import { getVCSFromHost, vcses } from './vcsTool.js';
 import gitUrlParse from 'parse-github-url';
 
 /**
@@ -56,7 +56,9 @@ export const getPipelineNumberFromURL = (url: string): number | undefined => {
   const parts = url.split('/');
   const pipelineIndex = parts.indexOf('pipelines');
   if (pipelineIndex === -1) {
-    throw new Error('Invalid CircleCI URL format');
+    throw new Error(
+      'Error getting pipeline number from URL: Invalid CircleCI URL format',
+    );
   }
   const pipelineNumber = parts[pipelineIndex + 4];
 
@@ -123,13 +125,35 @@ export const getJobNumberFromURL = (url: string): number | undefined => {
 export const getProjectSlugFromURL = (url: string) => {
   const urlWithoutQuery = url.split('?')[0];
   const parts = urlWithoutQuery.split('/');
+
+  let startIndex = -1;
   const pipelineIndex = parts.indexOf('pipelines');
-  if (pipelineIndex === -1) {
-    throw new Error('Invalid CircleCI URL format');
+  if (pipelineIndex !== -1) {
+    startIndex = pipelineIndex + 1;
+  } else {
+    for (const vcs of vcses) {
+      const shortIndex = parts.indexOf(vcs.short);
+      const nameIndex = parts.indexOf(vcs.name);
+      if (shortIndex !== -1) {
+        startIndex = shortIndex;
+        break;
+      }
+      if (nameIndex !== -1) {
+        startIndex = nameIndex;
+        break;
+      }
+    }
   }
-  const vcs = parts[pipelineIndex + 1];
-  const org = parts[pipelineIndex + 2];
-  const project = parts[pipelineIndex + 3];
+
+  if (startIndex === -1) {
+    throw new Error(
+      'Error getting project slug from URL: Invalid CircleCI URL format',
+    );
+  }
+
+  const vcs = parts[startIndex];
+  const org = parts[startIndex + 1];
+  const project = parts[startIndex + 2];
 
   if (!vcs || !org || !project) {
     throw new Error('Unable to extract project information from URL');
@@ -157,6 +181,8 @@ export const getBranchFromURL = (url: string): string | undefined => {
     const urlObj = new URL(url);
     return urlObj.searchParams.get('branch') || undefined;
   } catch {
-    throw new Error('Invalid CircleCI URL format');
+    throw new Error(
+      'Error getting branch from URL: Invalid CircleCI URL format',
+    );
   }
 };

--- a/src/tools/getLatestPipelineStatus/inputSchema.ts
+++ b/src/tools/getLatestPipelineStatus/inputSchema.ts
@@ -29,6 +29,8 @@ export const getLatestPipelineStatusInputSchema = z.object({
     .describe(
       'The URL of the CircleCI project. Can be any of these formats:\n' +
         '- Project URL with branch: https://app.circleci.com/pipelines/gh/organization/project?branch=feature-branch\n' +
+        '- Legacy Pipeline URL: https://circleci.com/gh/organization/project/123\n' +
+        '- Legacy Pipeline URL with branch: https://circleci.com/gh/organization/project/123?branch=feature-branch\n' +
         '- Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123\n' +
         '- Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def\n' +
         '- Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz',

--- a/src/tools/getLatestPipelineStatus/tool.ts
+++ b/src/tools/getLatestPipelineStatus/tool.ts
@@ -12,12 +12,13 @@ export const getLatestPipelineStatusTool = {
     - Check build progress
     - Get pipeline information
 
-    Input options (EXACTLY ONE of these two options must be used):
+    Input options (EXACTLY ONE of these two options must be used. Before performing the tool call, ensure that the user has provided the correct inputs.):
 
     Option 1 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:
       * Project URL: https://app.circleci.com/pipelines/gh/organization/project
       * Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123
+      * Legacy Pipeline URL: https://circleci.com/gh/organization/project/123
       * Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def
       * Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz
 
@@ -28,7 +29,7 @@ export const getLatestPipelineStatusTool = {
 
     Additional Requirements:
     - Never call this tool with incomplete parameters
-    - If using Option 1, the URLs MUST be provided by the user - do not attempt to construct or guess URLs
+    - If using Option 1, the URLs MUST be provided by the user - do not attempt to construct, reconstruct or guess URLs.
     - If using Option 2, ALL THREE parameters (workspaceRoot, gitRemoteURL, branch) must be provided
     - If neither option can be fully satisfied, ask the user for the missing information before making the tool call
   `,


### PR DESCRIPTION
 - Modify `package.json` to use a specific version of `@modelcontextprotocol/inspector` and simplify the `build:inspector` script
 - Enhance error messages in `index.test.ts` for invalid CircleCI URL formats and add tests for legacy CircleCI URLs
 - Update `index.ts` to support legacy CircleCI URL formats and improve error handling
 - Document legacy CircleCI URL formats in `inputSchema.ts` for `getLatestPipelineStatus`
 - Clarify input requirements and handling of URLs in `getLatestPipelineStatus/tool.ts`