### PR TITLE
fix: fix `get_job_test_results` tool to filter tests by result when a job number is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2025-05-13
+
+### Fixed
+
+- Fixed `get_job_test_results` tool to filter tests by result when a job number is provided
+
 ## [0.6.1] - 2025-05-13
 
 ### Updated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/lib/pipeline-job-tests/getJobTests.ts
+++ b/src/lib/pipeline-job-tests/getJobTests.ts
@@ -34,7 +34,12 @@ export const getJobTests = async ({
       projectSlug,
       jobNumber,
     });
-    return tests;
+
+    if (!filterByTestsResult) {
+      return tests;
+    }
+
+    return tests.filter((test) => test.result === filterByTestsResult);
   }
 
   if (pipelineNumber) {


### PR DESCRIPTION
#56 

Fixed `get_job_test_results` tool to filter tests by result when a job number is provided. We weren't filtering the tests by result when a job number was provided.

![image](https://github.com/user-attachments/assets/2d9c9efd-bf9b-4bc8-8f8b-eca11a6c98da)

