### PR TITLE
feat: add `anthropic` dependency to `run_evaluation_tests` tool config

### DIFF
--- a/src/tools/runEvaluationTests/handler.ts
+++ b/src/tools/runEvaluationTests/handler.ts
@@ -181,9 +181,10 @@ jobs:
     steps:
       - run: |
           curl https://gist.githubusercontent.com/jvincent42/10bf3d2d2899033ae1530cf429ed03f8/raw/0d8419bd4b6bdeeb63e786e8e6db638a44ca91ce/eval.py > eval.py
-          echo "deepeval>=2.8.2
-          openai>=1.76.2
-          pyyaml>=6.0.2
+          echo "deepeval>=3.0.3
+          openai>=1.84.0
+          anthropic>=0.54.0
+          PyYAML>=6.0.2
           " > requirements.txt
           pip install -r requirements.txt
       - run: |

--- a/src/tools/shared/constants.ts
+++ b/src/tools/shared/constants.ts
@@ -12,7 +12,7 @@ export const workflowUrlDescription =
 
 // PROMPT TEMPLATE ITERATION & TESTING TOOL CONSTANTS
 // NOTE: We want to be extremely consistent with the tool names and parameters passed through the Prompt Workbench toolchain, since one tool's output may be used as input for another tool.
-export const defaultModel = 'gpt-4o-mini';
+export const defaultModel = 'gpt-4.1-mini';
 export const promptsOutputDirectory = './prompts';
 export const fileExtension = '.prompt.yml';
 export const fileNameTemplate = `<relevant-name>${fileExtension}`;


### PR DESCRIPTION
# Changes
- added `anthropic` dependency to `run_evaluation_tests` tool config
- set `defaultModel = 'gpt-4.1-mini'` based on [new Circlet default](https://github.com/circleci/prompt-template-workbench/pull/838)