### PR TITLE
Fixed Claude config file routes for mac and windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,6 @@ Add the following to your cursor MCP config:
   }
 }
 ```
-To locate this file:
-
-macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-
-Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-
-[Claude Desktop setup](https://modelcontextprotocol.io/quickstart/user)
 
 
 #### Using Docker
@@ -188,6 +181,13 @@ Add the following to your claude_desktop_config.json:
   }
 }
 ```
+To locate this file:
+
+macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+[Claude Desktop setup](https://modelcontextprotocol.io/quickstart/user)
 
 #### Using Docker
 


### PR DESCRIPTION
The routes for Claude config file on windows and mac were under `Installation > Cursor`. Solved this by moving the routes to `Installation > Claude` 