### PR TITLE
feat: analyze diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2025-06-06
+
+### Added
+
+- Added `analyze_diff` tool to analyze git diffs against cursor rules to identify rule violations
+  - Evaluates code changes against repository coding standards and best practices
+  - Provides detailed violation reports with confidence scores and explanations
+  - Supports both staged and unstaged changes and all changes analysis
+  - Returns actionable feedback for maintaining code quality consistency
+
 ## [0.9.0] - 2025-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.1] - 2025-06-06
+## [0.9.1] - 2025-06-12
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ https://github.com/user-attachments/assets/3c765985-8827-442a-a8dc-5069e01edb74
 - CircleCI API token - you can generate one through the CircleCI. [Learn more](https://circleci.com/docs/managing-api-tokens/) or [click here](https://app.circleci.com/settings/user/tokens) for quick access.
 
 For NPX installation:
+
 - pnpm package manager - [Learn more](https://pnpm.io/installation)
 - Node.js >= v18.0.0
 
 For Docker installation:
+
 - Docker - [Learn more](https://docs.docker.com/get-docker/)
 
 ## Installation
@@ -60,8 +62,10 @@ Add the following to your cursor MCP config:
         "run",
         "--rm",
         "-i",
-        "-e", "CIRCLECI_TOKEN",
-        "-e", "CIRCLECI_BASE_URL",
+        "-e",
+        "CIRCLECI_TOKEN",
+        "-e",
+        "CIRCLECI_BASE_URL",
         "circleci:mcp-server-circleci"
       ],
       "env": {
@@ -141,8 +145,10 @@ To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using Docker:
         "run",
         "--rm",
         "-i",
-        "-e", "CIRCLECI_TOKEN",
-        "-e", "CIRCLECI_BASE_URL",
+        "-e",
+        "CIRCLECI_TOKEN",
+        "-e",
+        "CIRCLECI_BASE_URL",
         "circleci:mcp-server-circleci"
       ],
       "env": {
@@ -188,8 +194,10 @@ Add the following to your claude_desktop_config.json:
         "run",
         "--rm",
         "-i",
-        "-e", "CIRCLECI_TOKEN",
-        "-e", "CIRCLECI_BASE_URL",
+        "-e",
+        "CIRCLECI_TOKEN",
+        "-e",
+        "CIRCLECI_BASE_URL",
         "circleci:mcp-server-circleci"
       ],
       "env": {
@@ -266,8 +274,10 @@ Add the following to your windsurf mcp_config.json:
         "run",
         "--rm",
         "-i",
-        "-e", "CIRCLECI_TOKEN",
-        "-e", "CIRCLECI_BASE_URL",
+        "-e",
+        "CIRCLECI_TOKEN",
+        "-e",
+        "CIRCLECI_BASE_URL",
         "circleci:mcp-server-circleci"
       ],
       "env": {
@@ -299,6 +309,7 @@ npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claud
   Retrieves detailed failure logs from CircleCI builds. This tool can be used in three ways:
 
   1. Using Project Slug and Branch (Recommended Workflow):
+
      - First, list your available projects:
        - Use the list_followed_projects tool to get your projects
        - Example: "List my CircleCI projects"
@@ -308,6 +319,7 @@ npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claud
        - Example: "Get build failures for my-project on the main branch"
 
   2. Using CircleCI URLs:
+
      - Provide a failed job URL or pipeline URL directly
      - Example: "Get logs from https://app.circleci.com/pipelines/github/org/repo/123"
 
@@ -338,6 +350,7 @@ npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claud
   This tool can be used in three ways:
 
   1. Using Project Slug (Recommended Workflow):
+
      - First, list your available projects:
        - Use the list_followed_projects tool to get your projects
        - Example: "List my CircleCI projects"
@@ -373,6 +386,7 @@ npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claud
   Retrieves the status of the latest pipeline for a given branch. This tool can be used in three ways:
 
   1. Using Project Slug and Branch (Recommended Workflow):
+
      - First, list your available projects:
        - Use the list_followed_projects tool to get your projects
        - Example: "List my CircleCI projects"
@@ -428,6 +442,7 @@ npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claud
   Retrieves test metadata for CircleCI jobs, allowing you to analyze test results without leaving your IDE. This tool can be used in three ways:
 
   1. Using Project Slug and Branch (Recommended Workflow):
+
      - First, list your available projects:
        - Use the list_followed_projects tool to get your projects
        - Example: "List my CircleCI projects"
@@ -562,6 +577,7 @@ npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claud
   Triggers a pipeline to run. This tool can be used in three ways:
 
   1. Using Project Slug and Branch (Recommended Workflow):
+
      - First, list your available projects:
        - Use the list_followed_projects tool to get your projects
        - Example: "List my CircleCI projects"
@@ -602,6 +618,43 @@ npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claud
   This is particularly useful for:
 
   - Quickly rerunning a workflow from its start or from the failed job without visiting the CircleCI web UI
+
+- `analyze_diff`
+
+  Analyzes git diffs against cursor rules to identify rule violations.
+
+  This tool can be used by providing:
+
+  1. Git Diff Content:
+
+     - Staged changes: `git diff --cached`
+     - Unstaged changes: `git diff`
+     - All changes: `git diff HEAD`
+     - Example: "Analyze my staged changes against the cursor rules"
+
+  2. Repository Rules:
+     - Rules from `.cursorrules` file in your repository root
+     - Rules from `.cursor/rules` directory
+     - Multiple rule files combined with `---` separator
+     - Example: "Check my diff against the TypeScript coding standards"
+
+  The tool provides:
+
+  - Detailed violation reports with confidence scores
+  - Specific explanations for each rule violation
+
+  Example usage scenarios:
+
+  - "Analyze my staged changes for any rule violations"
+  - "Check my unstaged changes against rules"
+
+  This is particularly useful for:
+
+  - Pre-commit code quality checks
+  - Ensuring consistency with team coding standards
+  - Catching rule violations before code review
+
+  The tool integrates with your existing cursor rules setup and provides immediate feedback on code quality, helping you catch issues early in the development process.
 
 # Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/circleci-tools.ts
+++ b/src/circleci-tools.ts
@@ -21,6 +21,8 @@ import { runEvaluationTestsTool } from './tools/runEvaluationTests/tool.js';
 import { runEvaluationTests } from './tools/runEvaluationTests/handler.js';
 import { rerunWorkflowTool } from './tools/rerunWorkflow/tool.js';
 import { rerunWorkflow } from './tools/rerunWorkflow/handler.js';
+import { analyzeDiffTool } from './tools/analyzeDiff/tool.js';
+import { analyzeDiff } from './tools/analyzeDiff/handler.js';
 
 // Define the tools with their configurations
 export const CCI_TOOLS = [
@@ -35,6 +37,7 @@ export const CCI_TOOLS = [
   listFollowedProjectsTool,
   runEvaluationTestsTool,
   rerunWorkflowTool,
+  analyzeDiffTool,
 ];
 
 // Extract the tool names as a union type
@@ -61,4 +64,5 @@ export const CCI_HANDLERS = {
   list_followed_projects: listFollowedProjects,
   run_evaluation_tests: runEvaluationTests,
   rerun_workflow: rerunWorkflow,
+  analyze_diff: analyzeDiff,
 } satisfies ToolHandlers;

--- a/src/clients/circlet/circlet.ts
+++ b/src/clients/circlet/circlet.ts
@@ -1,5 +1,5 @@
 import { HTTPClient } from '../circleci/httpClient.js';
-import { PromptObject } from '../schemas.js';
+import { PromptObject, RuleReview } from '../schemas.js';
 import { z } from 'zod';
 import { PromptOrigin } from '../../tools/shared/constants.js';
 
@@ -18,7 +18,6 @@ export const RecommendedTestsResponseSchema = z.object({
 export type RecommendedTestsResponse = z.infer<
   typeof RecommendedTestsResponseSchema
 >;
-
 export class CircletAPI {
   protected client: HTTPClient;
 
@@ -70,5 +69,25 @@ export class CircletAPI {
     }
 
     return parsedResult.data.recommendedTests;
+  }
+
+  async ruleReview({
+    diff,
+    rules,
+  }: {
+    diff: string;
+    rules: string;
+  }): Promise<RuleReview> {
+    const rawResult = await this.client.post<unknown>('/rule-review', {
+      diff,
+      rules,
+    });
+    const parsedResult = RuleReview.safeParse(rawResult);
+    if (!parsedResult.success) {
+      throw new Error(
+        `Failed to parse rule review response. Error: ${parsedResult.error.message}`,
+      );
+    }
+    return parsedResult.data;
   }
 }

--- a/src/clients/circlet/circlet.ts
+++ b/src/clients/circlet/circlet.ts
@@ -79,7 +79,7 @@ export class CircletAPI {
     rules: string;
   }): Promise<RuleReview> {
     const rawResult = await this.client.post<unknown>('/rule-review', {
-      diff,
+      changeSet: diff,
       rules,
     });
     const parsedResult = RuleReview.safeParse(rawResult);

--- a/src/clients/schemas.ts
+++ b/src/clients/schemas.ts
@@ -31,29 +31,42 @@ const promptObjectSchema = z
   );
 
 const RuleReviewSchema = z.object({
-  evaluation: z.array(
-    z.object({
-      rule_item: z.string(),
-      status: z.enum(['COMPLIANT', 'VIOLATION', 'HUMAN_REVIEW_REQUIRED']),
-      status_reasoning: z.string(),
-      confidence_score: z.number(),
-      violation_instances: z
-        .array(
+  isRuleCompliant: z.boolean(),
+  relatedRules: z.object({
+    compliant: z.array(
+      z.object({
+        rule: z.string(),
+        reason: z.string(),
+        confidence_score: z.number(),
+      }),
+    ),
+    violations: z.array(
+      z.object({
+        rule: z.string(),
+        reason: z.string(),
+        confidence_score: z.number(),
+        violation_instances: z.array(
           z.object({
             line_numbers_in_diff: z.array(z.string()),
             violating_code_snippet: z.string(),
             explanation_of_violation: z.string(),
           }),
-        )
-        .optional(),
-      human_review_required: z
-        .object({
+        ),
+      }),
+    ),
+    requiresHumanReview: z.array(
+      z.object({
+        rule: z.string(),
+        reason: z.string(),
+        confidence_score: z.number(),
+        human_review_required: z.object({
           points_of_ambiguity: z.array(z.string()),
           questions_for_manual_reviewer: z.array(z.string()),
-        })
-        .optional(),
-    }),
-  ),
+        }),
+      }),
+    ),
+  }),
+  unrelatedRules: z.array(z.string()),
 });
 
 const FollowedProjectSchema = z.object({

--- a/src/clients/schemas.ts
+++ b/src/clients/schemas.ts
@@ -30,6 +30,32 @@ const promptObjectSchema = z
     'a complete prompt template with a template string and a context schema',
   );
 
+const RuleReviewSchema = z.object({
+  evaluation: z.array(
+    z.object({
+      rule_item: z.string(),
+      status: z.enum(['COMPLIANT', 'VIOLATION', 'HUMAN_REVIEW_REQUIRED']),
+      status_reasoning: z.string(),
+      confidence_score: z.number(),
+      violation_instances: z
+        .array(
+          z.object({
+            line_numbers_in_diff: z.array(z.string()),
+            violating_code_snippet: z.string(),
+            explanation_of_violation: z.string(),
+          }),
+        )
+        .optional(),
+      human_review_required: z
+        .object({
+          points_of_ambiguity: z.array(z.string()),
+          questions_for_manual_reviewer: z.array(z.string()),
+        })
+        .optional(),
+    }),
+  ),
+});
+
 const FollowedProjectSchema = z.object({
   name: z.string(),
   slug: z.string(),
@@ -189,3 +215,6 @@ export type PromptObject = z.infer<typeof PromptObject>;
 
 export const RerunWorkflow = RerunWorkflowSchema;
 export type RerunWorkflow = z.infer<typeof RerunWorkflowSchema>;
+
+export const RuleReview = RuleReviewSchema;
+export type RuleReview = z.infer<typeof RuleReviewSchema>;

--- a/src/clients/schemas.ts
+++ b/src/clients/schemas.ts
@@ -37,19 +37,19 @@ const RuleReviewSchema = z.object({
       z.object({
         rule: z.string(),
         reason: z.string(),
-        confidence_score: z.number(),
+        confidenceScore: z.number(),
       }),
     ),
     violations: z.array(
       z.object({
         rule: z.string(),
         reason: z.string(),
-        confidence_score: z.number(),
-        violation_instances: z.array(
+        confidenceScore: z.number(),
+        violationInstances: z.array(
           z.object({
-            line_numbers_in_diff: z.array(z.string()),
-            violating_code_snippet: z.string(),
-            explanation_of_violation: z.string(),
+            lineNumbersInDiff: z.array(z.string()),
+            violatingCodeSnippet: z.string(),
+            explanationOfViolation: z.string(),
           }),
         ),
       }),
@@ -58,10 +58,10 @@ const RuleReviewSchema = z.object({
       z.object({
         rule: z.string(),
         reason: z.string(),
-        confidence_score: z.number(),
-        human_review_required: z.object({
-          points_of_ambiguity: z.array(z.string()),
-          questions_for_manual_reviewer: z.array(z.string()),
+        confidenceScore: z.number(),
+        humanReviewRequired: z.object({
+          pointsOfAmbiguity: z.array(z.string()),
+          questionsForManualReviewer: z.array(z.string()),
         }),
       }),
     ),

--- a/src/tools/analyzeDiff/handler.test.ts
+++ b/src/tools/analyzeDiff/handler.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeDiff } from './handler.js';
+
+describe('analyzeDiff', () => {
+  it('should return formatted output when rules are provided', async () => {
+    const mockArgs = {
+      params: {
+        diff: 'diff --git a/test.ts b/test.ts\n+console.log("test");',
+        rules: 'Rule 1: No console.log statements\nRule 2: Use proper logging',
+      },
+    };
+
+    const controller = new AbortController();
+    const result = await analyzeDiff(mockArgs, { signal: controller.signal });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: `Rules from ${mockArgs.params.rules}:\n${mockArgs.params.rules}\n\nDiff: ${mockArgs.params.diff}`,
+        },
+      ],
+    });
+  });
+
+  it('should return no rules message when rules are not provided', async () => {
+    const mockArgs = {
+      params: {
+        diff: 'diff --git a/test.ts b/test.ts\n+console.log("test");',
+        rules: '',
+      },
+    };
+
+    const controller = new AbortController();
+    const result = await analyzeDiff(mockArgs, { signal: controller.signal });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'No rules found. Please add rules to your repository.',
+        },
+      ],
+    });
+  });
+
+  it('should return no rules message when rules are empty string', async () => {
+    const mockArgs = {
+      params: {
+        diff: 'diff --git a/test.ts b/test.ts\n+console.log("test");',
+        rules: '',
+      },
+    };
+
+    const controller = new AbortController();
+    const result = await analyzeDiff(mockArgs, { signal: controller.signal });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'No rules found. Please add rules to your repository.',
+        },
+      ],
+    });
+  });
+
+  it('should handle empty diff with rules provided', async () => {
+    const mockArgs = {
+      params: {
+        diff: '',
+        rules: 'Rule 1: No console.log statements',
+      },
+    };
+
+    const controller = new AbortController();
+    const result = await analyzeDiff(mockArgs, { signal: controller.signal });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: `Rules from ${mockArgs.params.rules}:\n${mockArgs.params.rules}\n\nDiff: `,
+        },
+      ],
+    });
+  });
+
+  it('should handle complex diff content with multiple rules', async () => {
+    const mockArgs = {
+      params: {
+        diff: `diff --git a/src/component.ts b/src/component.ts
+index 1234567..abcdefg 100644
+--- a/src/component.ts
++++ b/src/component.ts
+@@ -1,5 +1,8 @@
+ export class Component {
++  private data: any = {};
++  
+   constructor() {
++    console.log("Component created");
+   }
+ }`,
+        rules: `Rule 1: No console.log statements
+Rule 2: Avoid using 'any' type
+Rule 3: Use proper TypeScript types
+---
+Rule 4: All functions must have JSDoc comments`,
+      },
+    };
+
+    const controller = new AbortController();
+    const result = await analyzeDiff(mockArgs, { signal: controller.signal });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: `Rules from ${mockArgs.params.rules}:\n${mockArgs.params.rules}\n\nDiff: ${mockArgs.params.diff}`,
+        },
+      ],
+    });
+  });
+
+  it('should handle multiline rules and preserve formatting', async () => {
+    const mockArgs = {
+      params: {
+        diff: '+const x = 5;\n+console.log(x);',
+        rules: `# Cursor Rules Example
+
+## Rule: No Console Logs
+Description: Remove all console.log statements before committing code.
+
+## Rule: TypeScript Safety
+Description: Avoid using 'any' type.`,
+      },
+    };
+
+    const controller = new AbortController();
+    const result = await analyzeDiff(mockArgs, { signal: controller.signal });
+
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('Rules from');
+    expect(result.content[0].text).toContain('No Console Logs');
+    expect(result.content[0].text).toContain('TypeScript Safety');
+    expect(result.content[0].text).toContain('Diff: +const x = 5;');
+  });
+
+  it('should handle whitespace-only rules as truthy', async () => {
+    const mockArgs = {
+      params: {
+        diff: 'diff --git a/test.ts b/test.ts\n+const test = true;',
+        rules: '   \n\t  \n   ',
+      },
+    };
+
+    const controller = new AbortController();
+    const result = await analyzeDiff(mockArgs, { signal: controller.signal });
+
+    // Whitespace-only string should be treated as truthy in JavaScript
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: `Rules from    \n\t  \n   :\n   \n\t  \n   \n\nDiff: diff --git a/test.ts b/test.ts\n+const test = true;`,
+        },
+      ],
+    });
+  });
+});

