### PR TITLE
claude_desktop_config file routes for mac and windows added at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ Add the following to your claude_desktop_config.json:
 }
 ```
 To locate this file:
+
 macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
 Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
 [Claude Desktop setup](https://modelcontextprotocol.io/quickstart/user)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://github.com/user-attachments/assets/3c765985-8827-442a-a8dc-5069e01edb74
 
 ## Requirements
 
-- CircleCI API token - you can generate one through the CircleCI. [Learn more](https://circleci.com/docs/managing-api-tokens/) or [click here](https://app.circleci.com/settings/user/tokens) for quick access.
+- CircleCI Personal API Token - you can generate one through the CircleCI. [Learn more](https://circleci.com/docs/managing-api-tokens/) or [click here](https://app.circleci.com/settings/user/tokens) for quick access.
 
 For NPX installation:
 - pnpm package manager - [Learn more](https://pnpm.io/installation)

--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ Add the following to your claude_desktop_config.json:
   }
 }
 ```
+To locate this file:
+macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
+Windows: %APPDATA%\Claude\claude_desktop_config.json
+
+[Claude Desktop setup](https://modelcontextprotocol.io/quickstart/user)
 
 #### Using Docker
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ Add the following to your claude_desktop_config.json:
 }
 ```
 To locate this file:
-macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
-Windows: %APPDATA%\Claude\claude_desktop_config.json
+macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
 [Claude Desktop setup](https://modelcontextprotocol.io/quickstart/user)
 


### PR DESCRIPTION
As seen at https://circleci.com/blog/circleci-mcp-server/, I added the routes where to find the claude_desktop_config file