### PR TITLE
feat: add ability to filter job tests by result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2025-05-13
+
+### Added
+
+- Added `filterByTestsResult` parameter to `get_job_test_results` tool
+  - Filter the tests by result
+  - Support for filtering by `failure` or `success`
+
 ## [0.5.1] - 2025-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ https://docs.windsurf.com/windsurf/mcp
     - Error messages
     - Runtime duration
   - List of successful tests with timing information
+  - Filter by tests result
 
   This is particularly useful for:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/lib/pipeline-job-tests/getJobTests.ts
+++ b/src/lib/pipeline-job-tests/getJobTests.ts
@@ -10,17 +10,20 @@ import { rateLimitedRequests } from '../rateLimitedRequests/index.js';
  * @param {number} [params.pipelineNumber] - The pipeline number to fetch tests for
  * @param {number} [params.jobNumber] - The job number to fetch tests for
  * @param {string} [params.branch] - The branch to fetch tests for
+ * @param {string} [params.filterByTestsResult] - The result of the tests to filter by
  */
 export const getJobTests = async ({
   projectSlug,
   pipelineNumber,
   jobNumber,
   branch,
+  filterByTestsResult,
 }: {
   projectSlug: string;
   pipelineNumber?: number;
   jobNumber?: number;
   branch?: string;
+  filterByTestsResult?: 'failure' | 'success';
 }) => {
   const circleci = getCircleCIClient();
   let pipeline: Pipeline | undefined;
@@ -98,5 +101,11 @@ export const getJobTests = async ({
     }),
   );
 
-  return testsArrays.flat();
+  const tests = testsArrays.flat();
+
+  if (!filterByTestsResult) {
+    return tests;
+  }
+
+  return tests.filter((test) => test.result === filterByTestsResult);
 };

--- a/src/tools/getJobTestResults/handler.test.ts
+++ b/src/tools/getJobTestResults/handler.test.ts
@@ -159,4 +159,144 @@ describe('getJobTestResults handler', () => {
       jobNumber: undefined,
     });
   });
+
+  it('should filter test results by success when filterByTestsResult is success', async () => {
+    vi.spyOn(projectDetection, 'getProjectSlugFromURL').mockReturnValue(
+      'gh/org/repo',
+    );
+    vi.spyOn(projectDetection, 'getJobNumberFromURL').mockReturnValue(123);
+
+    const mockTests = [
+      {
+        message: 'No failures',
+        run_time: 0.5,
+        file: 'src/test1.js',
+        result: 'success',
+        name: 'should pass test 1',
+        classname: 'TestClass1',
+      },
+      {
+        message: 'Test failed',
+        run_time: 0.3,
+        file: 'src/test2.js',
+        result: 'failure',
+        name: 'should fail test 2',
+        classname: 'TestClass2',
+      },
+      {
+        message: 'No failures',
+        run_time: 0.4,
+        file: 'src/test3.js',
+        result: 'success',
+        name: 'should pass test 3',
+        classname: 'TestClass3',
+      },
+    ];
+
+    vi.spyOn(getJobTestsModule, 'getJobTests').mockResolvedValue(mockTests);
+
+    vi.spyOn(formatJobTestsModule, 'formatJobTests').mockReturnValue({
+      content: [
+        {
+          type: 'text',
+          text: 'Test results output',
+        },
+      ],
+    });
+
+    const args = {
+      params: {
+        projectURL:
+          'https://app.circleci.com/pipelines/gh/org/repo/123/workflows/abc-def/jobs/123',
+        filterByTestsResult: 'success',
+      },
+    } as any;
+
+    const controller = new AbortController();
+    const response = await getJobTestResults(args, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+
+    expect(getJobTestsModule.getJobTests).toHaveBeenCalledWith({
+      projectSlug: 'gh/org/repo',
+      branch: undefined,
+      jobNumber: 123,
+      filterByTestsResult: 'success',
+    });
+  });
+
+  it('should filter test results by failure when filterByTestsResult is failure', async () => {
+    vi.spyOn(projectDetection, 'getProjectSlugFromURL').mockReturnValue(
+      'gh/org/repo',
+    );
+    vi.spyOn(projectDetection, 'getJobNumberFromURL').mockReturnValue(123);
+
+    const mockTests = [
+      {
+        message: 'No failures',
+        run_time: 0.5,
+        file: 'src/test1.js',
+        result: 'success',
+        name: 'should pass test 1',
+        classname: 'TestClass1',
+      },
+      {
+        message: 'Test failed',
+        run_time: 0.3,
+        file: 'src/test2.js',
+        result: 'failure',
+        name: 'should fail test 2',
+        classname: 'TestClass2',
+      },
+      {
+        message: 'Test failed',
+        run_time: 0.4,
+        file: 'src/test3.js',
+        result: 'failure',
+        name: 'should fail test 3',
+        classname: 'TestClass3',
+      },
+    ];
+
+    vi.spyOn(getJobTestsModule, 'getJobTests').mockResolvedValue(mockTests);
+
+    vi.spyOn(formatJobTestsModule, 'formatJobTests').mockReturnValue({
+      content: [
+        {
+          type: 'text',
+          text: 'Test results output',
+        },
+      ],
+    });
+
+    const args = {
+      params: {
+        projectURL:
+          'https://app.circleci.com/pipelines/gh/org/repo/123/workflows/abc-def/jobs/123',
+        filterByTestsResult: 'failure',
+      },
+    } as any;
+
+    const controller = new AbortController();
+    const response = await getJobTestResults(args, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+
+    expect(getJobTestsModule.getJobTests).toHaveBeenCalledWith({
+      projectSlug: 'gh/org/repo',
+      branch: undefined,
+      jobNumber: 123,
+      filterByTestsResult: 'failure',
+    });
+  });
 });

