### PR TITLE
Minor improvements for routes and API Token at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://github.com/user-attachments/assets/3c765985-8827-442a-a8dc-5069e01edb74
 
 ## Requirements
 
-- CircleCI API token - you can generate one through the CircleCI. [Learn more](https://circleci.com/docs/managing-api-tokens/) or [click here](https://app.circleci.com/settings/user/tokens) for quick access.
+- CircleCI Personal API Token - you can generate one through the CircleCI. [Learn more](https://circleci.com/docs/managing-api-tokens/) or [click here](https://app.circleci.com/settings/user/tokens) for quick access.
 
 For NPX installation:
 
@@ -48,6 +48,14 @@ Add the following to your cursor MCP config:
   }
 }
 ```
+To locate this file:
+
+macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+[Claude Desktop setup](https://modelcontextprotocol.io/quickstart/user)
+
 
 #### Using Docker
 


### PR DESCRIPTION
Merging 
https://github.com/CircleCI-Public/mcp-server-circleci/pull/79/
https://github.com/CircleCI-Public/mcp-server-circleci/pull/78
as one PR. Both were approved, the difference from this PR and the above is, this is not a form from original repo

### Changes:
- Renaming from CircleCi API Token to **CircleCi Personal Token**
At CircleCi Platform, you can find your API token named as Personal API Tokens in User settings > Personal API Tokens.
Small change to standardize naming conventions.

- Adding routes where to find claude_desktop_config file 
As seen at https://circleci.com/blog/circleci-mcp-server/