--- a/src/tools/analyzeDiff/handler.test.ts
+++ b/src/tools/analyzeDiff/handler.test.ts
@@ -81,7 +81,7 @@ describe('analyzeDiff', () => {
           {
             rule: 'Rule 1: No console.log statements',
             reason: 'No console.log statements found',
-            confidence_score: 0.95,
+            confidenceScore: 0.95,
           },
         ],
         violations: [],
@@ -149,12 +149,12 @@ Rule 4: All functions must have JSDoc comments`,
           {
             rule: 'No Console Logs',
             reason: 'Console.log statements found in code',
-            confidence_score: 0.98,
-            violation_instances: [
+            confidenceScore: 0.98,
+            violationInstances: [
               {
-                line_numbers_in_diff: ['2'],
-                violating_code_snippet: 'console.log(x);',
-                explanation_of_violation: 'Direct console.log usage',
+                lineNumbersInDiff: ['2'],
+                violatingCodeSnippet: 'console.log(x);',
+                explanationOfViolation: 'Direct console.log usage',
               },
             ],
           },
@@ -211,7 +211,7 @@ Description: Avoid using 'any' type.`,
           {
             rule: 'No console.log statements',
             reason: 'Code follows proper logging practices',
-            confidence_score: 0.95,
+            confidenceScore: 0.95,
           },
         ],
         violations: [],
