### PR TITLE
feat: list projects tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2025-05-13
+
+### Added
+
+- Added `list_followed_projects` tool to list all projects that the user is following on CircleCI
+
 ## [0.6.2] - 2025-05-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -352,6 +352,31 @@ https://docs.windsurf.com/windsurf/mcp
   - Identify edge cases and potential issues
   - Improve overall AI application quality
 
+- `list_followed_projects`
+
+  Lists all projects that the user is following on CircleCI. This tool:
+
+  1. Retrieves and Displays Projects:
+     - Shows all projects the user has access to and is following
+     - Provides the project name and projectSlug for each entry
+     - Example: "List my CircleCI projects"
+
+  The tool returns a formatted list of projects, example output:
+  
+  ```
+  Projects followed:
+  1. my-project (projectSlug: gh/organization/my-project)
+  2. another-project (projectSlug: gh/organization/another-project)
+  ```
+
+  This is particularly useful for:
+  
+  - Identifying which CircleCI projects are available to you
+  - Obtaining the projectSlug needed for other CircleCI tools
+  - Selecting a project for subsequent operations
+
+  Note: The projectSlug (not the project name) is required for many other CircleCI tools, and will be used for those tool calls after a project is selected.
+
 - `run_pipeline`
 
   Triggers a pipeline to run. This tool can be used in two ways:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/circleci-tools.ts
+++ b/src/circleci-tools.ts
@@ -15,6 +15,8 @@ import { recommendPromptTemplateTestsTool } from './tools/recommendPromptTemplat
 import { recommendPromptTemplateTests } from './tools/recommendPromptTemplateTests/handler.js';
 import { runPipeline } from './tools/runPipeline/handler.js';
 import { runPipelineTool } from './tools/runPipeline/tool.js';
