### PR TITLE
chore: update changelog and bump version to 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2025-06-18
+
+### Added
+
+- Add `speedMode` and `filterBy` parameters to the `analyze_diff` tool
+
 ## [0.10.1] - 2025-06-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",


### PR DESCRIPTION
**Changes:**
- Change log 
- Version bump

This is a retroactive change following the changes implemented [here](https://github.com/CircleCI-Public/mcp-server-circleci/pull/89)