@@ -264,24 +264,24 @@ Description: Avoid using 'any' type.`,
           {
             rule: 'No console.log statements',
             reason: 'Console.log statements found in the code',
-            confidence_score: 0.98,
-            violation_instances: [
+            confidenceScore: 0.98,
+            violationInstances: [
               {
-                line_numbers_in_diff: ['5'],
-                violating_code_snippet: 'console.log("test");',
-                explanation_of_violation: 'Direct console.log usage',
+                lineNumbersInDiff: ['5'],
+                violatingCodeSnippet: 'console.log("test");',
+                explanationOfViolation: 'Direct console.log usage',
               },
             ],
           },
           {
             rule: 'Avoid using any type',
             reason: 'Any type usage reduces type safety',
-            confidence_score: 0.92,
-            violation_instances: [
+            confidenceScore: 0.92,
+            violationInstances: [
               {
-                line_numbers_in_diff: ['3'],
-                violating_code_snippet: 'private data: any = {};',
-                explanation_of_violation: 'Variable declared with any type',
+                lineNumbersInDiff: ['3'],
+                violatingCodeSnippet: 'private data: any = {};',
+                explanationOfViolation: 'Variable declared with any type',
               },
             ],
           },
@@ -354,12 +354,12 @@ Confidence Score: 0.92`,
           {
             rule: 'No magic numbers',
             reason: 'Magic numbers make code less maintainable',
-            confidence_score: 0.85,
-            violation_instances: [
+            confidenceScore: 0.85,
+            violationInstances: [
               {
-                line_numbers_in_diff: ['2'],
-                violating_code_snippet: 'const timeout = 5000;',
-                explanation_of_violation: 'Hardcoded timeout value',
+                lineNumbersInDiff: ['2'],
+                violatingCodeSnippet: 'const timeout = 5000;',
+                explanationOfViolation: 'Hardcoded timeout value',
               },
             ],
           },

--- a/src/tools/analyzeDiff/handler.ts
+++ b/src/tools/analyzeDiff/handler.ts
@@ -1,0 +1,31 @@
+import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { analyzeDiffInputSchema } from './inputSchema.js';
+
+/**
+ * Analyzes a git diff against cursor rules to identify rule violations
+ * @param args - Tool arguments containing diff content and rules
+ * @returns Analysis result with any rule violations found
+ */
+export const analyzeDiff: ToolCallback<{
+  params: typeof analyzeDiffInputSchema;
+}> = async (args) => {
+  const { diff, rules } = args.params;
+  if (rules) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Rules from ${rules}:\n${rules}\n\nDiff: ${diff}`,
+        },
+      ],
+    };
+  }
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `No rules found. Please add rules to your repository.`,
+      },
+    ],
+  };
+};

--- a/src/tools/analyzeDiff/handler.ts
+++ b/src/tools/analyzeDiff/handler.ts
@@ -46,7 +46,7 @@ export const analyzeDiff: ToolCallback<{
           type: 'text',
           text: response.relatedRules.violations
             .map((violation) => {
-              return `Rule: ${violation.rule}\nReason: ${violation.reason}\nConfidence Score: ${violation.confidence_score}`;
+              return `Rule: ${violation.rule}\nReason: ${violation.reason}\nConfidence Score: ${violation.confidenceScore}`;
             })
             .join('\n\n'),
         },

--- a/src/tools/analyzeDiff/inputSchema.ts
+++ b/src/tools/analyzeDiff/inputSchema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const analyzeDiffInputSchema = z.object({
+  diff: z
+    .string()
+    .describe(
+      'Git diff content to analyze. Default is staged change if user is not explicitly asking for unstaged changes or all changes.',
+    ),
+  rules: z
+    .string()
+    .describe(
+      'Rules to use for analysis. Rule from .cursorrules or rules in .cursor/rules directory. Combine all rules from multiple files by separating them with ---',
+    ),
+});

--- a/src/tools/analyzeDiff/tool.ts
+++ b/src/tools/analyzeDiff/tool.ts
@@ -1,0 +1,18 @@
+import { analyzeDiffInputSchema } from './inputSchema.js';
+
+export const analyzeDiffTool = {
+  name: 'analyze_diff' as const,
+  description: `
+  This tool is used to analyze a git diff (unstaged, staged, or all changes) against cursor rules to check for ruleviolations.
+  By default, the tool will use the staged changes if the user does not explicitly ask for unstaged changes or all changes.
+
+  Parameters:
+  - params: An object containing:
+    - diff: string - A git diff string.
+    - rules: string - Rules to use for analysis. Rule from .cursorrules or rules in .cursor/rules directory. Combine all rules from multiple files by separating them with ---
+
+  Returns:
+  - A list of violations found in the git diff.
+  `,
+  inputSchema: analyzeDiffInputSchema,
+};

--- a/src/tools/analyzeDiff/tool.ts
+++ b/src/tools/analyzeDiff/tool.ts
@@ -3,7 +3,7 @@ import { analyzeDiffInputSchema } from './inputSchema.js';
 export const analyzeDiffTool = {
   name: 'analyze_diff' as const,
   description: `
-  This tool is used to analyze a git diff (unstaged, staged, or all changes) against cursor rules to check for ruleviolations.
+  This tool is used to analyze a git diff (unstaged, staged, or all changes) against cursor rules to check for rule violations.
   By default, the tool will use the staged changes if the user does not explicitly ask for unstaged changes or all changes.
 
   Parameters:


### PR DESCRIPTION
Testing
===
- add unit test to the tool handler

Implementation & Technical Considerations
===
- add a new tool `analyze_diff` (a tool to analyze git diffs against cursor rules to identify rule violations)
- use dynamic discovery for the params to find git diffs and cursor rules instead of providing the rule path, rule directory from envs which requires reading files manually in the handler.
- use the rule_review logic from circlet endpoint

Screenshots/Videos
===