### PR TITLE
fix: fixes #53 to handle URLs without pipelines in path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2025-05-10
+
+### Fixed
+
+- Fixed project detection and pipeline number extraction from URLs with custom server domains
+
 ## [0.4.3] - 2025-05-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -31,7 +31,7 @@ describe('getPipelineNumberFromURL', () => {
     expect(() =>
       getPipelineNumberFromURL('https://app.circleci.com/invalid/url'),
     ).toThrow(
-      'Error getting pipeline number from URL: Invalid CircleCI URL format',
+      'Error getting project slug from URL to get pipeline number: Invalid CircleCI URL format',
     );
   });
 

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -18,10 +18,30 @@ describe('getPipelineNumberFromURL', () => {
       url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
       expected: 123,
     },
+    // Workflow URL (no pipelines in URL)
+    {
+      url: 'https://circleci.server.customdomain.com/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
+      expected: 2,
+    },
     // Project URL (no pipeline number)
     {
       url: 'https://app.circleci.com/pipelines/gh/organization/project',
       expected: undefined,
+    },
+    // Project URL (no pipelines and no pipeline number in path)
+    {
+      url: 'https://app.circleci.com/gh/organization/project',
+      expected: undefined,
+    },
+    // Project URL (no pipelines in URL but pipeline number in path)
+    {
+      url: 'https://circleci.com/gh/organization/project/123',
+      expected: 123,
+    },
+    // Project URL (no pipelines in URL but pipeline number in path)
+    {
+      url: 'https://circleci.server.customdomain.com/gh/organization/project/123',
+      expected: 123,
     },
   ])('extracts pipeline number $expected from URL', ({ url, expected }) => {
     expect(getPipelineNumberFromURL(url)).toBe(expected);

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -55,12 +55,27 @@ export const identifyProjectSlug = async ({
 export const getPipelineNumberFromURL = (url: string): number | undefined => {
   const parts = url.split('/');
   const pipelineIndex = parts.indexOf('pipelines');
-  if (pipelineIndex === -1) {
-    throw new Error(
-      'Error getting pipeline number from URL: Invalid CircleCI URL format',
-    );
+
+  let pipelineNumber: string | undefined;
+
+  if (pipelineIndex !== -1) {
+    pipelineNumber = parts[pipelineIndex + 4];
+  } else {
+    let projectSlug: string | undefined;
+    try {
+      projectSlug = getProjectSlugFromURL(url);
+    } catch {
+      throw new Error(
+        'Error getting project slug from URL to get pipeline number: Invalid CircleCI URL format',
+      );
+    }
+
+    const slugIndex = parts.indexOf(projectSlug);
+    const nextPart = parts[slugIndex + 1];
+    if (slugIndex >= 0 && nextPart?.match(/^\d+$/)) {
+      pipelineNumber = nextPart;
+    }
   }
-  const pipelineNumber = parts[pipelineIndex + 4];
 
   if (!pipelineNumber) {
     return undefined;

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -70,7 +70,10 @@ export const getPipelineNumberFromURL = (url: string): number | undefined => {
       );
     }
 
-    const slugIndex = parts.indexOf(projectSlug);
+    const slugParts = projectSlug.split('/');
+    const lastSlugPart = slugParts[slugParts.length - 1];
+    const slugIndex = parts.findIndex((part) => part === lastSlugPart);
+
     const nextPart = parts[slugIndex + 1];
     if (slugIndex >= 0 && nextPart?.match(/^\d+$/)) {
       pipelineNumber = nextPart;


### PR DESCRIPTION
 - Refactor `getPipelineNumberFromURL` to handle URLs without a pipeline index
 - Update error message to specify project slug when getting pipeline number