--- a/src/tools/getJobTestResults/handler.ts
+++ b/src/tools/getJobTestResults/handler.ts
@@ -14,7 +14,13 @@ import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
 export const getJobTestResults: ToolCallback<{
   params: typeof getJobTestResultsInputSchema;
 }> = async (args) => {
-  const { workspaceRoot, gitRemoteURL, branch, projectURL } = args.params;
+  const {
+    workspaceRoot,
+    gitRemoteURL,
+    branch,
+    projectURL,
+    filterByTestsResult,
+  } = args.params;
 
   let pipelineNumber: number | undefined;
   let projectSlug: string | undefined;
@@ -51,6 +57,7 @@ export const getJobTestResults: ToolCallback<{
     pipelineNumber,
     branch: branchFromURL || branch,
     jobNumber,
+    filterByTestsResult,
   });
 
   return formatJobTests(testResults);

--- a/src/tools/getJobTestResults/inputSchema.ts
+++ b/src/tools/getJobTestResults/inputSchema.ts
@@ -35,4 +35,13 @@ export const getJobTestResultsInputSchema = z.object({
         '- Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/123',
     )
     .optional(),
+  filterByTestsResult: z
+    .enum(['failure', 'success'])
+    .describe(
+      `Filter the tests by result.
+      If "failure", only failed tests will be returned.
+      If "success", only successful tests will be returned.
+      `,
+    )
+    .optional(),
 });

--- a/src/tools/getJobTestResults/tool.ts
+++ b/src/tools/getJobTestResults/tool.ts
@@ -25,6 +25,13 @@ export const getJobTestResultsTool = {
          "WARNING: The test results have been truncated. Only showing the most recent entries. Some test data may not be visible."
        - Only proceed with test result analysis after acknowledging the truncation
 
+    2. Test Result Filtering:
+       - Use filterByTestsResult parameter to filter test results:
+         * filterByTestsResult: 'failure' - Show only failed tests
+         * filterByTestsResult: 'success' - Show only successful tests
+       - When looking for failed tests, ALWAYS set filterByTestsResult to 'failure'
+       - When checking if tests are passing, set filterByTestsResult to 'success'
+
     Input options (EXACTLY ONE of these two options must be used):
 
     Option 1 - Direct URL (provide ONE of these):


### PR DESCRIPTION
#56 

Added the ability to filter the tests by result for the `get_job_test_results` tool.

The tool now supports the following options:

- `filterByTestsResult`: 'failure' - Show only failed tests
- `filterByTestsResult`: 'success' - Show only successful tests

The tool will now return a list of tests that match the filter.


**All tests**

![image](https://github.com/user-attachments/assets/998bd496-1326-403b-883e-dc5620c32bc9)



**Failed tests**

![image](https://github.com/user-attachments/assets/ddbb7a58-390d-4561-bbac-459bf70a6dd6)



**Passed tests**

![image](https://github.com/user-attachments/assets/bcd33609-df01-40a9-8764-decf78a334f6)