+import { listFollowedProjectsTool } from './tools/listFollowedProjects/tool.js';
+import { listFollowedProjects } from './tools/listFollowedProjects/handler.js';
 
 // Define the tools with their configurations
 export const CCI_TOOLS = [
@@ -26,6 +28,7 @@ export const CCI_TOOLS = [
   createPromptTemplateTool,
   recommendPromptTemplateTestsTool,
   runPipelineTool,
+  listFollowedProjectsTool,
 ];
 
 // Extract the tool names as a union type
@@ -49,4 +52,5 @@ export const CCI_HANDLERS = {
   create_prompt_template: createPromptTemplate,
   recommend_prompt_template_tests: recommendPromptTemplateTests,
   run_pipeline: runPipeline,
+  list_followed_projects: listFollowedProjects,
 } satisfies ToolHandlers;

--- a/src/clients/circleci-private/me.ts
+++ b/src/clients/circleci-private/me.ts
@@ -37,8 +37,7 @@ export class MeAPI {
 
     const startTime = Date.now();
     const allProjects: FollowedProject[] = [];
-    // Track unique project slugs to prevent duplicates
-    const seenSlugs = new Set<string>();
+
     let nextPageToken: string | null = null;
     let previousPageToken: string | null = null;
     let pageCount = 0;
@@ -69,13 +68,7 @@ export class MeAPI {
 
       pageCount++;
 
-      // Only add projects that haven't been seen before
-      for (const project of result.items) {
-        if (!seenSlugs.has(project.slug)) {
-          seenSlugs.add(project.slug);
-          allProjects.push(project);
-        }
-      }
+      allProjects.push(...result.items);
 
       // Store the current token before updating
       previousPageToken = nextPageToken;

--- a/src/clients/circleci-private/me.ts
+++ b/src/clients/circleci-private/me.ts
@@ -42,19 +42,21 @@ export class MeAPI {
     let previousPageToken: string | null = null;
     let pageCount = 0;
 
-    let reachedMaxPagesOrTimeout = false;
-
     do {
       // Check timeout
       if (Date.now() - startTime > timeoutMs) {
-        reachedMaxPagesOrTimeout = true;
-        break;
+        return {
+          projects: allProjects,
+          reachedMaxPagesOrTimeout: true,
+        };
       }
 
       // Check page limit
       if (pageCount >= maxPages) {
-        reachedMaxPagesOrTimeout = true;
-        break;
+        return {
+          projects: allProjects,
+          reachedMaxPagesOrTimeout: true,
+        };
       }
 
       const params = nextPageToken ? { 'page-token': nextPageToken } : {};
@@ -76,14 +78,16 @@ export class MeAPI {
 
       // Break if we received the same token as before (stuck in a loop)
       if (nextPageToken && nextPageToken === previousPageToken) {
-        reachedMaxPagesOrTimeout = true;
-        break;
+        return {
+          projects: allProjects,
+          reachedMaxPagesOrTimeout: true,
+        };
       }
     } while (nextPageToken);
 
     return {
       projects: allProjects,
-      reachedMaxPagesOrTimeout,
+      reachedMaxPagesOrTimeout: false,
     };
   }
 }

--- a/src/clients/circleci-private/me.ts
+++ b/src/clients/circleci-private/me.ts
@@ -58,7 +58,7 @@ export class MeAPI {
         break;
       }
 
-      const params = nextPageToken ? { next_page_token: nextPageToken } : {};
+      const params = nextPageToken ? { 'page-token': nextPageToken } : {};
       const rawResult = await this.client.get<unknown>(
         '/me/followed-projects',
         params,

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -24,7 +24,8 @@ export const identifyProjectSlug = async ({
     throw new Error(`VCS with host ${parsedGitURL.host} is not handled`);
   }
 
-  const followedProjects = await cciPrivateClients.me.getFollowedProjects();
+  const { projects: followedProjects } =
+    await cciPrivateClients.me.getFollowedProjects();
   if (!followedProjects) {
     throw new Error('Failed to get followed projects');
   }
@@ -51,7 +52,7 @@ export const identifyProjectSlug = async ({
  * // Pipeline URL with complex project path
  * getPipelineNumberFromURL('https://app.circleci.com/pipelines/circleci/GM1mbrQEWnNbzLKEnotDo4/5gh9pgQgohHwicwomY5nYQ/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv')
  * // returns 123
- * 
+ *
  * @example
  * // URL without pipelines segment. This is a legacy job URL format.
  * getPipelineNumberFromURL('https://circleci.com/gh/organization/project/2')
@@ -83,7 +84,7 @@ export const getPipelineNumberFromURL = (url: string): number | undefined => {
  * // Job URL
  * getJobNumberFromURL('https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv/jobs/456')
  * // returns 456
- * 
+ *
  * @example
  * // Legacy job URL format
  * getJobNumberFromURL('https://circleci.com/gh/organization/project/123')
@@ -98,15 +99,15 @@ export const getJobNumberFromURL = (url: string): number | undefined => {
   const parts = url.split('/');
   const jobsIndex = parts.indexOf('jobs');
   const pipelineIndex = parts.indexOf('pipelines');
-  
+
   // Handle legacy URL format (e.g. https://circleci.com/gh/organization/project/123)
   if (jobsIndex === -1 && pipelineIndex === -1) {
     const jobNumber = parts[parts.length - 1];
-      if (!jobNumber) {
-        return undefined;
-      }
-      const parsedNumber = Number(jobNumber);
-      if (isNaN(parsedNumber)) {
+    if (!jobNumber) {
+      return undefined;
+    }
+    const parsedNumber = Number(jobNumber);
+    if (isNaN(parsedNumber)) {
       throw new Error('Job number in URL is not a valid number');
     }
     return parsedNumber;

--- a/src/tools/getBuildFailureLogs/handler.test.ts
+++ b/src/tools/getBuildFailureLogs/handler.test.ts
@@ -98,4 +98,54 @@ describe('getBuildFailureLogs handler', () => {
     expect(response.content[0]).toHaveProperty('type', 'text');
     expect(typeof response.content[0].text).toBe('string');
   });
+
+  it('should handle projectSlug and branch inputs correctly', async () => {
+    const mockLogs = [
+      {
+        jobName: 'build',
+        steps: [
+          {
+            stepName: 'Build app',
+            logs: { output: 'Build failed', error: 'Error: build failed' },
+          },
+        ],
+      },
+    ];
+
+    vi.spyOn(getPipelineJobLogsModule, 'default').mockResolvedValue(mockLogs);
+
+    vi.spyOn(formatJobLogs, 'formatJobLogs').mockReturnValue({
+      content: [
+        {
+          type: 'text',
+          text: 'Formatted job logs',
+        },
+      ],
+    });
+
+    const args = {
+      params: {
+        projectSlug: 'gh/org/repo',
+        branch: 'feature/new-feature',
+      },
+    } as any;
+
+    const controller = new AbortController();
+    const response = await getBuildFailureLogs(args, {
+      signal: controller.signal,
+    });
+
+    expect(getPipelineJobLogsModule.default).toHaveBeenCalledWith({
+      projectSlug: 'gh/org/repo',
+      branch: 'feature/new-feature',
+      pipelineNumber: undefined,
+      jobNumber: undefined,
+    });
+
+    expect(formatJobLogs.formatJobLogs).toHaveBeenCalledWith(mockLogs);
+    expect(response).toHaveProperty('content');
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+  });
 });

--- a/src/tools/getBuildFailureLogs/handler.test.ts
+++ b/src/tools/getBuildFailureLogs/handler.test.ts
@@ -56,30 +56,6 @@ describe('getBuildFailureLogs handler', () => {
     expect(typeof response.content[0].text).toBe('string');
   });
 
-  it('should return a valid MCP error response when projectSlug is provided without branch', async () => {
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
-        // No branch provided
-      },
-    } as any;
-
-    const controller = new AbortController();
-    const response = await getBuildFailureLogs(args, {
-      signal: controller.signal,
-    });
-
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(Array.isArray(response.content)).toBe(true);
-    expect(response.content[0]).toHaveProperty('type', 'text');
-    expect(response.content[0].text).toContain('Branch not provided');
-
-    // Verify that getPipelineJobLogs was not called
-    expect(getPipelineJobLogsModule.default).not.toHaveBeenCalled();
-    expect(formatJobLogs.formatJobLogs).not.toHaveBeenCalled();
-  });
-
   it('should return a valid MCP success response with logs', async () => {
     vi.spyOn(projectDetection, 'getProjectSlugFromURL').mockReturnValue(
       'gh/org/repo',

--- a/src/tools/getBuildFailureLogs/handler.test.ts
+++ b/src/tools/getBuildFailureLogs/handler.test.ts
@@ -56,6 +56,30 @@ describe('getBuildFailureLogs handler', () => {
     expect(typeof response.content[0].text).toBe('string');
   });
 
+  it('should return a valid MCP error response when projectSlug is provided without branch', async () => {
+    const args = {
+      params: {
+        projectSlug: 'gh/org/repo',
+        // No branch provided
+      },
+    } as any;
+
+    const controller = new AbortController();
+    const response = await getBuildFailureLogs(args, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(response).toHaveProperty('isError', true);
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(response.content[0].text).toContain('Branch not provided');
+
+    // Verify that getPipelineJobLogs was not called
+    expect(getPipelineJobLogsModule.default).not.toHaveBeenCalled();
+    expect(formatJobLogs.formatJobLogs).not.toHaveBeenCalled();
+  });
+
   it('should return a valid MCP success response with logs', async () => {
     vi.spyOn(projectDetection, 'getProjectSlugFromURL').mockReturnValue(
       'gh/org/repo',

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -13,13 +13,27 @@ import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
 export const getBuildFailureLogs: ToolCallback<{
   params: typeof getBuildFailureOutputInputSchema;
 }> = async (args) => {
-  const { workspaceRoot, gitRemoteURL, branch, projectURL } = args.params;
+  const {
+    workspaceRoot,
+    gitRemoteURL,
+    branch,
+    projectURL,
+    projectSlug: inputProjectSlug,
+  } = args.params;
 
   let projectSlug: string | undefined;
   let pipelineNumber: number | undefined;
   let branchFromURL: string | undefined;
   let jobNumber: number | undefined;
-  if (projectURL) {
+
+  if (inputProjectSlug) {
+    if (!branch) {
+      return mcpErrorOutput(
+        'Branch not provided. When using projectSlug, a branch must also be specified.',
+      );
+    }
+    projectSlug = inputProjectSlug;
+  } else if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);
     pipelineNumber = getPipelineNumberFromURL(projectURL);
     branchFromURL = getBranchFromURL(projectURL);
@@ -30,7 +44,7 @@ export const getBuildFailureLogs: ToolCallback<{
     });
   } else {
     return mcpErrorOutput(
-      'No inputs provided. Ask the user to provide the inputs user can provide based on the tool description.',
+      'Missing required inputs. Please provide either: 1) projectSlug with branch, 2) projectURL, or 3) workspaceRoot with gitRemoteURL and branch.',
     );
   }
 

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -27,11 +27,6 @@ export const getBuildFailureLogs: ToolCallback<{
   let jobNumber: number | undefined;
 
   if (inputProjectSlug) {
-    if (!branch) {
-      return mcpErrorOutput(
-        'Branch not provided. When using projectSlug, a branch must also be specified.',
-      );
-    }
     projectSlug = inputProjectSlug;
   } else if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);

--- a/src/tools/getBuildFailureLogs/inputSchema.ts
+++ b/src/tools/getBuildFailureLogs/inputSchema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import {
   branchDescription,
-  projectSlugDescription,
+  projectSlugDescriptionNoBranch,
 } from '../sharedInputSchemas.js';
 
 export const getBuildFailureOutputInputSchema = z.object({
-  projectSlug: z.string().describe(projectSlugDescription).optional(),
+  projectSlug: z.string().describe(projectSlugDescriptionNoBranch).optional(),
   branch: z.string().describe(branchDescription).optional(),
   projectURL: z
     .string()

--- a/src/tools/getBuildFailureLogs/inputSchema.ts
+++ b/src/tools/getBuildFailureLogs/inputSchema.ts
@@ -1,20 +1,12 @@
 import { z } from 'zod';
+import {
+  branchDescription,
+  projectSlugDescription,
+} from '../sharedInputSchemas.js';
 
 export const getBuildFailureOutputInputSchema = z.object({
-  projectSlug: z
-    .string()
-    .describe(
-      'The project slug from listFollowedProjects. When using this option, branch must also be provided.',
-    )
-    .optional(),
-  branch: z
-    .string()
-    .describe(
-      'The name of the branch currently checked out in local workspace. ' +
-        'This should match local git branch. ' +
-        'For example: "feature/my-branch", "bugfix/123", "main", "master" etc.',
-    )
-    .optional(),
+  projectSlug: z.string().describe(projectSlugDescription).optional(),
+  branch: z.string().describe(branchDescription).optional(),
   projectURL: z
     .string()
     .describe(

--- a/src/tools/getBuildFailureLogs/inputSchema.ts
+++ b/src/tools/getBuildFailureLogs/inputSchema.ts
@@ -1,19 +1,10 @@
 import { z } from 'zod';
 
 export const getBuildFailureOutputInputSchema = z.object({
-  workspaceRoot: z
+  projectSlug: z
     .string()
     .describe(
-      'The absolute path to the root directory of your project workspace. ' +
-        'This should be the top-level folder containing your source code, configuration files, and dependencies. ' +
-        'For example: "/home/user/my-project" or "C:\\Users\\user\\my-project"',
-    )
-    .optional(),
-  gitRemoteURL: z
-    .string()
-    .describe(
-      'The URL of the remote git repository. This should be the URL of the repository that you cloned to your local workspace. ' +
-        'For example: "https://github.com/user/my-project.git"',
+      'The project slug from listFollowedProjects. When using this option, branch must also be provided.',
     )
     .optional(),
   branch: z
@@ -32,6 +23,21 @@ export const getBuildFailureOutputInputSchema = z.object({
         '- Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123\n' +
         '- Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def\n' +
         '- Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz',
+    )
+    .optional(),
+  workspaceRoot: z
+    .string()
+    .describe(
+      'The absolute path to the root directory of your project workspace. ' +
+        'This should be the top-level folder containing your source code, configuration files, and dependencies. ' +
+        'For example: "/home/user/my-project" or "C:\\Users\\user\\my-project"',
+    )
+    .optional(),
+  gitRemoteURL: z
+    .string()
+    .describe(
+      'The URL of the remote git repository. This should be the URL of the repository that you cloned to your local workspace. ' +
+        'For example: "https://github.com/user/my-project.git"',
     )
     .optional(),
 });

--- a/src/tools/getBuildFailureLogs/tool.ts
+++ b/src/tools/getBuildFailureLogs/tool.ts
@@ -12,9 +12,13 @@ export const getBuildFailureLogsTool = {
          "WARNING: The logs have been truncated. Only showing the most recent entries. Earlier build failures may not be visible."
        - Only proceed with log analysis after acknowledging the truncation
 
-    Input options (EXACTLY ONE of these two options must be used):
+    Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Direct URL (provide ONE of these):
+    Option 1 - Project Slug (BOTH of these must be provided together):
+    - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
+    - branch: The name of the branch to retrieve logs for
+
+    Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:
       * Project URL: https://app.circleci.com/pipelines/gh/organization/project
       * Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123
@@ -22,16 +26,22 @@ export const getBuildFailureLogsTool = {
       * Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def
       * Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz
 
-    Option 2 - Project Detection (ALL of these must be provided together):
+    Option 3 - Project Detection (ALL of these must be provided together):
     - workspaceRoot: The absolute path to the workspace root
     - gitRemoteURL: The URL of the git remote repository
     - branch: The name of the current branch
+    
+    Recommended Workflow:
+    1. Use listFollowedProjects tool to get a list of projects
+    2. Extract the projectSlug from the chosen project (format: "gh/organization/project")
+    3. Use that projectSlug with a branch name for this tool
 
     Additional Requirements:
     - Never call this tool with incomplete parameters
-    - If using Option 1, the URLs MUST be provided by the user - do not attempt to construct or guess URLs
-    - If using Option 2, ALL THREE parameters (workspaceRoot, gitRemoteURL, branch) must be provided
-    - If neither option can be fully satisfied, ask the user for the missing information before making the tool call
+    - If using Option 1, make sure to extract the projectSlug exactly as provided by listFollowedProjects
+    - If using Option 2, the URLs MUST be provided by the user - do not attempt to construct or guess URLs
+    - If using Option 3, ALL THREE parameters (workspaceRoot, gitRemoteURL, branch) must be provided
+    - If none of the options can be fully satisfied, ask the user for the missing information before making the tool call
     `,
   inputSchema: getBuildFailureOutputInputSchema,
 };

--- a/src/tools/getBuildFailureLogs/tool.ts
+++ b/src/tools/getBuildFailureLogs/tool.ts
@@ -14,9 +14,9 @@ export const getBuildFailureLogsTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Project Slug (BOTH of these must be provided together):
+    Option 1 - Project Slug and optional branch:
     - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
-    - branch: The name of the branch to retrieve logs for
+    - branch: The name of the branch to retrieve logs for (optional)
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:

--- a/src/tools/getFlakyTests/handler.ts
+++ b/src/tools/getFlakyTests/handler.ts
@@ -12,11 +12,18 @@ import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
 export const getFlakyTestLogs: ToolCallback<{
   params: typeof getFlakyTestLogsInputSchema;
 }> = async (args) => {
-  const { workspaceRoot, gitRemoteURL, projectURL } = args.params;
+  const {
+    workspaceRoot,
+    gitRemoteURL,
+    projectURL,
+    projectSlug: inputProjectSlug,
+  } = args.params;
 
   let projectSlug: string | null | undefined;
 
-  if (projectURL) {
+  if (inputProjectSlug) {
+    projectSlug = inputProjectSlug;
+  } else if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);
   } else if (workspaceRoot && gitRemoteURL) {
     projectSlug = await identifyProjectSlug({
@@ -24,7 +31,7 @@ export const getFlakyTestLogs: ToolCallback<{
     });
   } else {
     return mcpErrorOutput(
-      'No inputs provided. Ask the user to provide the inputs user can provide based on the tool description.',
+      'Missing required inputs. Please provide either: 1) projectSlug, 2) projectURL, or 3) workspaceRoot with gitRemoteURL.',
     );
   }
 

--- a/src/tools/getFlakyTests/inputSchema.ts
+++ b/src/tools/getFlakyTests/inputSchema.ts
@@ -1,12 +1,8 @@
 import { z } from 'zod';
+import { projectSlugDescriptionNoBranch } from '../sharedInputSchemas.js';
 
 export const getFlakyTestLogsInputSchema = z.object({
-  projectSlug: z
-    .string()
-    .describe(
-      'The project slug from listFollowedProjects tool (e.g., "gh/organization/project").',
-    )
-    .optional(),
+  projectSlug: z.string().describe(projectSlugDescriptionNoBranch).optional(),
   workspaceRoot: z
     .string()
     .describe(

--- a/src/tools/getFlakyTests/inputSchema.ts
+++ b/src/tools/getFlakyTests/inputSchema.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 
 export const getFlakyTestLogsInputSchema = z.object({
+  projectSlug: z
+    .string()
+    .describe(
+      'The project slug from listFollowedProjects tool (e.g., "gh/organization/project").',
+    )
+    .optional(),
   workspaceRoot: z
     .string()
     .describe(

--- a/src/tools/getFlakyTests/tool.ts
+++ b/src/tools/getFlakyTests/tool.ts
@@ -14,24 +14,28 @@ export const getFlakyTestLogsTool = {
          "WARNING: The logs have been truncated. Only showing the most recent entries. Earlier build failures may not be visible."
        - Only proceed with log analysis after acknowledging the truncation
 
-    Input options (EXACTLY ONE of these two options must be used):
+    Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Direct URL (provide ONE of these):
+    Option 1 - Project Slug:
+    - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
+
+    Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:
       * Project URL: https://app.circleci.com/pipelines/gh/organization/project
       * Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123
       * Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def
       * Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz
 
-    Option 2 - Project Detection (ALL of these must be provided together):
+    Option 3 - Project Detection (ALL of these must be provided together):
     - workspaceRoot: The absolute path to the workspace root
     - gitRemoteURL: The URL of the git remote repository
 
     Additional Requirements:
     - Never call this tool with incomplete parameters
-    - If using Option 1, the URLs MUST be provided by the user - do not attempt to construct or guess URLs
-    - If using Option 2, BOTH parameters (workspaceRoot, gitRemoteURL) must be provided
-    - If neither option can be fully satisfied, ask the user for the missing information before making the tool call
+    - If using Option 1, make sure to extract the projectSlug exactly as provided by listFollowedProjects
+    - If using Option 2, the URLs MUST be provided by the user - do not attempt to construct or guess URLs
+    - If using Option 3, BOTH parameters (workspaceRoot, gitRemoteURL) must be provided
+    - If none of the options can be fully satisfied, ask the user for the missing information before making the tool call
     `,
   inputSchema: getFlakyTestLogsInputSchema,
 };

--- a/src/tools/getJobTestResults/handler.ts
+++ b/src/tools/getJobTestResults/handler.ts
@@ -20,6 +20,7 @@ export const getJobTestResults: ToolCallback<{
     branch,
     projectURL,
     filterByTestsResult,
+    projectSlug: inputProjectSlug,
   } = args.params;
 
   let pipelineNumber: number | undefined;
@@ -27,7 +28,14 @@ export const getJobTestResults: ToolCallback<{
   let jobNumber: number | undefined;
   let branchFromURL: string | undefined;
 
-  if (projectURL) {
+  if (inputProjectSlug) {
+    if (!branch) {
+      return mcpErrorOutput(
+        'Branch not provided. When using projectSlug, a branch must also be specified.',
+      );
+    }
+    projectSlug = inputProjectSlug;
+  } else if (projectURL) {
     pipelineNumber = getPipelineNumberFromURL(projectURL);
     projectSlug = getProjectSlugFromURL(projectURL);
     branchFromURL = getBranchFromURL(projectURL);
@@ -38,7 +46,7 @@ export const getJobTestResults: ToolCallback<{
     });
   } else {
     return mcpErrorOutput(
-      'No inputs provided. Ask the user to provide the inputs user can provide based on the tool description.',
+      'Missing required inputs. Please provide either: 1) projectSlug with branch, 2) projectURL, or 3) workspaceRoot with gitRemoteURL and branch.',
     );
   }
 

--- a/src/tools/getJobTestResults/handler.ts
+++ b/src/tools/getJobTestResults/handler.ts
@@ -29,11 +29,6 @@ export const getJobTestResults: ToolCallback<{
   let branchFromURL: string | undefined;
 
   if (inputProjectSlug) {
-    if (!branch) {
-      return mcpErrorOutput(
-        'Branch not provided. When using projectSlug, a branch must also be specified.',
-      );
-    }
     projectSlug = inputProjectSlug;
   } else if (projectURL) {
     pipelineNumber = getPipelineNumberFromURL(projectURL);

--- a/src/tools/getJobTestResults/inputSchema.ts
+++ b/src/tools/getJobTestResults/inputSchema.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 
 export const getJobTestResultsInputSchema = z.object({
+  projectSlug: z
+    .string()
+    .describe(
+      'The project slug from listFollowedProjects. When using this option, branch must also be provided.',
+    )
+    .optional(),
   workspaceRoot: z
     .string()
     .describe(

--- a/src/tools/getJobTestResults/inputSchema.ts
+++ b/src/tools/getJobTestResults/inputSchema.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
+import {
+  branchDescription,
+  projectSlugDescription,
+} from '../sharedInputSchemas.js';
 
 export const getJobTestResultsInputSchema = z.object({
-  projectSlug: z
-    .string()
-    .describe(
-      'The project slug from listFollowedProjects. When using this option, branch must also be provided.',
-    )
-    .optional(),
+  projectSlug: z.string().describe(projectSlugDescription).optional(),
+  branch: z.string().describe(branchDescription).optional(),
   workspaceRoot: z
     .string()
     .describe(
@@ -20,14 +20,6 @@ export const getJobTestResultsInputSchema = z.object({
     .describe(
       'The URL of the remote git repository. This should be the URL of the repository that you cloned to your local workspace. ' +
         'For example: "https://github.com/user/my-project.git"',
-    )
-    .optional(),
-  branch: z
-    .string()
-    .describe(
-      'The name of the branch currently checked out in local workspace. ' +
-        'This should match local git branch. ' +
-        'For example: "feature/my-branch", "bugfix/123", "main", "master" etc.',
     )
     .optional(),
   projectURL: z

--- a/src/tools/getJobTestResults/inputSchema.ts
+++ b/src/tools/getJobTestResults/inputSchema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import {
   branchDescription,
-  projectSlugDescription,
+  projectSlugDescriptionNoBranch,
 } from '../sharedInputSchemas.js';
 
 export const getJobTestResultsInputSchema = z.object({
-  projectSlug: z.string().describe(projectSlugDescription).optional(),
+  projectSlug: z.string().describe(projectSlugDescriptionNoBranch).optional(),
   branch: z.string().describe(branchDescription).optional(),
   workspaceRoot: z
     .string()

--- a/src/tools/getJobTestResults/tool.ts
+++ b/src/tools/getJobTestResults/tool.ts
@@ -32,15 +32,19 @@ export const getJobTestResultsTool = {
        - When looking for failed tests, ALWAYS set filterByTestsResult to 'failure'
        - When checking if tests are passing, set filterByTestsResult to 'success'
 
-    Input options (EXACTLY ONE of these two options must be used):
+    Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Direct URL (provide ONE of these):
+    Option 1 - Project Slug (BOTH of these must be provided together):
+    - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
+    - branch: The name of the branch to retrieve test results for
+
+    Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI job in any of these formats:
       * Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/789
       * Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def
       * Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123
 
-    Option 2 - Project Detection (ALL of these must be provided together):
+    Option 3 - Project Detection (ALL of these must be provided together):
     - workspaceRoot: The absolute path to the workspace root
     - gitRemoteURL: The URL of the git remote repository
     - branch: The name of the current branch
@@ -49,9 +53,10 @@ export const getJobTestResultsTool = {
 
     Additional Requirements:
     - Never call this tool with incomplete parameters
-    - If using Option 1, the URL MUST be provided by the user - do not attempt to construct or guess URLs
-    - If using Option 2, ALL THREE parameters (workspaceRoot, gitRemoteURL, branch) must be provided
-    - If neither option can be fully satisfied, ask the user for the missing information before making the tool call
+    - If using Option 1, make sure to extract the projectSlug exactly as provided by listFollowedProjects and include the branch parameter
+    - If using Option 2, the URL MUST be provided by the user - do not attempt to construct or guess URLs
+    - If using Option 3, ALL THREE parameters (workspaceRoot, gitRemoteURL, branch) must be provided
+    - If none of the options can be fully satisfied, ask the user for the missing information before making the tool call
     `,
   inputSchema: getJobTestResultsInputSchema,
 };

--- a/src/tools/getJobTestResults/tool.ts
+++ b/src/tools/getJobTestResults/tool.ts
@@ -34,9 +34,9 @@ export const getJobTestResultsTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Project Slug (BOTH of these must be provided together):
+    Option 1 - Project Slug and optional branch:
     - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
-    - branch: The name of the branch to retrieve test results for
+    - branch: The name of the branch to retrieve test results for (optional)
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI job in any of these formats:

--- a/src/tools/getLatestPipelineStatus/handler.test.ts
+++ b/src/tools/getLatestPipelineStatus/handler.test.ts
@@ -140,33 +140,6 @@ describe('getLatestPipelineStatus handler', () => {
     expect(response).toEqual(mockFormattedResponse);
   });
 
-  it('should return error when projectSlug is provided without branch', async () => {
-    const args = {
-      params: {
-        projectSlug: 'gh/circleci/project',
-        // No branch provided
-      },
-    };
-
-    const controller = new AbortController();
-    const response = await getLatestPipelineStatus(args as any, {
-      signal: controller.signal,
-    });
-
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(response.content[0]).toHaveProperty('type', 'text');
-    expect(response.content[0].text).toContain('Branch not provided');
-
-    // Verify that no further processing was attempted
-    expect(
-      getLatestPipelineWorkflowsModule.getLatestPipelineWorkflows,
-    ).not.toHaveBeenCalled();
-    expect(
-      formatLatestPipelineStatusModule.formatLatestPipelineStatus,
-    ).not.toHaveBeenCalled();
-  });
-
   it('should return error when no valid inputs are provided', async () => {
     const args = {
       params: {},

--- a/src/tools/getLatestPipelineStatus/handler.test.ts
+++ b/src/tools/getLatestPipelineStatus/handler.test.ts
@@ -111,6 +111,62 @@ describe('getLatestPipelineStatus handler', () => {
     expect(response).toEqual(mockFormattedResponse);
   });
 
+  it('should get latest pipeline status using projectSlug and branch', async () => {
+    const args = {
+      params: {
+        projectSlug: 'gh/circleci/project',
+        branch: 'feature/branch',
+      },
+    };
+
+    const controller = new AbortController();
+    const response = await getLatestPipelineStatus(args as any, {
+      signal: controller.signal,
+    });
+
+    // Verify that project detection functions were not called
+    expect(projectDetection.getProjectSlugFromURL).not.toHaveBeenCalled();
+    expect(projectDetection.identifyProjectSlug).not.toHaveBeenCalled();
+
+    expect(
+      getLatestPipelineWorkflowsModule.getLatestPipelineWorkflows,
+    ).toHaveBeenCalledWith({
+      projectSlug: 'gh/circleci/project',
+      branch: 'feature/branch',
+    });
+    expect(
+      formatLatestPipelineStatusModule.formatLatestPipelineStatus,
+    ).toHaveBeenCalledWith(mockWorkflows);
+    expect(response).toEqual(mockFormattedResponse);
+  });
+
+  it('should return error when projectSlug is provided without branch', async () => {
+    const args = {
+      params: {
+        projectSlug: 'gh/circleci/project',
+        // No branch provided
+      },
+    };
+
+    const controller = new AbortController();
+    const response = await getLatestPipelineStatus(args as any, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(response).toHaveProperty('isError', true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(response.content[0].text).toContain('Branch not provided');
+
+    // Verify that no further processing was attempted
+    expect(
+      getLatestPipelineWorkflowsModule.getLatestPipelineWorkflows,
+    ).not.toHaveBeenCalled();
+    expect(
+      formatLatestPipelineStatusModule.formatLatestPipelineStatus,
+    ).not.toHaveBeenCalled();
+  });
+
   it('should return error when no valid inputs are provided', async () => {
     const args = {
       params: {},
@@ -123,7 +179,7 @@ describe('getLatestPipelineStatus handler', () => {
 
     expect(response).toHaveProperty('content');
     expect(response.content[0]).toHaveProperty('type', 'text');
-    expect(response.content[0].text).toContain('No inputs provided');
+    expect(response.content[0].text).toContain('Missing required inputs');
   });
 
   it('should return error when project slug cannot be identified', async () => {

--- a/src/tools/getLatestPipelineStatus/handler.ts
+++ b/src/tools/getLatestPipelineStatus/handler.ts
@@ -12,21 +12,34 @@ import { formatLatestPipelineStatus } from '../../lib/latest-pipeline/formatLate
 export const getLatestPipelineStatus: ToolCallback<{
   params: typeof getLatestPipelineStatusInputSchema;
 }> = async (args) => {
-  const { workspaceRoot, gitRemoteURL, branch, projectURL } = args.params;
+  const {
+    workspaceRoot,
+    gitRemoteURL,
+    branch,
+    projectURL,
+    projectSlug: inputProjectSlug,
+  } = args.params;
 
   let projectSlug: string | null | undefined;
   let branchFromURL: string | null | undefined;
 
-  if (projectURL) {
+  if (inputProjectSlug) {
+    if (!branch) {
+      return mcpErrorOutput(
+        'Branch not provided. When using projectSlug, a branch must also be specified.',
+      );
+    }
+    projectSlug = inputProjectSlug;
+  } else if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);
     branchFromURL = getBranchFromURL(projectURL);
-  } else if (workspaceRoot && gitRemoteURL) {
+  } else if (workspaceRoot && gitRemoteURL && branch) {
     projectSlug = await identifyProjectSlug({
       gitRemoteURL,
     });
   } else {
     return mcpErrorOutput(
-      'No inputs provided. Ask the user to provide the inputs user can provide based on the tool description.',
+      'Missing required inputs. Please provide either: 1) projectSlug with branch, 2) projectURL, or 3) workspaceRoot with gitRemoteURL and branch.',
     );
   }
 

--- a/src/tools/getLatestPipelineStatus/handler.ts
+++ b/src/tools/getLatestPipelineStatus/handler.ts
@@ -24,11 +24,6 @@ export const getLatestPipelineStatus: ToolCallback<{
   let branchFromURL: string | null | undefined;
 
   if (inputProjectSlug) {
-    if (!branch) {
-      return mcpErrorOutput(
-        'Branch not provided. When using projectSlug, a branch must also be specified.',
-      );
-    }
     projectSlug = inputProjectSlug;
   } else if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);

--- a/src/tools/getLatestPipelineStatus/handler.ts
+++ b/src/tools/getLatestPipelineStatus/handler.ts
@@ -28,7 +28,7 @@ export const getLatestPipelineStatus: ToolCallback<{
   } else if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);
     branchFromURL = getBranchFromURL(projectURL);
-  } else if (workspaceRoot && gitRemoteURL && branch) {
+  } else if (workspaceRoot && gitRemoteURL) {
     projectSlug = await identifyProjectSlug({
       gitRemoteURL,
     });

--- a/src/tools/getLatestPipelineStatus/inputSchema.ts
+++ b/src/tools/getLatestPipelineStatus/inputSchema.ts
@@ -1,20 +1,12 @@
 import { z } from 'zod';
+import {
+  branchDescription,
+  projectSlugDescription,
+} from '../sharedInputSchemas.js';
 
 export const getLatestPipelineStatusInputSchema = z.object({
-  projectSlug: z
-    .string()
-    .describe(
-      'The project slug from listFollowedProjects. When using this option, branch must also be provided.',
-    )
-    .optional(),
-  branch: z
-    .string()
-    .describe(
-      'The name of the branch currently checked out in local workspace. ' +
-        'This should match local git branch. ' +
-        'For example: "feature/my-branch", "bugfix/123", "main", "master" etc.',
-    )
-    .optional(),
+  projectSlug: z.string().describe(projectSlugDescription).optional(),
+  branch: z.string().describe(branchDescription).optional(),
   projectURL: z
     .string()
     .describe(

--- a/src/tools/getLatestPipelineStatus/inputSchema.ts
+++ b/src/tools/getLatestPipelineStatus/inputSchema.ts
@@ -1,19 +1,10 @@
 import { z } from 'zod';
 
 export const getLatestPipelineStatusInputSchema = z.object({
-  workspaceRoot: z
+  projectSlug: z
     .string()
     .describe(
-      'The absolute path to the root directory of your project workspace. ' +
-        'This should be the top-level folder containing your source code, configuration files, and dependencies. ' +
-        'For example: "/home/user/my-project" or "C:\\Users\\user\\my-project"',
-    )
-    .optional(),
-  gitRemoteURL: z
-    .string()
-    .describe(
-      'The URL of the remote git repository. This should be the URL of the repository that you cloned to your local workspace. ' +
-        'For example: "https://github.com/user/my-project.git"',
+      'The project slug from listFollowedProjects. When using this option, branch must also be provided.',
     )
     .optional(),
   branch: z
@@ -34,6 +25,21 @@ export const getLatestPipelineStatusInputSchema = z.object({
         '- Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123\n' +
         '- Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def\n' +
         '- Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz',
+    )
+    .optional(),
+  workspaceRoot: z
+    .string()
+    .describe(
+      'The absolute path to the root directory of your project workspace. ' +
+        'This should be the top-level folder containing your source code, configuration files, and dependencies. ' +
+        'For example: "/home/user/my-project" or "C:\\Users\\user\\my-project"',
+    )
+    .optional(),
+  gitRemoteURL: z
+    .string()
+    .describe(
+      'The URL of the remote git repository. This should be the URL of the repository that you cloned to your local workspace. ' +
+        'For example: "https://github.com/user/my-project.git"',
     )
     .optional(),
 });

--- a/src/tools/getLatestPipelineStatus/inputSchema.ts
+++ b/src/tools/getLatestPipelineStatus/inputSchema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import {
   branchDescription,
-  projectSlugDescription,
+  projectSlugDescriptionNoBranch,
 } from '../sharedInputSchemas.js';
 
 export const getLatestPipelineStatusInputSchema = z.object({
-  projectSlug: z.string().describe(projectSlugDescription).optional(),
+  projectSlug: z.string().describe(projectSlugDescriptionNoBranch).optional(),
   branch: z.string().describe(branchDescription).optional(),
   projectURL: z
     .string()

--- a/src/tools/getLatestPipelineStatus/tool.ts
+++ b/src/tools/getLatestPipelineStatus/tool.ts
@@ -14,9 +14,9 @@ export const getLatestPipelineStatusTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Project Slug (BOTH of these must be provided together):
+    Option 1 - Project Slug and optional branch:
     - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
-    - branch: The name of the branch to retrieve status for
+    - branch: The name of the branch to retrieve pipeline status for (optional)
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:

--- a/src/tools/getLatestPipelineStatus/tool.ts
+++ b/src/tools/getLatestPipelineStatus/tool.ts
@@ -12,9 +12,13 @@ export const getLatestPipelineStatusTool = {
     - Check build progress
     - Get pipeline information
 
-    Input options (EXACTLY ONE of these two options must be used. Before performing the tool call, ensure that the user has provided the correct inputs.):
+    Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Direct URL (provide ONE of these):
+    Option 1 - Project Slug (BOTH of these must be provided together):
+    - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
+    - branch: The name of the branch to retrieve status for
+
+    Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:
       * Project URL: https://app.circleci.com/pipelines/gh/organization/project
       * Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123
@@ -22,16 +26,22 @@ export const getLatestPipelineStatusTool = {
       * Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz
       * Legacy Job URL: https://circleci.com/gh/organization/project/123
 
-    Option 2 - Project Detection (ALL of these must be provided together):
+    Option 3 - Project Detection (ALL of these must be provided together):
     - workspaceRoot: The absolute path to the workspace root
     - gitRemoteURL: The URL of the git remote repository
     - branch: The name of the current branch
+    
+    Recommended Workflow:
+    1. Use listFollowedProjects tool to get a list of projects
+    2. Extract the projectSlug from the chosen project (format: "gh/organization/project")
+    3. Use that projectSlug with a branch name for this tool
 
     Additional Requirements:
     - Never call this tool with incomplete parameters
-    - If using Option 1, the URLs MUST be provided by the user - do not attempt to construct, reconstruct or guess URLs.
-    - If using Option 2, ALL THREE parameters (workspaceRoot, gitRemoteURL, branch) must be provided
-    - If neither option can be fully satisfied, ask the user for the missing information before making the tool call
+    - If using Option 1, make sure to extract the projectSlug exactly as provided by listFollowedProjects
+    - If using Option 2, the URLs MUST be provided by the user - do not attempt to construct or guess URLs
+    - If using Option 3, ALL THREE parameters (workspaceRoot, gitRemoteURL, branch) must be provided
+    - If none of the options can be fully satisfied, ask the user for the missing information before making the tool call
   `,
   inputSchema: getLatestPipelineStatusInputSchema,
 };

--- a/src/tools/listFollowedProjects/handler.test.ts
+++ b/src/tools/listFollowedProjects/handler.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listFollowedProjects } from './handler.js';
+import * as clientModule from '../../clients/client.js';
+
+vi.mock('../../clients/client.js');
+
+describe('listFollowedProjects handler', () => {
+  const mockCircleCIPrivateClient = {
+    me: {
+      getFollowedProjects: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(clientModule, 'getCircleCIPrivateClient').mockReturnValue(
+      mockCircleCIPrivateClient as any,
+    );
+  });
+
+  it('should return an error when no projects are found', async () => {
+    mockCircleCIPrivateClient.me.getFollowedProjects.mockResolvedValue({
+      projects: [],
+      reachedMaxPagesOrTimeout: false,
+    });
+
+    const args = { params: {} } as any;
+    const controller = new AbortController();
+    const response = await listFollowedProjects(args, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(response).toHaveProperty('isError', true);
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+    expect(response.content[0].text).toContain('No projects found');
+  });
+
+  it('should return a list of followed projects', async () => {
+    const mockProjects = [
+      { name: 'Project 1', slug: 'gh/org/project1' },
+      { name: 'Project 2', slug: 'gh/org/project2' },
+    ];
+
+    mockCircleCIPrivateClient.me.getFollowedProjects.mockResolvedValue({
+      projects: mockProjects,
+      reachedMaxPagesOrTimeout: false,
+    });
+
+    const args = { params: {} } as any;
+    const controller = new AbortController();
+    const response = await listFollowedProjects(args, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+    expect(response.content[0].text).toContain('Projects followed:');
+    expect(response.content[0].text).toContain('Project 1');
+    expect(response.content[0].text).toContain('gh/org/project1');
+    expect(response.content[0].text).toContain('Project 2');
+    expect(response.content[0].text).toContain('gh/org/project2');
+  });
+
+  it('should add a warning when not all projects were included', async () => {
+    const mockProjects = [{ name: 'Project 1', slug: 'gh/org/project1' }];
+
+    mockCircleCIPrivateClient.me.getFollowedProjects.mockResolvedValue({
+      projects: mockProjects,
+      reachedMaxPagesOrTimeout: true,
+    });
+
+    const args = { params: {} } as any;
+    const controller = new AbortController();
+    const response = await listFollowedProjects(args, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+    expect(response.content[0].text).toContain(
+      'WARNING: Not all projects were included',
+    );
+    expect(response.content[0].text).toContain('Project 1');
+    expect(response.content[0].text).toContain('gh/org/project1');
+  });
+});

--- a/src/tools/listFollowedProjects/handler.ts
+++ b/src/tools/listFollowedProjects/handler.ts
@@ -1,0 +1,42 @@
+import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
+import { getCircleCIPrivateClient } from '../../clients/client.js';
+import { listFollowedProjectsInputSchema } from './inputSchema.js';
+
+export const listFollowedProjects: ToolCallback<{
+  params: typeof listFollowedProjectsInputSchema;
+}> = async () => {
+  const circleciPrivate = getCircleCIPrivateClient();
+  const followedProjects = await circleciPrivate.me.getFollowedProjects();
+
+  const { projects, reachedMaxPagesOrTimeout } = followedProjects;
+
+  if (projects.length === 0) {
+    return mcpErrorOutput(
+      'No projects found. Please make sure you have access to projects and have followed them.',
+    );
+  }
+
+  const formattedProjectChoices = projects
+    .map(
+      (project, index) =>
+        `${index + 1}. ${project.name} (projectSlug: ${project.slug})`,
+    )
+    .join('\n');
+
+  let resultText = `Projects followed:\n${formattedProjectChoices}\n\nPlease have the user choose one of these projects by name or number. When they choose, you (the LLM) should extract and use the projectSlug (not the project name) associated with their chosen project for subsequent tool calls. This projectSlug is required for tools like get_build_failure_logs, getFlakyTests, and get_job_test_results.`;
+
+  if (reachedMaxPagesOrTimeout) {
+    resultText = `WARNING: Not all projects were included due to pagination limits or timeout.\n\n${resultText}`;
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: resultText,
+      },
+    ],
+  };
+};

--- a/src/tools/listFollowedProjects/inputSchema.ts
+++ b/src/tools/listFollowedProjects/inputSchema.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const listFollowedProjectsInputSchema = z.object({});

--- a/src/tools/listFollowedProjects/tool.ts
+++ b/src/tools/listFollowedProjects/tool.ts
@@ -18,7 +18,7 @@ export const listFollowedProjectsTool = {
     1. Run this tool to see available projects
     2. User selects a project from the list
     3. The LLM should extract and use the projectSlug (not the project name) from the selected project for subsequent tool calls
-    4. The projectSlug is required for many other CircleCI tools, including get_build_failure_logs, getFlakyTests, and get_job_test_results
+    4. The projectSlug is required for many other CircleCI tools, and will be used for those tool calls after a project is selected
     
     Note: If pagination limits are reached, the tool will indicate that not all projects could be displayed.
     

--- a/src/tools/listFollowedProjects/tool.ts
+++ b/src/tools/listFollowedProjects/tool.ts
@@ -21,6 +21,8 @@ export const listFollowedProjectsTool = {
     4. The projectSlug is required for many other CircleCI tools, including get_build_failure_logs, getFlakyTests, and get_job_test_results
     
     Note: If pagination limits are reached, the tool will indicate that not all projects could be displayed.
+    
+    IMPORTANT: Do not automatically run any additional tools after this tool is called. Wait for explicit user instruction before executing further tool calls. It is acceptable to list out tool call options for the user to choose from.
     `,
   inputSchema: listFollowedProjectsInputSchema,
 };

--- a/src/tools/listFollowedProjects/tool.ts
+++ b/src/tools/listFollowedProjects/tool.ts
@@ -1,0 +1,26 @@
+import { listFollowedProjectsInputSchema } from './inputSchema.js';
+
+export const listFollowedProjectsTool = {
+  name: 'list_followed_projects' as const,
+  description: `
+    This tool lists all projects that the user is following on CircleCI.
+    
+    Common use cases:
+    - Identify which CircleCI projects are available to the user
+    - Select a project for subsequent operations
+    - Obtain the projectSlug needed for other CircleCI tools
+    
+    Returns:
+    - A list of projects that the user is following on CircleCI
+    - Each entry includes the project name and its projectSlug
+    
+    Workflow:
+    1. Run this tool to see available projects
+    2. User selects a project from the list
+    3. The LLM should extract and use the projectSlug (not the project name) from the selected project for subsequent tool calls
+    4. The projectSlug is required for many other CircleCI tools, including get_build_failure_logs, getFlakyTests, and get_job_test_results
+    
+    Note: If pagination limits are reached, the tool will indicate that not all projects could be displayed.
+    `,
+  inputSchema: listFollowedProjectsInputSchema,
+};

--- a/src/tools/listFollowedProjects/tool.ts
+++ b/src/tools/listFollowedProjects/tool.ts
@@ -22,7 +22,7 @@ export const listFollowedProjectsTool = {
     
     Note: If pagination limits are reached, the tool will indicate that not all projects could be displayed.
     
-    IMPORTANT: Do not automatically run any additional tools after this tool is called. Wait for explicit user instruction before executing further tool calls. It is acceptable to list out tool call options for the user to choose from.
+    IMPORTANT: Do not automatically run any additional tools after this tool is called. Wait for explicit user instruction before executing further tool calls. The LLM MUST NOT invoke any other CircleCI tools until receiving a clear instruction from the user about what to do next, even if the user selects a project. It is acceptable to list out tool call options for the user to choose from, but do not execute them until instructed.
     `,
   inputSchema: listFollowedProjectsInputSchema,
 };

--- a/src/tools/runPipeline/handler.ts
+++ b/src/tools/runPipeline/handler.ts
@@ -17,12 +17,20 @@ export const runPipeline: ToolCallback<{
     branch,
     projectURL,
     pipelineChoiceName,
+    projectSlug: inputProjectSlug,
   } = args.params;
 
   let projectSlug: string | undefined;
   let branchFromURL: string | undefined;
 
-  if (projectURL) {
+  if (inputProjectSlug) {
+    if (!branch) {
+      return mcpErrorOutput(
+        'Branch not provided. When using projectSlug, a branch must also be specified.',
+      );
+    }
+    projectSlug = inputProjectSlug;
+  } else if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);
     branchFromURL = getBranchFromURL(projectURL);
   } else if (workspaceRoot && gitRemoteURL && branch) {
@@ -31,7 +39,7 @@ export const runPipeline: ToolCallback<{
     });
   } else {
     return mcpErrorOutput(
-      'No inputs provided. Ask the user to provide the inputs user can provide based on the tool description.',
+      'Missing required inputs. Please provide either: 1) projectSlug with branch, 2) projectURL, or 3) workspaceRoot with gitRemoteURL and branch.',
     );
   }
 

--- a/src/tools/runPipeline/inputSchema.ts
+++ b/src/tools/runPipeline/inputSchema.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 
 export const runPipelineInputSchema = z.object({
+  projectSlug: z
+    .string()
+    .describe(
+      'The project slug from listFollowedProjects tool (e.g., "gh/organization/project"). When using this option, branch must also be provided.',
+    )
+    .optional(),
   workspaceRoot: z
     .string()
     .describe(

--- a/src/tools/runPipeline/inputSchema.ts
+++ b/src/tools/runPipeline/inputSchema.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
+import {
+  branchDescription,
+  projectSlugDescription,
+} from '../sharedInputSchemas.js';
 
 export const runPipelineInputSchema = z.object({
-  projectSlug: z
-    .string()
-    .describe(
-      'The project slug from listFollowedProjects tool (e.g., "gh/organization/project"). When using this option, branch must also be provided.',
-    )
-    .optional(),
+  projectSlug: z.string().describe(projectSlugDescription).optional(),
+  branch: z.string().describe(branchDescription).optional(),
   workspaceRoot: z
     .string()
     .describe(
@@ -20,14 +20,6 @@ export const runPipelineInputSchema = z.object({
     .describe(
       'The URL of the remote git repository. This should be the URL of the repository that you cloned to your local workspace. ' +
         'For example: "https://github.com/user/my-project.git"',
-    )
-    .optional(),
-  branch: z
-    .string()
-    .describe(
-      'The name of the branch currently checked out in local workspace. ' +
-        'This should match local git branch. ' +
-        'For example: "feature/my-branch", "bugfix/123", "main", "master" etc.',
     )
     .optional(),
   projectURL: z

--- a/src/tools/runPipeline/tool.ts
+++ b/src/tools/runPipeline/tool.ts
@@ -5,16 +5,20 @@ export const runPipelineTool = {
   description: `
     This tool triggers a new CircleCI pipeline and returns the URL to monitor its progress.
 
-    Input options (EXACTLY ONE of these two options must be used):
+    Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Direct URL (provide ONE of these):
+    Option 1 - Project Slug (BOTH of these must be provided together):
+    - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
+    - branch: The name of the branch to retrieve logs for
+
+    Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:
       * Project URL with branch: https://app.circleci.com/pipelines/gh/organization/project?branch=feature-branch
       * Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123
       * Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def
       * Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz
 
-    Option 2 - Project Detection (ALL of these must be provided together):
+    Option 3 - Project Detection (ALL of these must be provided together):
     - workspaceRoot: The absolute path to the workspace root
     - gitRemoteURL: The URL of the git remote repository
     - branch: The name of the current branch
@@ -27,9 +31,10 @@ export const runPipelineTool = {
 
     Additional Requirements:
     - Never call this tool with incomplete parameters
-    - If using Option 1, the URLs MUST be provided by the user - do not attempt to construct or guess URLs
-    - If using Option 2, ALL THREE parameters (workspaceRoot, gitRemoteURL, branch) must be provided
-    - If neither option can be fully satisfied, ask the user for the missing information before making the tool call
+    - If using Option 1, make sure to extract the projectSlug exactly as provided by listFollowedProjects
+    - If using Option 2, the URLs MUST be provided by the user - do not attempt to construct or guess URLs
+    - If using Option 3, ALL THREE parameters (workspaceRoot, gitRemoteURL, branch) must be provided
+    - If none of the options can be fully satisfied, ask the user for the missing information before making the tool call
 
     Returns:
     - A URL to the newly triggered pipeline that can be used to monitor its progress

--- a/src/tools/sharedInputSchemas.ts
+++ b/src/tools/sharedInputSchemas.ts
@@ -1,0 +1,2 @@
+export const projectSlugDescription = `The project slug from listFollowedProjects tool (e.g., "gh/organization/project"). When using this option, branch must also be provided.`;
+export const branchDescription = `The name of the branch currently checked out in local workspace. This should match local git branch. For example: "feature/my-branch", "bugfix/123", "main", "master" etc.`;

--- a/src/tools/sharedInputSchemas.ts
+++ b/src/tools/sharedInputSchemas.ts
@@ -1,2 +1,3 @@
 export const projectSlugDescription = `The project slug from listFollowedProjects tool (e.g., "gh/organization/project"). When using this option, branch must also be provided.`;
+export const projectSlugDescriptionNoBranch = `The project slug from listFollowedProjects tool (e.g., "gh/organization/project").`;
 export const branchDescription = `The name of the branch currently checked out in local workspace. This should match local git branch. For example: "feature/my-branch", "bugfix/123", "main", "master" etc.`;


### PR DESCRIPTION
Adding a tool to list followed projects, so the user can choose from them to then use the other tools. Makes for a more conversational workflow, instead of having to go grab a URL

Video:

https://github.com/user-attachments/assets/c2597e11-8b3e-4fb9-aefa-25c88ef7c577

