### PR TITLE
feat: Support legacy job urls for get build failure logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2025-05-13
+
+### Updated
+
+- Updated `get_build_failure_logs` tool to support legacy job url format like `https://circleci.com/gh/organization/project/123`
+
 ## [0.6.0] - 2025-05-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/lib/pipeline-job-logs/getPipelineJobLogs.ts
+++ b/src/lib/pipeline-job-logs/getPipelineJobLogs.ts
@@ -6,22 +6,35 @@ export type GetPipelineJobLogsParams = {
   projectSlug: string;
   branch?: string;
   pipelineNumber?: number; // if provided, always use this to fetch the pipeline instead of the branch
+  jobNumber?: number; // if provided, always use this to fetch the job instead of the branch and pipeline number
 };
 
 const getPipelineJobLogs = async ({
   projectSlug,
   branch,
   pipelineNumber,
+  jobNumber,
 }: GetPipelineJobLogsParams) => {
   const circleci = getCircleCIClient();
   let pipeline: Pipeline | undefined;
 
+  // If jobNumber is provided, fetch the job logs directly
+  if (jobNumber) {
+    return await getJobLogs({
+      projectSlug,
+      jobNumbers: [jobNumber],
+      failedStepsOnly: true,
+    });
+  }
+  
+  // If pipelineNumber is provided, fetch the pipeline logs for failed steps in jobs
   if (pipelineNumber) {
     pipeline = await circleci.pipelines.getPipelineByNumber({
       projectSlug,
       pipelineNumber,
     });
   } else if (branch) {
+    // If branch is provided, fetch the pipeline logs for failed steps in jobs for a branch
     const pipelines = await circleci.pipelines.getPipelines({
       projectSlug,
       branch,
@@ -29,7 +42,8 @@ const getPipelineJobLogs = async ({
 
     pipeline = pipelines[0];
   } else {
-    throw new Error('Either pipelineNumber or branch must be provided');
+    // If no jobNumber, pipelineNumber or branch is provided, throw an error
+    throw new Error('Either jobNumber, pipelineNumber or branch must be provided');
   }
 
   if (!pipeline) {

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -4,12 +4,12 @@ import {
   getProjectSlugFromURL,
   getBranchFromURL,
   identifyProjectSlug,
+  getJobNumberFromURL,
 } from '../../lib/project-detection/index.js';
 import { getBuildFailureOutputInputSchema } from './inputSchema.js';
 import getPipelineJobLogs from '../../lib/pipeline-job-logs/getPipelineJobLogs.js';
 import { formatJobLogs } from '../../lib/pipeline-job-logs/getJobLogs.js';
 import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
-
 export const getBuildFailureLogs: ToolCallback<{
   params: typeof getBuildFailureOutputInputSchema;
 }> = async (args) => {
@@ -18,11 +18,12 @@ export const getBuildFailureLogs: ToolCallback<{
   let projectSlug: string | undefined;
   let pipelineNumber: number | undefined;
   let branchFromURL: string | undefined;
-
+  let jobNumber: number | undefined;
   if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);
     pipelineNumber = getPipelineNumberFromURL(projectURL);
     branchFromURL = getBranchFromURL(projectURL);
+    jobNumber = getJobNumberFromURL(projectURL);
   } else if (workspaceRoot && gitRemoteURL && branch) {
     projectSlug = await identifyProjectSlug({
       gitRemoteURL,
@@ -47,6 +48,7 @@ export const getBuildFailureLogs: ToolCallback<{
     projectSlug,
     branch: branchFromURL || branch,
     pipelineNumber,
+    jobNumber,
   });
 
   return formatJobLogs(logs);

--- a/src/tools/getBuildFailureLogs/tool.ts
+++ b/src/tools/getBuildFailureLogs/tool.ts
@@ -18,6 +18,7 @@ export const getBuildFailureLogsTool = {
     - projectURL: The URL of the CircleCI project in any of these formats:
       * Project URL: https://app.circleci.com/pipelines/gh/organization/project
       * Pipeline URL: https://app.circleci.com/pipelines/gh/organization/project/123
+      * Legacy Job URL: https://circleci.com/pipelines/gh/organization/project/123
       * Workflow URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def
       * Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/xyz
 


### PR DESCRIPTION
implements https://github.com/CircleCI-Public/mcp-server-circleci/issues/51#issuecomment-2873879446

Support `get_build_failure_logs` to work with Url shape `https://domain.com/vcs/organization/project/job-number`

# Regular Tool call with pipeline url
![image](https://github.com/user-attachments/assets/1655c0ee-5de4-427e-b09a-efb3e3b6015f)

# Tool call with Legacy Job URL (which gets redirected on UI)
![image](https://github.com/user-attachments/assets/a5cb8681-4963-434c-96cd-5bfc219e521b)

# Tool call with Regular Job URL
![image](https://github.com/user-attachments/assets/940ed6c0-1be8-4f1b-b14e-213723309311)

