### PR TITLE
require branch when using projectSlug for pipeline tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2025-05-14
+
+### Updated
+
+- Updated `get_build_failure_logs`, `get_job_test_results`, and `get_latest_pipeline_status` tools to require a branch parameter when using projectSlug option
+
+
 ## [0.7.0] - 2025-05-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/lib/pipeline-job-logs/getPipelineJobLogs.ts
+++ b/src/lib/pipeline-job-logs/getPipelineJobLogs.ts
@@ -26,7 +26,6 @@ const getPipelineJobLogs = async ({
       failedStepsOnly: true,
     });
   }
-  
   // If pipelineNumber is provided, fetch the pipeline logs for failed steps in jobs
   if (pipelineNumber) {
     pipeline = await circleci.pipelines.getPipelineByNumber({
@@ -43,7 +42,9 @@ const getPipelineJobLogs = async ({
     pipeline = pipelines[0];
   } else {
     // If no jobNumber, pipelineNumber or branch is provided, throw an error
-    throw new Error('Either jobNumber, pipelineNumber or branch must be provided');
+    throw new Error(
+      'Either jobNumber, pipelineNumber or branch must be provided',
+    );
   }
 
   if (!pipeline) {

--- a/src/tools/getBuildFailureLogs/handler.test.ts
+++ b/src/tools/getBuildFailureLogs/handler.test.ts
@@ -56,6 +56,26 @@ describe('getBuildFailureLogs handler', () => {
     expect(typeof response.content[0].text).toBe('string');
   });
 
+  it('should return a valid MCP error response when projectSlug is provided without branch', async () => {
+    const args = {
+      params: {
+        projectSlug: 'gh/org/repo',
+      },
+    } as any;
+
+    const controller = new AbortController();
+    const response = await getBuildFailureLogs(args, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(response).toHaveProperty('isError', true);
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+    expect(response.content[0].text).toContain('Branch not provided');
+  });
+
   it('should return a valid MCP success response with logs', async () => {
     vi.spyOn(projectDetection, 'getProjectSlugFromURL').mockReturnValue(
       'gh/org/repo',

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -27,6 +27,11 @@ export const getBuildFailureLogs: ToolCallback<{
   let jobNumber: number | undefined;
 
   if (inputProjectSlug) {
+    if (!branch) {
+      return mcpErrorOutput(
+        'Branch not provided. When using projectSlug, a branch must also be specified.',
+      );
+    }
     projectSlug = inputProjectSlug;
   } else if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);

--- a/src/tools/getBuildFailureLogs/inputSchema.ts
+++ b/src/tools/getBuildFailureLogs/inputSchema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import {
   branchDescription,
-  projectSlugDescriptionNoBranch,
+  projectSlugDescription,
 } from '../sharedInputSchemas.js';
 
 export const getBuildFailureOutputInputSchema = z.object({
-  projectSlug: z.string().describe(projectSlugDescriptionNoBranch).optional(),
+  projectSlug: z.string().describe(projectSlugDescription).optional(),
   branch: z.string().describe(branchDescription).optional(),
   projectURL: z
     .string()

--- a/src/tools/getBuildFailureLogs/tool.ts
+++ b/src/tools/getBuildFailureLogs/tool.ts
@@ -14,9 +14,9 @@ export const getBuildFailureLogsTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Project Slug and optional branch:
+    Option 1 - Project Slug and branch (BOTH required):
     - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
-    - branch: The name of the branch to retrieve logs for (optional)
+    - branch: The name of the branch (required when using projectSlug)
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:

--- a/src/tools/getBuildFailureLogs/tool.ts
+++ b/src/tools/getBuildFailureLogs/tool.ts
@@ -1,5 +1,5 @@
 import { getBuildFailureOutputInputSchema } from './inputSchema.js';
-import { option1Description } from '../sharedInputSchemas.js';
+import { option1DescriptionBranchRequired } from '../sharedInputSchemas.js';
 
 export const getBuildFailureLogsTool = {
   name: 'get_build_failure_logs' as const,
@@ -15,7 +15,7 @@ export const getBuildFailureLogsTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    ${option1Description}
+    ${option1DescriptionBranchRequired}
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:

--- a/src/tools/getBuildFailureLogs/tool.ts
+++ b/src/tools/getBuildFailureLogs/tool.ts
@@ -1,4 +1,5 @@
 import { getBuildFailureOutputInputSchema } from './inputSchema.js';
+import { option1Description } from '../sharedInputSchemas.js';
 
 export const getBuildFailureLogsTool = {
   name: 'get_build_failure_logs' as const,
@@ -14,9 +15,7 @@ export const getBuildFailureLogsTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Project Slug and branch (BOTH required):
-    - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
-    - branch: The name of the branch (required when using projectSlug)
+    ${option1Description}
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:

--- a/src/tools/getJobTestResults/handler.test.ts
+++ b/src/tools/getJobTestResults/handler.test.ts
@@ -56,6 +56,26 @@ describe('getJobTestResults handler', () => {
     expect(typeof response.content[0].text).toBe('string');
   });
 
+  it('should return a valid MCP error response when projectSlug is provided without branch', async () => {
+    const args = {
+      params: {
+        projectSlug: 'gh/org/repo',
+      },
+    } as any;
+
+    const controller = new AbortController();
+    const response = await getJobTestResults(args, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(response).toHaveProperty('isError', true);
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+    expect(response.content[0].text).toContain('Branch not provided');
+  });
+
   it('should return a valid MCP success response with test results for a specific job', async () => {
     vi.spyOn(projectDetection, 'getProjectSlugFromURL').mockReturnValue(
       'gh/org/repo',

--- a/src/tools/getJobTestResults/handler.ts
+++ b/src/tools/getJobTestResults/handler.ts
@@ -29,6 +29,11 @@ export const getJobTestResults: ToolCallback<{
   let branchFromURL: string | undefined;
 
   if (inputProjectSlug) {
+    if (!branch) {
+      return mcpErrorOutput(
+        'Branch not provided. When using projectSlug, a branch must also be specified.',
+      );
+    }
     projectSlug = inputProjectSlug;
   } else if (projectURL) {
     pipelineNumber = getPipelineNumberFromURL(projectURL);

--- a/src/tools/getJobTestResults/inputSchema.ts
+++ b/src/tools/getJobTestResults/inputSchema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import {
   branchDescription,
-  projectSlugDescriptionNoBranch,
+  projectSlugDescription,
 } from '../sharedInputSchemas.js';
 
 export const getJobTestResultsInputSchema = z.object({
-  projectSlug: z.string().describe(projectSlugDescriptionNoBranch).optional(),
+  projectSlug: z.string().describe(projectSlugDescription).optional(),
   branch: z.string().describe(branchDescription).optional(),
   workspaceRoot: z
     .string()

--- a/src/tools/getJobTestResults/tool.ts
+++ b/src/tools/getJobTestResults/tool.ts
@@ -34,9 +34,9 @@ export const getJobTestResultsTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Project Slug and optional branch:
+    Option 1 - Project Slug and branch (BOTH required):
     - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
-    - branch: The name of the branch to retrieve test results for (optional)
+    - branch: The name of the branch (required when using projectSlug)
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI job in any of these formats:

--- a/src/tools/getJobTestResults/tool.ts
+++ b/src/tools/getJobTestResults/tool.ts
@@ -1,4 +1,5 @@
 import { getJobTestResultsInputSchema } from './inputSchema.js';
+import { option1Description } from '../sharedInputSchemas.js';
 
 export const getJobTestResultsTool = {
   name: 'get_job_test_results' as const,
@@ -34,9 +35,7 @@ export const getJobTestResultsTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Project Slug and branch (BOTH required):
-    - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
-    - branch: The name of the branch (required when using projectSlug)
+    ${option1Description}
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI job in any of these formats:

--- a/src/tools/getJobTestResults/tool.ts
+++ b/src/tools/getJobTestResults/tool.ts
@@ -1,5 +1,5 @@
 import { getJobTestResultsInputSchema } from './inputSchema.js';
-import { option1Description } from '../sharedInputSchemas.js';
+import { option1DescriptionBranchRequired } from '../sharedInputSchemas.js';
 
 export const getJobTestResultsTool = {
   name: 'get_job_test_results' as const,
@@ -35,7 +35,7 @@ export const getJobTestResultsTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    ${option1Description}
+    ${option1DescriptionBranchRequired}
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI job in any of these formats:

--- a/src/tools/getLatestPipelineStatus/handler.test.ts
+++ b/src/tools/getLatestPipelineStatus/handler.test.ts
@@ -82,6 +82,26 @@ describe('getLatestPipelineStatus handler', () => {
     expect(response).toEqual(mockFormattedResponse);
   });
 
+  it('should return a valid MCP error response when projectSlug is provided without branch', async () => {
+    const args = {
+      params: {
+        projectSlug: 'gh/circleci/project',
+      },
+    };
+
+    const controller = new AbortController();
+    const response = await getLatestPipelineStatus(args as any, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(response).toHaveProperty('isError', true);
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+    expect(response.content[0].text).toContain('Branch not provided');
+  });
+
   it('should get latest pipeline status using workspace and git info', async () => {
     const args = {
       params: {

--- a/src/tools/getLatestPipelineStatus/handler.ts
+++ b/src/tools/getLatestPipelineStatus/handler.ts
@@ -24,6 +24,11 @@ export const getLatestPipelineStatus: ToolCallback<{
   let branchFromURL: string | null | undefined;
 
   if (inputProjectSlug) {
+    if (!branch) {
+      return mcpErrorOutput(
+        'Branch not provided. When using projectSlug, a branch must also be specified.',
+      );
+    }
     projectSlug = inputProjectSlug;
   } else if (projectURL) {
     projectSlug = getProjectSlugFromURL(projectURL);

--- a/src/tools/getLatestPipelineStatus/inputSchema.ts
+++ b/src/tools/getLatestPipelineStatus/inputSchema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import {
   branchDescription,
-  projectSlugDescriptionNoBranch,
+  projectSlugDescription,
 } from '../sharedInputSchemas.js';
 
 export const getLatestPipelineStatusInputSchema = z.object({
-  projectSlug: z.string().describe(projectSlugDescriptionNoBranch).optional(),
+  projectSlug: z.string().describe(projectSlugDescription).optional(),
   branch: z.string().describe(branchDescription).optional(),
   projectURL: z
     .string()

--- a/src/tools/getLatestPipelineStatus/tool.ts
+++ b/src/tools/getLatestPipelineStatus/tool.ts
@@ -1,4 +1,5 @@
 import { getLatestPipelineStatusInputSchema } from './inputSchema.js';
+import { option1Description } from '../sharedInputSchemas.js';
 
 export const getLatestPipelineStatusTool = {
   name: 'get_latest_pipeline_status' as const,
@@ -14,9 +15,7 @@ export const getLatestPipelineStatusTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Project Slug and branch (BOTH required):
-    - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
-    - branch: The name of the branch (required when using projectSlug)
+    ${option1Description}
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:

--- a/src/tools/getLatestPipelineStatus/tool.ts
+++ b/src/tools/getLatestPipelineStatus/tool.ts
@@ -14,9 +14,9 @@ export const getLatestPipelineStatusTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Project Slug and optional branch:
+    Option 1 - Project Slug and branch (BOTH required):
     - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
-    - branch: The name of the branch to retrieve pipeline status for (optional)
+    - branch: The name of the branch (required when using projectSlug)
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:

--- a/src/tools/getLatestPipelineStatus/tool.ts
+++ b/src/tools/getLatestPipelineStatus/tool.ts
@@ -1,5 +1,5 @@
 import { getLatestPipelineStatusInputSchema } from './inputSchema.js';
-import { option1Description } from '../sharedInputSchemas.js';
+import { option1DescriptionBranchRequired } from '../sharedInputSchemas.js';
 
 export const getLatestPipelineStatusTool = {
   name: 'get_latest_pipeline_status' as const,
@@ -15,7 +15,7 @@ export const getLatestPipelineStatusTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    ${option1Description}
+    ${option1DescriptionBranchRequired}
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:

--- a/src/tools/runPipeline/tool.ts
+++ b/src/tools/runPipeline/tool.ts
@@ -1,4 +1,5 @@
 import { runPipelineInputSchema } from './inputSchema.js';
+import { option1Description } from '../sharedInputSchemas.js';
 
 export const runPipelineTool = {
   name: 'run_pipeline' as const,
@@ -7,9 +8,7 @@ export const runPipelineTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-      Option 1 - Project Slug and branch (BOTH required):
-    - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
-    - branch: The name of the branch (required when using projectSlug)
+    ${option1Description}
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:

--- a/src/tools/runPipeline/tool.ts
+++ b/src/tools/runPipeline/tool.ts
@@ -7,9 +7,9 @@ export const runPipelineTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    Option 1 - Project Slug (BOTH of these must be provided together):
+      Option 1 - Project Slug and branch (BOTH required):
     - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
-    - branch: The name of the branch to retrieve logs for
+    - branch: The name of the branch (required when using projectSlug)
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:

--- a/src/tools/runPipeline/tool.ts
+++ b/src/tools/runPipeline/tool.ts
@@ -1,5 +1,5 @@
 import { runPipelineInputSchema } from './inputSchema.js';
-import { option1Description } from '../sharedInputSchemas.js';
+import { option1DescriptionBranchRequired } from '../sharedInputSchemas.js';
 
 export const runPipelineTool = {
   name: 'run_pipeline' as const,
@@ -8,7 +8,7 @@ export const runPipelineTool = {
 
     Input options (EXACTLY ONE of these THREE options must be used):
 
-    ${option1Description}
+    ${option1DescriptionBranchRequired}
 
     Option 2 - Direct URL (provide ONE of these):
     - projectURL: The URL of the CircleCI project in any of these formats:

--- a/src/tools/sharedInputSchemas.ts
+++ b/src/tools/sharedInputSchemas.ts
@@ -1,3 +1,6 @@
 export const projectSlugDescription = `The project slug from listFollowedProjects tool (e.g., "gh/organization/project"). When using this option, branch must also be provided.`;
 export const projectSlugDescriptionNoBranch = `The project slug from listFollowedProjects tool (e.g., "gh/organization/project").`;
 export const branchDescription = `The name of the branch currently checked out in local workspace. This should match local git branch. For example: "feature/my-branch", "bugfix/123", "main", "master" etc.`;
+export const option1Description = `Option 1 - Project Slug and branch (BOTH required):
+    - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
+    - branch: The name of the branch (required when using projectSlug)`;

--- a/src/tools/sharedInputSchemas.ts
+++ b/src/tools/sharedInputSchemas.ts
@@ -1,6 +1,6 @@
 export const projectSlugDescription = `The project slug from listFollowedProjects tool (e.g., "gh/organization/project"). When using this option, branch must also be provided.`;
 export const projectSlugDescriptionNoBranch = `The project slug from listFollowedProjects tool (e.g., "gh/organization/project").`;
 export const branchDescription = `The name of the branch currently checked out in local workspace. This should match local git branch. For example: "feature/my-branch", "bugfix/123", "main", "master" etc.`;
-export const option1Description = `Option 1 - Project Slug and branch (BOTH required):
+export const option1DescriptionBranchRequired = `Option 1 - Project Slug and branch (BOTH required):
     - projectSlug: The project slug obtained from listFollowedProjects tool (e.g., "gh/organization/project")
     - branch: The name of the branch (required when using projectSlug)`;


### PR DESCRIPTION
Previously these tools all would grab the latest pipeline, regardless of what branch it was. This isn't particularly useful because there could be many branches running pipelines at any time, so getting the most recent may not be work relevant to the user.

Now the tool descriptions / inputSchemas tell the LLM a branch is required, and if it is run without a branch a useful error is returned so the LLM / user knows what they need to do.

ex:

<img width="894" alt="image" src="https://github.com/user-attachments/assets/0dd639f5-557d-4a4d-9451-ccbbc1dc2c02" />
