### PR TITLE
add file output mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2025-06-17
+
+### Added
+
+- Added `USE_FILE_OUTPUT` environment variable to `get_flaky_tests` tool
+  - When set to `true`, the tool will write flaky tests to files in the `./flaky-tests-output` directory instead of returning the results in the response
+  - The tool will return the file paths of the written files in the response
+
 ## [0.9.2] - 2025-06-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/tools/getFlakyTests/handler.test.ts
+++ b/src/tools/getFlakyTests/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getFlakyTestLogs } from './handler.js';
+import { getFlakyTestLogs, useFileOutputDirectory } from './handler.js';
 import * as projectDetection from '../../lib/project-detection/index.js';
 import * as getFlakyTestsModule from '../../lib/flaky-tests/getFlakyTests.js';
 import * as formatFlakyTestsModule from '../../lib/flaky-tests/getFlakyTests.js';
@@ -8,15 +8,32 @@ import * as formatFlakyTestsModule from '../../lib/flaky-tests/getFlakyTests.js'
 vi.mock('../../lib/project-detection/index.js');
 vi.mock('../../lib/flaky-tests/getFlakyTests.js');
 
+// Define mock functions using vi.hoisted() to make them available everywhere
+const { mockWriteFileSync, mockMkdirSync, mockJoin } = vi.hoisted(() => ({
+  mockWriteFileSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockJoin: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
+}));
+
+vi.mock('path', () => ({
+  join: mockJoin,
+}));
+
 describe('getFlakyTestLogs handler', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    delete process.env.USE_FILE_OUTPUT;
   });
 
   it('should return a valid MCP error response when no inputs are provided', async () => {
     const args = {
       params: {},
-    } as any;
+    };
 
     const controller = new AbortController();
     const response = await getFlakyTestLogs(args, {
@@ -40,7 +57,7 @@ describe('getFlakyTestLogs handler', () => {
         workspaceRoot: '/workspace',
         gitRemoteURL: 'https://github.com/org/repo.git',
       },
-    } as any;
+    };
 
     const controller = new AbortController();
     const response = await getFlakyTestLogs(args, {
@@ -55,18 +72,16 @@ describe('getFlakyTestLogs handler', () => {
   });
 
   it('should use projectSlug directly when provided', async () => {
-    const mockGetFlakyTests = vi
-      .spyOn(getFlakyTestsModule, 'default')
-      .mockResolvedValue([
-        {
-          name: 'flakyTest',
-          message: 'Test failure message',
-          run_time: '1.5',
-          result: 'failure',
-          classname: 'TestClass',
-          file: 'path/to/file.js',
-        },
-      ]);
+    vi.spyOn(getFlakyTestsModule, 'default').mockResolvedValue([
+      {
+        name: 'flakyTest',
+        message: 'Test failure message',
+        run_time: '1.5',
+        result: 'failure',
+        classname: 'TestClass',
+        file: 'path/to/file.js',
+      },
+    ]);
 
     vi.spyOn(formatFlakyTestsModule, 'formatFlakyTests').mockReturnValue({
       content: [
@@ -81,14 +96,14 @@ describe('getFlakyTestLogs handler', () => {
       params: {
         projectSlug: 'gh/org/repo',
       },
-    } as any;
+    };
 
     const controller = new AbortController();
     await getFlakyTestLogs(args, {
       signal: controller.signal,
     });
 
-    expect(mockGetFlakyTests).toHaveBeenCalledWith({
+    expect(getFlakyTestsModule.default).toHaveBeenCalledWith({
       projectSlug: 'gh/org/repo',
     });
     // Verify that no project detection methods were called
@@ -125,7 +140,7 @@ describe('getFlakyTestLogs handler', () => {
       params: {
         projectURL: 'https://app.circleci.com/pipelines/gh/org/repo',
       },
-    } as any;
+    };
 
     const controller = new AbortController();
     const response = await getFlakyTestLogs(args, {
@@ -136,5 +151,78 @@ describe('getFlakyTestLogs handler', () => {
     expect(Array.isArray(response.content)).toBe(true);
     expect(response.content[0]).toHaveProperty('type', 'text');
     expect(typeof response.content[0].text).toBe('string');
+  });
+
+  it('should write flaky tests to files when USE_FILE_OUTPUT is true', async () => {
+    process.env.USE_FILE_OUTPUT = 'true';
+
+    // Mock path.join to return predictable file paths for cross-platform test consistency
+    // This ensures the same path format regardless of OS (Windows uses \, Unix uses /)
+    mockJoin.mockImplementation((dir, filename) => `${dir}/${filename}`);
+
+    vi.spyOn(getFlakyTestsModule, 'default').mockResolvedValue([
+      {
+        name: 'flakyTest',
+        message: 'Test failure message',
+        run_time: '1.5',
+        result: 'failure',
+        classname: 'TestClass',
+        file: 'path/to/file.js',
+      },
+      {
+        name: 'anotherFlakyTest',
+        message: 'Another test failure',
+        run_time: '2.1',
+        result: 'failure',
+        classname: 'AnotherClass',
+        file: 'path/to/another.js',
+      },
+    ]);
+
+    const args = {
+      params: {
+        projectSlug: 'gh/org/repo',
+      },
+    };
+
+    const controller = new AbortController();
+    const response = await getFlakyTestLogs(args, {
+      signal: controller.signal,
+    });
+
+    expect(mockMkdirSync).toHaveBeenCalledWith(useFileOutputDirectory, {
+      recursive: true,
+    });
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(2);
+
+    expect(response).toHaveProperty('content');
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(response.content[0].text).toContain(
+      'Successfully wrote 2 flaky tests',
+    );
+    expect(response.content[0].text).toContain(useFileOutputDirectory);
+  });
+
+  it('should handle no flaky tests found in file output mode', async () => {
+    process.env.USE_FILE_OUTPUT = 'true';
+
+    vi.spyOn(getFlakyTestsModule, 'default').mockResolvedValue([]);
+
+    const args = {
+      params: {
+        projectSlug: 'gh/org/repo',
+      },
+    };
+
+    const controller = new AbortController();
+    const response = await getFlakyTestLogs(args, {
+      signal: controller.signal,
+    });
+
+    expect(response).toHaveProperty('content');
+    expect(response.content[0].text).toBe(
+      'No flaky tests found - no files created',
+    );
   });
 });

--- a/src/tools/getFlakyTests/handler.test.ts
+++ b/src/tools/getFlakyTests/handler.test.ts
@@ -199,7 +199,7 @@ describe('getFlakyTestLogs handler', () => {
     expect(Array.isArray(response.content)).toBe(true);
     expect(response.content[0]).toHaveProperty('type', 'text');
     expect(response.content[0].text).toContain(
-      'Successfully wrote 2 flaky tests',
+      'Found 2 flaky tests that need stabilization',
     );
     expect(response.content[0].text).toContain(useFileOutputDirectory);
   });

--- a/src/tools/getFlakyTests/handler.ts
+++ b/src/tools/getFlakyTests/handler.ts
@@ -8,6 +8,11 @@ import getFlakyTests, {
   formatFlakyTests,
 } from '../../lib/flaky-tests/getFlakyTests.js';
 import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+import { Test } from '../../clients/schemas.js';
+
+export const useFileOutputDirectory = './flaky-tests-output';
 
 export const getFlakyTestLogs: ToolCallback<{
   params: typeof getFlakyTestLogsInputSchema;
@@ -48,5 +53,118 @@ export const getFlakyTestLogs: ToolCallback<{
     projectSlug,
   });
 
+  if (process.env.USE_FILE_OUTPUT === 'true') {
+    return await writeTestsToFiles({ tests });
+  }
+
   return formatFlakyTests(tests);
+};
+
+const generateSafeFilename = ({
+  test,
+  index,
+}: {
+  test: Test;
+  index: number;
+}): string => {
+  const safeTestName = (test.name || 'unnamed-test')
+    .replace(/[^a-zA-Z0-9\-_]/g, '_')
+    .substring(0, 50); // Limit length
+
+  return `flaky-test-${index + 1}-${safeTestName}.txt`;
+};
+
+/**
+ * Write test data to a file
+ */
+const writeTestToFile = ({
+  test,
+  filePath,
+  index,
+}: {
+  test: Test;
+  filePath: string;
+  index: number;
+}): void => {
+  const testContent = [
+    `Flaky Test #${index + 1}`,
+    '='.repeat(50),
+    test.file && `File Name: ${test.file}`,
+    test.classname && `Classname: ${test.classname}`,
+    test.name && `Test name: ${test.name}`,
+    test.result && `Result: ${test.result}`,
+    test.run_time && `Run time: ${test.run_time}`,
+    test.message && `Message: ${test.message}`,
+    '',
+    'Raw Test Data:',
+    '-'.repeat(20),
+    JSON.stringify(test, null, 2),
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  writeFileSync(filePath, testContent, 'utf8');
+};
+
+/**
+ * Write flaky tests to individual files
+ * @param params Configuration parameters
+ * @param params.tests Array of test objects to write to files
+ * @returns Response object with success message or error
+ */
+const writeTestsToFiles = async ({
+  tests,
+}: {
+  tests: Test[];
+}): Promise<{
+  content: {
+    type: 'text';
+    text: string;
+  }[];
+}> => {
+  if (tests.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: 'No flaky tests found - no files created',
+        },
+      ],
+    };
+  }
+
+  try {
+    // Create directory recursively
+    const { mkdirSync } = await import('fs');
+    mkdirSync(useFileOutputDirectory, { recursive: true });
+  } catch (error) {
+    return mcpErrorOutput(
+      `Failed to create output directory: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const filePaths: string[] = [];
+
+  try {
+    tests.forEach((test, index) => {
+      const filename = generateSafeFilename({ test, index });
+      const filePath = join(useFileOutputDirectory, filename);
+
+      writeTestToFile({ test, filePath, index });
+      filePaths.push(filePath);
+    });
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Successfully wrote ${tests.length} flaky tests to individual files:\n\n${filePaths.map((path) => `- ${path}`).join('\n')}\n\nFiles are located in: ${useFileOutputDirectory}`,
+        },
+      ],
+    };
+  } catch (error) {
+    return mcpErrorOutput(
+      `Failed to write flaky test files: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 };

--- a/src/tools/getFlakyTests/handler.ts
+++ b/src/tools/getFlakyTests/handler.ts
@@ -163,7 +163,7 @@ const writeTestsToFiles = async ({
       content: [
         {
           type: 'text' as const,
-          text: `Found ${tests.length} flaky tests that need stabilization. Review each file to identify failure patterns and root causes, then fix the underlying issues.\n\nFocus on:\n- Timing issues (race conditions, insufficient waits)\n- Environment dependencies (network, external services)\n- Test isolation problems (shared state, cleanup issues)\n- Non-deterministic assertions\n\nTest files:\n${filePaths.map((path) => `- ${path}`).join('\n')}\n\nFiles are located in: ${useFileOutputDirectory}`,
+          text: `Found ${tests.length} flaky tests that need stabilization. Each file contains test failure data and metadata - analyze these reports to understand what's causing the flakiness, then locate and fix the actual test code.\n\nFocus on identifying:\n- Timing issues (race conditions, insufficient waits)\n- Environment dependencies (network, external services)\n- Test isolation problems (shared state, cleanup issues)\n- Non-deterministic assertions\n\nFlaky test reports:\n${filePaths.map((path) => `- ${path}`).join('\n')}\n\nFiles are located in: ${useFileOutputDirectory}`,
         },
       ],
     };

--- a/src/tools/getFlakyTests/handler.ts
+++ b/src/tools/getFlakyTests/handler.ts
@@ -54,7 +54,12 @@ export const getFlakyTestLogs: ToolCallback<{
   });
 
   if (process.env.USE_FILE_OUTPUT === 'true') {
-    return await writeTestsToFiles({ tests });
+    try {
+      return await writeTestsToFiles({ tests });
+    } catch (error) {
+      console.error(error);
+      return formatFlakyTests(tests);
+    }
   }
 
   return formatFlakyTests(tests);
@@ -158,7 +163,7 @@ const writeTestsToFiles = async ({
       content: [
         {
           type: 'text' as const,
-          text: `Successfully wrote ${tests.length} flaky tests to individual files:\n\n${filePaths.map((path) => `- ${path}`).join('\n')}\n\nFiles are located in: ${useFileOutputDirectory}`,
+          text: `Found ${tests.length} flaky tests that need stabilization. Review each file to identify failure patterns and root causes, then fix the underlying issues.\n\nFocus on:\n- Timing issues (race conditions, insufficient waits)\n- Environment dependencies (network, external services)\n- Test isolation problems (shared state, cleanup issues)\n- Non-deterministic assertions\n\nTest files:\n${filePaths.map((path) => `- ${path}`).join('\n')}\n\nFiles are located in: ${useFileOutputDirectory}`,
         },
       ],
     };


### PR DESCRIPTION
ticket: https://circleci.atlassian.net/browse/AITEAM-658

when `process.env.USE_FILE_OUTPUT === 'true'` the flaky tests tool will output files in the current directory. this is friendlier for claude code to parse large outputs.

here is an example of one of the files that is output:

```
Flaky Test #1
==================================================
Classname: pipelines/trigger.spec.ts
Test name: Trigger a Pipeline › pipeline exists
Result: failure
Run time: 60.613
Message: trigger.spec.ts:7:7 pipeline exists
[chromium] › pipelines/trigger.spec.ts:7:7 › Trigger a Pipeline › pipeline exists ────────────────

    Test timeout of 30000ms exceeded.

    Error: locator.click: Test timeout of 30000ms exceeded.
    Call log:
      - waiting for getByRole('combobox', { name: 'Selected branch' }).first()
        - locator resolved to <input value="" title="" disabled type="text" data-rac="" role="combobox" autocorrect="off" autocomplete="off" spellcheck="false" class="css-no1n62" data-hovered="true" data-disabled="true" aria-expanded="false" aria-autocomplete="list" aria-label="Selected branch" id="react-aria1187167253-:rit:"/>
      - attempting click action
        2 × waiting for element to be visible, enabled and stable
          - element is not enabled
        - retrying click action
        - waiting 20ms
        2 × waiting for element to be visible, enabled and stable
          - element is not enabled
        - retrying click action
          - waiting 100ms
        40 × waiting for element to be visible, enabled and stable
           - element is not enabled
         - retrying click action
           - waiting 500ms


      28 |       .getByRole('combobox', { name: 'Selected branch' })
      29 |       .first()
    > 30 |       .click();
         |        ^
      31 |     await page.getByLabel('main-branch-name-option').click();
      32 |     await page.getByLabel('Selected branch', { exact: true }).click();
      33 |     await page.getByLabel('main-branch-name-option').first().click();
        at /mnt/ramdisk/web-ui/test/e2e/tests/pipelines/trigger.spec.ts:30:8

    Error Context: ../test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium/error-context.md

    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
    test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium/trace.zip
    Usage:

        npx playwright show-trace test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium/trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────

    Retry #1 ───────────────────────────────────────────────────────────────────────────────────────

    Test timeout of 30000ms exceeded.

    Error: locator.click: Test timeout of 30000ms exceeded.
    Call log:
      - waiting for getByRole('combobox', { name: 'Selected branch' }).first()
        - locator resolved to <input value="" title="" disabled type="text" data-rac="" role="combobox" autocorrect="off" autocomplete="off" spellcheck="false" class="css-no1n62" data-hovered="true" data-disabled="true" aria-expanded="false" aria-autocomplete="list" aria-label="Selected branch" id="react-aria6625091898-:rit:"/>
      - attempting click action
        2 × waiting for element to be visible, enabled and stable
          - element is not enabled
        - retrying click action
        - waiting 20ms
        2 × waiting for element to be visible, enabled and stable
          - element is not enabled
        - retrying click action
          - waiting 100ms
        41 × waiting for element to be visible, enabled and stable
           - element is not enabled
         - retrying click action
           - waiting 500ms


      28 |       .getByRole('combobox', { name: 'Selected branch' })
      29 |       .first()
    > 30 |       .click();
         |        ^
      31 |     await page.getByLabel('main-branch-name-option').click();
      32 |     await page.getByLabel('Selected branch', { exact: true }).click();
      33 |     await page.getByLabel('main-branch-name-option').first().click();
        at /mnt/ramdisk/web-ui/test/e2e/tests/pipelines/trigger.spec.ts:30:8

    Error Context: ../test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium-retry1/error-context.md

    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────
    test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium-retry1/trace.zip
    Usage:

        npx playwright show-trace test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium-retry1/trace.zip

    ────────────────────────────────────────────────────────────────────────────────────────────────[[ATTACHMENT|../pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium/error-context.md]]

[[ATTACHMENT|../pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium/trace.zip]]

[[ATTACHMENT|../pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium-retry1/error-context.md]]

[[ATTACHMENT|../pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium-retry1/trace.zip]]
Raw Test Data:
--------------------
{
  "message": "trigger.spec.ts:7:7 pipeline exists\n[chromium] › pipelines/trigger.spec.ts:7:7 › Trigger a Pipeline › pipeline exists ────────────────\n\n    Test timeout of 30000ms exceeded.\n\n    Error: locator.click: Test timeout of 30000ms exceeded.\n    Call log:\n      - waiting for getByRole('combobox', { name: 'Selected branch' }).first()\n        - locator resolved to <input value=\"\" title=\"\" disabled type=\"text\" data-rac=\"\" role=\"combobox\" autocorrect=\"off\" autocomplete=\"off\" spellcheck=\"false\" class=\"css-no1n62\" data-hovered=\"true\" data-disabled=\"true\" aria-expanded=\"false\" aria-autocomplete=\"list\" aria-label=\"Selected branch\" id=\"react-aria1187167253-:rit:\"/>\n      - attempting click action\n        2 × waiting for element to be visible, enabled and stable\n          - element is not enabled\n        - retrying click action\n        - waiting 20ms\n        2 × waiting for element to be visible, enabled and stable\n          - element is not enabled\n        - retrying click action\n          - waiting 100ms\n        40 × waiting for element to be visible, enabled and stable\n           - element is not enabled\n         - retrying click action\n           - waiting 500ms\n\n\n      28 |       .getByRole('combobox', { name: 'Selected branch' })\n      29 |       .first()\n    > 30 |       .click();\n         |        ^\n      31 |     await page.getByLabel('main-branch-name-option').click();\n      32 |     await page.getByLabel('Selected branch', { exact: true }).click();\n      33 |     await page.getByLabel('main-branch-name-option').first().click();\n        at /mnt/ramdisk/web-ui/test/e2e/tests/pipelines/trigger.spec.ts:30:8\n\n    Error Context: ../test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium/error-context.md\n\n    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────\n    test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium/trace.zip\n    Usage:\n\n        npx playwright show-trace test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium/trace.zip\n\n    ────────────────────────────────────────────────────────────────────────────────────────────────\n\n    Retry #1 ───────────────────────────────────────────────────────────────────────────────────────\n\n    Test timeout of 30000ms exceeded.\n\n    Error: locator.click: Test timeout of 30000ms exceeded.\n    Call log:\n      - waiting for getByRole('combobox', { name: 'Selected branch' }).first()\n        - locator resolved to <input value=\"\" title=\"\" disabled type=\"text\" data-rac=\"\" role=\"combobox\" autocorrect=\"off\" autocomplete=\"off\" spellcheck=\"false\" class=\"css-no1n62\" data-hovered=\"true\" data-disabled=\"true\" aria-expanded=\"false\" aria-autocomplete=\"list\" aria-label=\"Selected branch\" id=\"react-aria6625091898-:rit:\"/>\n      - attempting click action\n        2 × waiting for element to be visible, enabled and stable\n          - element is not enabled\n        - retrying click action\n        - waiting 20ms\n        2 × waiting for element to be visible, enabled and stable\n          - element is not enabled\n        - retrying click action\n          - waiting 100ms\n        41 × waiting for element to be visible, enabled and stable\n           - element is not enabled\n         - retrying click action\n           - waiting 500ms\n\n\n      28 |       .getByRole('combobox', { name: 'Selected branch' })\n      29 |       .first()\n    > 30 |       .click();\n         |        ^\n      31 |     await page.getByLabel('main-branch-name-option').click();\n      32 |     await page.getByLabel('Selected branch', { exact: true }).click();\n      33 |     await page.getByLabel('main-branch-name-option').first().click();\n        at /mnt/ramdisk/web-ui/test/e2e/tests/pipelines/trigger.spec.ts:30:8\n\n    Error Context: ../test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium-retry1/error-context.md\n\n    attachment #2: trace (application/zip) ─────────────────────────────────────────────────────────\n    test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium-retry1/trace.zip\n    Usage:\n\n        npx playwright show-trace test-results/pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium-retry1/trace.zip\n\n    ────────────────────────────────────────────────────────────────────────────────────────────────[[ATTACHMENT|../pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium/error-context.md]]\n\n[[ATTACHMENT|../pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium/trace.zip]]\n\n[[ATTACHMENT|../pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium-retry1/error-context.md]]\n\n[[ATTACHMENT|../pipelines-trigger-Trigger-a-Pipeline-pipeline-exists-chromium-retry1/trace.zip]]",
  "run_time": 60.613,
  "result": "failure",
  "name": "Trigger a Pipeline › pipeline exists",
  "classname": "pipelines/trigger.spec.ts"
}
```

Here is the tool output when this mode is used:

```
Found 50 flaky tests that need stabilization. Each file contains test failure data and metadata - analyze these reports to understand what's causing the flakiness, then locate and fix the actual test code.

Focus on identifying:
- Timing issues (race conditions, insufficient waits)
- Environment dependencies (network, external services)
- Test isolation problems (shared state, cleanup issues)
- Non-deterministic assertions

Flaky test reports:
- flaky-tests-output/flaky-test-1-Trigger_a_Pipeline___pipeline_exists.txt
- flaky-tests-output/flaky-test-2-edit_custom_webhook___should_show_error_if_config_.txt
- flaky-tests-output/flaky-test-3-create_custom_webhook___should_create_webhook.txt
- flaky-tests-output/flaky-test-4-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-5-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-6-should_expand_the_GitHub_App_trigger_and_show_corr.txt
- flaky-tests-output/flaky-test-7-Custom_Webhooks___verify_updates.txt
- flaky-tests-output/flaky-test-8-Trigger_a_Pipeline___pipeline_exists.txt
- flaky-tests-output/flaky-test-9-edit_custom_webhook___should_show_error_if_config_.txt
- flaky-tests-output/flaky-test-10-create_custom_webhook___should_create_webhook.txt
- flaky-tests-output/flaky-test-11-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-12-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-13-Check_if_we_need_to_re-authorize___re-auth_check.txt
- flaky-tests-output/flaky-test-14-Trigger_a_Pipeline___pipeline_exists.txt
- flaky-tests-output/flaky-test-15-edit_custom_webhook___should_show_error_if_config_.txt
- flaky-tests-output/flaky-test-16-create_custom_webhook___should_create_webhook.txt
- flaky-tests-output/flaky-test-17-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-18-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-19-helm_basic_restore_version_actions___restore_shoul.txt
- flaky-tests-output/flaky-test-20-should_expand_the_GitHub_App_trigger_and_show_corr.txt
- flaky-tests-output/flaky-test-21-should_edit_trigger_event_type_and_save_changes.txt
- flaky-tests-output/flaky-test-22-Trigger_a_Pipeline___pipeline_exists.txt
- flaky-tests-output/flaky-test-23-edit_custom_webhook___should_show_error_if_config_.txt
- flaky-tests-output/flaky-test-24-create_custom_webhook___should_create_webhook.txt
- flaky-tests-output/flaky-test-25-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-26-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-27-Trigger_a_Pipeline___pipeline_exists.txt
- flaky-tests-output/flaky-test-28-edit_custom_webhook___should_show_error_if_config_.txt
- flaky-tests-output/flaky-test-29-create_custom_webhook___should_create_webhook.txt
- flaky-tests-output/flaky-test-30-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-31-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-32-helm_basic_restore_version_actions___basic_restore.txt
- flaky-tests-output/flaky-test-33-Project_Deletion___delete_button_is_hidden_when_no.txt
- flaky-tests-output/flaky-test-34-Custom_Webhooks___verify_updates.txt
- flaky-tests-output/flaky-test-35-Project_Deletion___delete_button_is_hidden_when_no.txt
- flaky-tests-output/flaky-test-36-useLoadTimeAnalytics_when_first_called_when_loadin.txt
- flaky-tests-output/flaky-test-37-Contexts_Lifecycle___deletes_the_added_context.txt
- flaky-tests-output/flaky-test-38-Groups_lifecycle___delete_a_group.txt
- flaky-tests-output/flaky-test-39-helm_basic_restore_version_actions___basic_restore.txt
- flaky-tests-output/flaky-test-40-Project_Following___updates_UI_elements_on_follow_.txt
- flaky-tests-output/flaky-test-41-Classic_Project_Setup___Allows_users_to_start_buil.txt
- flaky-tests-output/flaky-test-42-Contexts_Lifecycle___navigate_to_the_added_context.txt
- flaky-tests-output/flaky-test-43-Custom_Webhooks___delete_a_trigger.txt
- flaky-tests-output/flaky-test-44-edit_custom_webhook___With_query_params___should_c.txt
- flaky-tests-output/flaky-test-45-edit_custom_webhook___With_query_params___should_c.txt
- flaky-tests-output/flaky-test-46-create_custom_webhook___should_create_webhook.txt
- flaky-tests-output/flaky-test-47-Project_setup_page_is_accessible___pipeline_defini.txt
- flaky-tests-output/flaky-test-48-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-49-useLoadTimeAnalytics_when_first_called_when_loadin.txt
- flaky-tests-output/flaky-test-50-Workflow_Graph___DAG_loads_successfully.txt

Files are located in: ./flaky-tests-output
```