### PR TITLE
fix: allow undefined branch for getBuildFailureLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2025-05-14
+
+### Fixed
+
+- Allow getPipelineJobLogs to fetch most recent pipeline when branch is undefined
+
 ## [0.7.0] - 2025-05-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/lib/pipeline-job-logs/getPipelineJobLogs.ts
+++ b/src/lib/pipeline-job-logs/getPipelineJobLogs.ts
@@ -34,7 +34,6 @@ const getPipelineJobLogs = async ({
       pipelineNumber,
     });
   } else {
-    // If branch is provided, fetch the pipeline logs for failed steps in jobs for a branch
     const pipelines = await circleci.pipelines.getPipelines({
       projectSlug,
       branch,

--- a/src/lib/pipeline-job-logs/getPipelineJobLogs.ts
+++ b/src/lib/pipeline-job-logs/getPipelineJobLogs.ts
@@ -26,14 +26,14 @@ const getPipelineJobLogs = async ({
       failedStepsOnly: true,
     });
   }
-  
+
   // If pipelineNumber is provided, fetch the pipeline logs for failed steps in jobs
   if (pipelineNumber) {
     pipeline = await circleci.pipelines.getPipelineByNumber({
       projectSlug,
       pipelineNumber,
     });
-  } else if (branch) {
+  } else {
     // If branch is provided, fetch the pipeline logs for failed steps in jobs for a branch
     const pipelines = await circleci.pipelines.getPipelines({
       projectSlug,
@@ -41,9 +41,6 @@ const getPipelineJobLogs = async ({
     });
 
     pipeline = pipelines[0];
-  } else {
-    // If no jobNumber, pipelineNumber or branch is provided, throw an error
-    throw new Error('Either jobNumber, pipelineNumber or branch must be provided');
   }
 
   if (!pipeline) {


### PR DESCRIPTION
Small update to allow the get build failure tool to run without branch. Previously an error would be returned if it was called without a branch.

This tool does work without the branch provided, it fetches the most recent pipeline whichever branch that happens to be if branch is empty.

before:

<img width="707" alt="image" src="https://github.com/user-attachments/assets/2b56cd3c-ba22-4cb7-aba7-3cbcc23f4638" />


after:

<img width="884" alt="image" src="https://github.com/user-attachments/assets/3769d733-ac79-4170-a4a3-f867e46d3b34" />
