### PR TITLE
chore: `mkdir -p prompts && cd prompts` on unversioned config for eval pipelines

### DIFF
--- a/src/tools/runEvaluationTests/handler.ts
+++ b/src/tools/runEvaluationTests/handler.ts
@@ -154,6 +154,7 @@ export const runEvaluationTests: ToolCallback<{
     .map(
       (file, index) =>
         `          if [ "$CIRCLE_NODE_INDEX" = "${index}" ]; then
+            mkdir -p prompts && cd prompts
             echo "${file.base64GzippedContent}" | base64 -d | gzip -d > ${file.fileName}
           fi`,
     )


### PR DESCRIPTION
Was seeing this error on the new eval runner script.

https://app.circleci.com/pipelines/gh/jvincent42/dummy/70/workflows/ae7c7ca4-8ef0-4117-9b4a-ad110731e140/jobs/55

```
🏎️💨  Running evaluation for template: config-assistant.prompt.yml

Traceback (most recent call last):
  File "/home/circleci/project/eval.py", line 378, in <module>
    main()
  File "/home/circleci/project/eval.py", line 350, in main
    results = run_test(template_name, api_key)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/eval.py", line 89, in run_test
    prompt_data = load_prompt_template(template_name)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/eval.py", line 51, in load_prompt_template
    with open(file_path, 'r') as f:
         ^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/prompts/config-assistant.prompt.yml'

Exited with code exit status 1
```