### PR TITLE
fix: fixes #51 Handle legacy job urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2025-05-12
+
+### Added
+
+- Fix handling of legacy job url format in tools
+- Fix handling of pagination of test results when no test results are found
+
 ## [0.5.0] - 2025-05-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/clients/circleci/tests.ts
+++ b/src/clients/circleci/tests.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 const TestResponseSchema = z.object({
   items: z.array(Test),
-  next_page_token: z.string().nullable(),
+  next_page_token: z.string().nullable().optional(),
 });
 
 export class TestsAPI {
@@ -70,7 +70,7 @@ export class TestsAPI {
 
       pageCount++;
       allTests.push(...result.items);
-      nextPageToken = result.next_page_token;
+      nextPageToken = result.next_page_token ?? null;
     } while (nextPageToken);
 
     return allTests;

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -23,7 +23,7 @@ describe('getPipelineNumberFromURL', () => {
       url: 'https://app.circleci.com/pipelines/gh/organization/project',
       expected: undefined,
     },
-    // Project URL (Legacy job URL format without job number returns undefined for pipeline number)
+    // Project URL (missing all info)
     {
       url: 'https://app.circleci.com/gh/organization/project',
       expected: undefined,

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -18,41 +18,34 @@ describe('getPipelineNumberFromURL', () => {
       url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
       expected: 123,
     },
-    // Workflow URL (no pipelines in URL)
-    {
-      url: 'https://circleci.server.customdomain.com/gh/organization/project/2/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv',
-      expected: 2,
-    },
     // Project URL (no pipeline number)
     {
       url: 'https://app.circleci.com/pipelines/gh/organization/project',
       expected: undefined,
     },
-    // Project URL (no pipelines and no pipeline number in path)
+    // Project URL (Legacy job URL format without job number returns undefined for pipeline number)
     {
       url: 'https://app.circleci.com/gh/organization/project',
       expected: undefined,
     },
-    // Project URL (no pipelines in URL but pipeline number in path)
+    // Project URL (Legacy job URL format with job number returns undefined for pipeline number)
     {
       url: 'https://circleci.com/gh/organization/project/123',
-      expected: 123,
+      expected: undefined,
     },
-    // Project URL (no pipelines in URL but pipeline number in path)
+    // Project URL (Legacy job URL format with job number returns undefined for pipeline number)
     {
       url: 'https://circleci.server.customdomain.com/gh/organization/project/123',
-      expected: 123,
+      expected: undefined,
     },
   ])('extracts pipeline number $expected from URL', ({ url, expected }) => {
     expect(getPipelineNumberFromURL(url)).toBe(expected);
   });
 
-  it('throws error for invalid CircleCI URL format', () => {
+  it('should not throw error for invalid CircleCI URL format. Returns undefined for pipeline number', () => {
     expect(() =>
       getPipelineNumberFromURL('https://app.circleci.com/invalid/url'),
-    ).toThrow(
-      'Error getting project slug from URL to get pipeline number: Invalid CircleCI URL format',
-    );
+    ).not.toThrow();
   });
 
   it('throws error when pipeline number is not a valid number', () => {
@@ -199,6 +192,16 @@ describe('getJobNumberFromURL', () => {
     {
       url: 'https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv/jobs/789',
       expected: 789,
+    },
+    // Job URL with legacy format
+    {
+      url: 'https://circleci.com/gh/organization/project/123',
+      expected: 123,
+    },
+    // Job URL with legacy format with custom domain
+    {
+      url: 'https://circleci.server.customdomain.com/gh/organization/project/123',
+      expected: 123,
     },
     // Workflow URL (no job number)
     {

--- a/src/tools/getLatestPipelineStatus/tool.ts
+++ b/src/tools/getLatestPipelineStatus/tool.ts
@@ -18,9 +18,9 @@ export const getLatestPipelineStatusTool = {
     - projectURL: The URL of the CircleCI project in any of these formats:
       * Project URL: https://app.circleci.com/pipelines/gh/organization/project
       * Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123
-      * Legacy Pipeline URL: https://circleci.com/gh/organization/project/123
       * Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def
       * Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz
+      * Legacy Job URL: https://circleci.com/gh/organization/project/123
 
     Option 2 - Project Detection (ALL of these must be provided together):
     - workspaceRoot: The absolute path to the workspace root


### PR DESCRIPTION
Fixes #51  the issue using Legacy Job URLs with tools.

We made a bad assumption in code if the URL is of format `https//domain.com/gh/org/project/Number" Number to be pipeline number which is actually a job number.
Now, if `jobs` is not present in the url and `pipelines` is also not present we assume the last number to be the job number.