### PR TITLE
feat: add filterBy and speedMode params to analyzeDiff tool

### DIFF
--- a/src/clients/circlet/circlet.ts
+++ b/src/clients/circlet/circlet.ts
@@ -1,7 +1,7 @@
 import { HTTPClient } from '../circleci/httpClient.js';
 import { PromptObject, RuleReview } from '../schemas.js';
 import { z } from 'zod';
-import { PromptOrigin } from '../../tools/shared/constants.js';
+import { PromptOrigin, FilterBy } from '../../tools/shared/constants.js';
 
 export const WorkbenchResponseSchema = z
   .object({
@@ -74,13 +74,19 @@ export class CircletAPI {
   async ruleReview({
     diff,
     rules,
+    speedMode,
+    filterBy,
   }: {
     diff: string;
     rules: string;
+    speedMode: boolean;
+    filterBy: FilterBy;
   }): Promise<RuleReview> {
     const rawResult = await this.client.post<unknown>('/rule-review', {
       changeSet: diff,
       rules,
+      speedMode,
+      filterBy,
     });
     const parsedResult = RuleReview.safeParse(rawResult);
     if (!parsedResult.success) {

--- a/src/clients/schemas.ts
+++ b/src/clients/schemas.ts
@@ -66,7 +66,7 @@ const RuleReviewSchema = z.object({
       }),
     ),
   }),
-  unrelatedRules: z.array(z.string()),
+  unrelatedRules: z.array(z.string()).optional(),
 });
 
 const FollowedProjectSchema = z.object({

--- a/src/tools/analyzeDiff/handler.test.ts
+++ b/src/tools/analyzeDiff/handler.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FilterBy } from '../shared/constants.js';
 import { analyzeDiff } from './handler.js';
+import { analyzeDiffInputSchema } from './inputSchema.js';
 import { CircletClient } from '../../clients/circlet/index.js';
 import { RuleReview } from '../../clients/schemas.js';
 
@@ -24,6 +26,8 @@ describe('analyzeDiff', () => {
 
     const mockArgs = {
       params: {
+        speedMode: false,
+        filterBy: FilterBy.none,
         diff: 'diff --git a/test.ts b/test.ts\n+console.log("test");',
         rules: '',
       },
@@ -55,6 +59,8 @@ describe('analyzeDiff', () => {
 
     const mockArgs = {
       params: {
+        speedMode: false,
+        filterBy: FilterBy.none,
         diff: '',
         rules: '',
       },
@@ -102,6 +108,8 @@ describe('analyzeDiff', () => {
 
     const mockArgs = {
       params: {
+        speedMode: false,
+        filterBy: FilterBy.none,
         diff: `diff --git a/src/component.ts b/src/component.ts
 index 1234567..abcdefg 100644
 --- a/src/component.ts
@@ -126,6 +134,8 @@ Rule 4: All functions must have JSDoc comments`,
     const result = await analyzeDiff(mockArgs, { signal: controller.signal });
 
     expect(mockCircletInstance.circlet.ruleReview).toHaveBeenCalledWith({
+      speedMode: false,
+      filterBy: FilterBy.none,
       diff: mockArgs.params.diff,
       rules: mockArgs.params.rules,
     });
@@ -176,6 +186,8 @@ Rule 4: All functions must have JSDoc comments`,
 
     const mockArgs = {
       params: {
+        speedMode: false,
+        filterBy: FilterBy.none,
         diff: '+const x = 5;\n+console.log(x);',
         rules: `# Cursor Rules Example
 
@@ -191,6 +203,8 @@ Description: Avoid using 'any' type.`,
     const result = await analyzeDiff(mockArgs, { signal: controller.signal });
 
     expect(mockCircletInstance.circlet.ruleReview).toHaveBeenCalledWith({
+      speedMode: false,
+      filterBy: FilterBy.none,
       diff: mockArgs.params.diff,
       rules: mockArgs.params.rules,
     });
@@ -232,6 +246,8 @@ Description: Avoid using 'any' type.`,
 
     const mockArgs = {
       params: {
+        speedMode: false,
+        filterBy: FilterBy.none,
         diff: 'diff --git a/test.ts b/test.ts\n+const logger = new Logger();',
         rules: 'Rule 1: No console.log statements\nRule 2: Use proper logging',
       },
@@ -241,6 +257,8 @@ Description: Avoid using 'any' type.`,
     const result = await analyzeDiff(mockArgs, { signal: controller.signal });
 
     expect(mockCircletInstance.circlet.ruleReview).toHaveBeenCalledWith({
+      speedMode: false,
+      filterBy: FilterBy.none,
       diff: mockArgs.params.diff,
       rules: mockArgs.params.rules,
     });
@@ -303,6 +321,8 @@ Description: Avoid using 'any' type.`,
 
     const mockArgs = {
       params: {
+        speedMode: false,
+        filterBy: FilterBy.none,
         diff: `diff --git a/src/component.ts b/src/component.ts
 index 1234567..abcdefg 100644
 --- a/src/component.ts
@@ -325,6 +345,8 @@ Rule 3: Use proper TypeScript types`,
     const result = await analyzeDiff(mockArgs, { signal: controller.signal });
 
     expect(mockCircletInstance.circlet.ruleReview).toHaveBeenCalledWith({
+      filterBy: FilterBy.none,
+      speedMode: false,
       diff: mockArgs.params.diff,
       rules: mockArgs.params.rules,
     });
@@ -381,6 +403,8 @@ Confidence Score: 0.92`,
 
     const mockArgs = {
       params: {
+        speedMode: false,
+        filterBy: FilterBy.none,
         diff: '+const timeout = 5000;',
         rules: 'Rule: No magic numbers',
       },
@@ -398,6 +422,49 @@ Reason: Magic numbers make code less maintainable
 Confidence Score: 0.85`,
         },
       ],
+    });
+  });
+
+  it('should set default values for speedMode and filterBy when not provided', async () => {
+    const mockRuleReview: RuleReview = {
+      isRuleCompliant: true,
+      relatedRules: {
+        compliant: [],
+        violations: [],
+        requiresHumanReview: [],
+      },
+      unrelatedRules: [],
+    };
+
+    const mockCircletInstance = {
+      circlet: {
+        ruleReview: vi.fn().mockResolvedValue(mockRuleReview),
+      },
+    };
+
+    vi.mocked(CircletClient).mockImplementation(
+      () => mockCircletInstance as any,
+    );
+
+    const rawParams = {
+      diff: '+const timeout = 5000;',
+      rules: 'Rule: No magic numbers',
+    };
+
+    const parsedParams = analyzeDiffInputSchema.parse(rawParams);
+    const mockArgs = {
+      params: parsedParams,
+    };
+
+    const controller = new AbortController();
+    await analyzeDiff(mockArgs, { signal: controller.signal });
+
+    // Verify default values (filterBy: FilterBy.none & speedMode: false) are applied when not explictly stated
+    expect(mockCircletInstance.circlet.ruleReview).toHaveBeenCalledWith({
+      diff: rawParams.diff,
+      rules: rawParams.rules,
+      filterBy: FilterBy.none,
+      speedMode: false,
     });
   });
 });

--- a/src/tools/analyzeDiff/handler.ts
+++ b/src/tools/analyzeDiff/handler.ts
@@ -10,7 +10,7 @@ import { CircletClient } from '../../clients/circlet/index.js';
 export const analyzeDiff: ToolCallback<{
   params: typeof analyzeDiffInputSchema;
 }> = async (args) => {
-  const { diff, rules } = args.params;
+  const { diff, rules, speedMode, filterBy } = args.params;
   const circlet = new CircletClient();
   if (!diff) {
     return {
@@ -37,6 +37,8 @@ export const analyzeDiff: ToolCallback<{
   const response = await circlet.circlet.ruleReview({
     diff,
     rules,
+    filterBy,
+    speedMode,
   });
 
   if (!response.isRuleCompliant) {

--- a/src/tools/analyzeDiff/inputSchema.ts
+++ b/src/tools/analyzeDiff/inputSchema.ts
@@ -1,14 +1,23 @@
 import { z } from 'zod';
+import { FilterBy } from '../shared/constants.js';
 
 export const analyzeDiffInputSchema = z.object({
+  speedMode: z
+    .boolean()
+    .default(false)
+    .describe('The status of speed mode. Defaults to false.'),
+  filterBy: z
+    .nativeEnum(FilterBy)
+    .default(FilterBy.none)
+    .describe(`Analysis filter. Defaults to ${FilterBy.none}`),
   diff: z
     .string()
     .describe(
-      'Git diff content to analyze. Default is staged change if user is not explicitly asking for unstaged changes or all changes.',
+      'Git diff content to analyze. Defaults to staged changes, unless the user explicitly asks for unstaged changes or all changes.',
     ),
   rules: z
     .string()
     .describe(
-      'Rules to use for analysis. Rule from .cursorrules or rules in .cursor/rules directory. Combine all rules from multiple files by separating them with ---',
+      'Rules to use for analysis, found in .cursorrules or the .cursor/rules directory. Combine all rules from multiple files by separating them with ---',
     ),
 });

--- a/src/tools/analyzeDiff/tool.ts
+++ b/src/tools/analyzeDiff/tool.ts
@@ -1,18 +1,21 @@
+import { FilterBy } from '../shared/constants.js';
 import { analyzeDiffInputSchema } from './inputSchema.js';
 
 export const analyzeDiffTool = {
   name: 'analyze_diff' as const,
   description: `
-  This tool is used to analyze a git diff (unstaged, staged, or all changes) against cursor rules to check for rule violations.
-  By default, the tool will use the staged changes if the user does not explicitly ask for unstaged changes or all changes.
+  This tool is used to analyze a git diff (unstaged, staged, or all changes) against cursor rules to identify rule violations.
+  By default, the tool will use the staged changes, unless the user explicitly asks for unstaged or all changes.
 
   Parameters:
   - params: An object containing:
+    - speedMode: boolean - A mode that can be enabled to speed up the analysis. Default value is false.
+    - filterBy: enum - "${FilterBy.violations}" | "${FilterBy.compliants}" | "${FilterBy.humanReviewRequired}" | "${FilterBy.none}" - A filter that can be applied to set the focus of the analysis. Default is ${FilterBy.none}.
     - diff: string - A git diff string.
-    - rules: string - Rules to use for analysis. Rule from .cursorrules or rules in .cursor/rules directory. Combine all rules from multiple files by separating them with ---
+    - rules: string - The rules to use for the analysis, found in .cursorrules or the .cursor/rules directory. Combine all rules from multiple files by separating them with ---
 
   Returns:
-  - A list of violations found in the git diff.
+  - A list of rule violations found in the git diff.
   `,
   inputSchema: analyzeDiffInputSchema,
 };

--- a/src/tools/shared/constants.ts
+++ b/src/tools/shared/constants.ts
@@ -31,3 +31,11 @@ export enum PromptOrigin {
   codebase = 'codebase', // pre-existing prompts in user's codebase
   requirements = 'requirements', // new feature requirements provided by user
 }
+
+// ANALYZE DIFF TOOL CONSTANTS
+export enum FilterBy {
+  violations = 'Violations',
+  compliants = 'Compliants',
+  humanReviewRequired = 'Human Review Required',
+  none = 'None',
+}


### PR DESCRIPTION

**Changes**: All changes are specific to the `analyzeDiff` tool

- **Input schema**: add `speedMode` and `filterBy` params
- **Client schema**: allow `unrelatedRules` array to be optional
- **Tests**: tweak existing tests to account for new params
- **Copy**: various copy adjustments to improve clarity

---

**Related PR**: https://github.com/circleci/prompt-template-workbench/pull/894

