### PR TITLE
try to only return the relevant tests, throw an error if we cannot create the folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2025-06-18
+
+### Fixed
+
+- Fixed bug in `get_flaky_tests` tool where unrelated tests were being returned
+- Fixed bug in `get_flaky_tests` tool where if the output directory cannot be created the tool would respond with an error. We now throw in that case, which makes us fallback to the text output.
+
 ## [0.11.0] - 2025-06-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -378,6 +378,12 @@ npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claud
        - Git remote URL
      - Example: "Find flaky tests in my current project"
 
+  The tool can be used in two ways:
+  1. Using text output mode (default):
+     - This will return the flaky tests and their details in a text format
+  2. Using file output mode: (requires the `FILE_OUTPUT_DIRECTORY` environment variable to be set)
+     - This will create a directory with the flaky tests and their details
+
   The tool returns detailed information about flaky tests, including:
 
   - Test names and file locations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/clients/schemas.ts
+++ b/src/clients/schemas.ts
@@ -124,6 +124,7 @@ const FlakyTestSchema = z.object({
   flaky_tests: z.array(
     z.object({
       job_number: z.number(),
+      classname: z.string(),
     }),
   ),
   total_flaky_tests: z.number(),

--- a/src/clients/schemas.ts
+++ b/src/clients/schemas.ts
@@ -124,7 +124,7 @@ const FlakyTestSchema = z.object({
   flaky_tests: z.array(
     z.object({
       job_number: z.number(),
-      classname: z.string(),
+      test_name: z.string(),
     }),
   ),
   total_flaky_tests: z.number(),

--- a/src/lib/flaky-tests/getFlakyTests.ts
+++ b/src/lib/flaky-tests/getFlakyTests.ts
@@ -13,32 +13,46 @@ const getFlakyTests = async ({ projectSlug }: { projectSlug: string }) => {
     throw new Error('Flaky tests not found');
   }
 
-  const jobNumbers = [
-    ...new Set(flakyTests.flaky_tests.map((test) => test.job_number)),
+  const flakyTestDetails = [
+    ...new Set(
+      flakyTests.flaky_tests.map((test) => ({
+        jobNumber: test.job_number,
+        classname: test.classname,
+      })),
+    ),
   ];
 
   const testsArrays = await rateLimitedRequests(
-    jobNumbers.map((jobNumber) => async () => {
+    flakyTestDetails.map(({ jobNumber, classname }) => async () => {
       try {
         const tests = await circleci.tests.getJobTests({
           projectSlug,
           jobNumber,
         });
-        return tests;
+        const matchingTest = tests.find((test) => test.classname === classname);
+        if (matchingTest) {
+          return matchingTest;
+        }
+        console.error(`Test ${classname} not found in job ${jobNumber}`);
+        return tests.filter((test) => test.result === 'failure');
       } catch (error) {
         if (error instanceof Error && error.message.includes('404')) {
           console.error(`Job ${jobNumber} not found:`, error);
-          return [];
+          return undefined;
         } else if (error instanceof Error && error.message.includes('429')) {
           console.error(`Rate limited for job request ${jobNumber}:`, error);
-          return [];
+          return undefined;
         }
         throw error;
       }
     }),
   );
 
-  return testsArrays.flat().filter((test) => test.result === 'failure');
+  const filteredTestsArrays = testsArrays
+    .flat()
+    .filter((test) => test !== undefined);
+
+  return filteredTestsArrays;
 };
 
 export const formatFlakyTests = (tests: Test[]) => {

--- a/src/lib/flaky-tests/getFlakyTests.ts
+++ b/src/lib/flaky-tests/getFlakyTests.ts
@@ -17,23 +17,23 @@ const getFlakyTests = async ({ projectSlug }: { projectSlug: string }) => {
     ...new Set(
       flakyTests.flaky_tests.map((test) => ({
         jobNumber: test.job_number,
-        classname: test.classname,
+        test_name: test.test_name,
       })),
     ),
   ];
 
   const testsArrays = await rateLimitedRequests(
-    flakyTestDetails.map(({ jobNumber, classname }) => async () => {
+    flakyTestDetails.map(({ jobNumber, test_name }) => async () => {
       try {
         const tests = await circleci.tests.getJobTests({
           projectSlug,
           jobNumber,
         });
-        const matchingTest = tests.find((test) => test.classname === classname);
+        const matchingTest = tests.find((test) => test.name === test_name);
         if (matchingTest) {
           return matchingTest;
         }
-        console.error(`Test ${classname} not found in job ${jobNumber}`);
+        console.error(`Test ${test_name} not found in job ${jobNumber}`);
         return tests.filter((test) => test.result === 'failure');
       } catch (error) {
         if (error instanceof Error && error.message.includes('404')) {

--- a/src/tools/getFlakyTests/handler.ts
+++ b/src/tools/getFlakyTests/handler.ts
@@ -150,7 +150,7 @@ const writeTestsToFiles = async ({
     const gitignoreContent = '# Ignore all flaky test output files\n*\n';
     writeFileSync(gitignorePath, gitignoreContent, 'utf8');
   } catch (error) {
-    return mcpErrorOutput(
+    throw new Error(
       `Failed to create output directory: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
@@ -170,7 +170,7 @@ const writeTestsToFiles = async ({
       content: [
         {
           type: 'text' as const,
-          text: `Found ${tests.length} flaky tests that need stabilization. Each file contains test failure data and metadata - analyze these reports to understand what's causing the flakiness, then locate and fix the actual test code.\n\nFocus on identifying:\n- Timing issues (race conditions, insufficient waits)\n- Environment dependencies (network, external services)\n- Test isolation problems (shared state, cleanup issues)\n- Non-deterministic assertions\n\nFlaky test reports:\n${filePaths.map((path) => `- ${path}`).join('\n')}\n\nFiles are located in: ${flakyTestsOutputDirectory}`,
+          text: `Found ${tests.length} flaky tests that need stabilization. Each file contains test failure data and metadata - analyze these reports to understand what's causing the flakiness, then locate and fix the actual test code.\n\nFlaky test reports:\n${filePaths.map((path) => `- ${path}`).join('\n')}\n\nFiles are located in: ${flakyTestsOutputDirectory}`,
         },
       ],
     };


### PR DESCRIPTION
Fixed the function to properly match flaky tests by classname instead of returning all tests from jobs.
Previously, the code was collecting all job numbers and returning all failed tests from those jobs, which included irrelevant tests.

The flaky tests endpoint gives us a `test_name` on each test, which is the name of the actual test in the suite. ex `should expand the GitHub App trigger and show correct details`. This matches the `name` on the test returned when fetching from the job endpoint.

changes:
  1. flaky tests request - Changed from collecting just job numbers to storing both job number and test_name
  2. Match by test_name - Added logic to find the specific test that matches the flaky test's test_name within each
  job
  3. Fallback handling - If the exact test_name match isn't found, it logs an error and falls back to any failed tests from that job
  from that job
  4. Better error handling - Changed error returns from empty arrays to undefined for cleaner filtering

  This ensures only the actual flaky tests (or relevant failed tests as fallback) are returned, eliminating the
  irrelevant test results.

Also fixed an issue where if the output directory cannot be created the tool would respond with an error. We now throw in that case, which makes us fallback to the text output.

example output for web-ui, now correctly returning the 25 flaky tests

```
Found 25 flaky tests that need stabilization. Each file contains test failure data and metadata - analyze these reports to understand what's causing the flakiness, then locate and fix the actual test code.

Flaky test reports:
- flaky-tests-output/flaky-test-1-should_expand_the_GitHub_App_trigger_and_show_corr.txt
- flaky-tests-output/flaky-test-2-Check_if_we_need_to_re-authorize___re-auth_check.txt
- flaky-tests-output/flaky-test-3-create_custom_webhook___should_create_webhook.txt
- flaky-tests-output/flaky-test-4-helm_basic_restore_version_actions___restore_shoul.txt
- flaky-tests-output/flaky-test-5-should_edit_trigger_event_type_and_save_changes.txt
- flaky-tests-output/flaky-test-6-Custom_Webhooks___verify_updates.txt
- flaky-tests-output/flaky-test-7-edit_custom_webhook___should_show_error_if_config_.txt
- flaky-tests-output/flaky-test-8-Project_Deletion___delete_button_is_hidden_when_no.txt
- flaky-tests-output/flaky-test-9-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-10-should_show_the_unsaved_changes_modal_when_clickin.txt
- flaky-tests-output/flaky-test-11-Trigger_a_Pipeline___pipeline_exists.txt
- flaky-tests-output/flaky-test-12-useLoadTimeAnalytics_when_first_called_when_loadin.txt
- flaky-tests-output/flaky-test-13-Contexts_Lifecycle___deletes_the_added_context.txt
- flaky-tests-output/flaky-test-14-Groups_lifecycle___delete_a_group.txt
- flaky-tests-output/flaky-test-15-helm_basic_restore_version_actions___basic_restore.txt
- flaky-tests-output/flaky-test-16-Project_Following___updates_UI_elements_on_follow_.txt
- flaky-tests-output/flaky-test-17-should_create_new_GitHub_App_trigger__change_event.txt
- flaky-tests-output/flaky-test-18-should_create_new_GitHub_App_trigger__change_event.txt
- flaky-tests-output/flaky-test-19-Classic_Project_Setup___Allows_users_to_start_buil.txt
- flaky-tests-output/flaky-test-20-Contexts_Lifecycle___navigate_to_the_added_context.txt
- flaky-tests-output/flaky-test-21-Custom_Webhooks___delete_a_trigger.txt
- flaky-tests-output/flaky-test-22-edit_custom_webhook___With_query_params___should_c.txt
- flaky-tests-output/flaky-test-23-edit_custom_webhook___With_query_params___should_c.txt
- flaky-tests-output/flaky-test-24-useLoadTimeAnalytics_when_first_called_when_loadin.txt
- flaky-tests-output/flaky-test-25-Workflow_Graph___DAG_loads_successfully.txt

Files are located in: .//flaky-tests-output
```