### PR TITLE
refactor: CircleCI MCP Server Circlet tool output from `.circleci/ai/prompts` to `./prompts` & various other prompt engineering

### DIFF
--- a/src/tools/recommendPromptTemplateTests/handler.test.ts
+++ b/src/tools/recommendPromptTemplateTests/handler.test.ts
@@ -68,7 +68,7 @@ describe('recommendPromptTemplateTests handler', () => {
       'save the `promptTemplate`, `contextSchema`, and `recommendedTests`',
     );
     expect(responseText).toContain('RULES FOR SAVING FILES:');
-    expect(responseText).toContain('.circleci/ai/prompts');
+    expect(responseText).toContain('./prompts');
   });
 
   it('should handle errors from CircletClient', async () => {

--- a/src/tools/recommendPromptTemplateTests/handler.ts
+++ b/src/tools/recommendPromptTemplateTests/handler.ts
@@ -39,7 +39,7 @@ RULES FOR SAVING FILES:
   - If a README already exists, update it with the new information.
   - If a README does not exist, create one.
 - The file should be formatted using the user's preferred conventions.
-- The file should be saved in the '.circleci/ai/prompts' directory.
+- The file should be saved in the './prompts' directory at the root of the project.
 - Only save the following files (and nothing else):
   - \`prompt_<relevant-name>.json\`
   - \`README.md\`


### PR DESCRIPTION
# Changes
- refactored CircleCI MCP Server Circlet tool output from `.circleci/ai/prompts` to `./prompts`
- various other prompt engineering