### PR TITLE
Update to support implementation of CCI as a remote MCP Server using HTTP on port 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,19 +13,41 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 
 # Build stage
 FROM base AS build
+# Install build dependencies
+RUN apk add --no-cache git python3 make g++
+# Copy package files first for better caching
 COPY package.json pnpm-lock.yaml ./
+# Install all dependencies including devDependencies for building
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile --ignore-scripts
+    pnpm install --frozen-lockfile --ignore-scripts=false
+# Install express types and ensure all dependencies are available
+RUN pnpm add -D @types/express
+# Copy source files
 COPY . .
+# Build the application
 RUN pnpm run build
+# Install production dependencies for the final image
+RUN pnpm install --prod --frozen-lockfile
 
 # Final stage - clean minimal image
 FROM node:lts-alpine
 ENV NODE_ENV=production
 WORKDIR /app
-COPY --from=prod-deps /app/node_modules /app/node_modules
+
+# Install pnpm
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+# Copy package files and install only production dependencies
+COPY package.json pnpm-lock.yaml ./
+# Install production dependencies
+RUN pnpm install --prod --frozen-lockfile
+
+# Copy built files and node_modules
 COPY --from=build /app/dist /app/dist
-COPY package.json ./
+COPY --from=build /app/node_modules /app/node_modules
+
+# Docker container to listen on port 8080
+EXPOSE 8080
 
 # Command to run the MCP server
 ENTRYPOINT ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -17,68 +17,99 @@ https://github.com/user-attachments/assets/3c765985-8827-442a-a8dc-5069e01edb74
 
 - CircleCI Personal API Token - you can generate one through the CircleCI. [Learn more](https://circleci.com/docs/managing-api-tokens/) or [click here](https://app.circleci.com/settings/user/tokens) for quick access.
 
-For NPX installation:
-
-- pnpm package manager - [Learn more](https://pnpm.io/installation)
-- Node.js >= v18.0.0
-
-For Docker installation:
-
 - Docker - [Learn more](https://docs.docker.com/get-docker/)
 
 ## Installation
 
+### Amazon Q Developer CLi
+
+#### Using a Self-Managed Remote MCP Server
+
+Create a wrapper script first
+
+Create a script file such as 'circleci-remote-mcp.sh':
+
+```bash
+#!/bin/bash
+export CIRCLECI_TOKEN="your-circleci-token"
+npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http --header "Authorization: Bearer ${CIRCLECI_TOKEN}"
+```
+
+Make it executable:
+
+```bash
+chmod +x circleci-remote-mcp.sh
+```
+
+Then add it:
+
+```bash
+q mcp add --name circleci --command "/full/path/to/circleci-remote-mcp.sh"
+```
+
+### Amazon Q Developer Console
+
+#### Using a Self-Managed Remote MCP Server
+
+Create a wrapper script first
+
+Create a script file such as 'circleci-remote-mcp.sh':
+
+```bash
+#!/bin/bash
+export CIRCLECI_TOKEN="your-circleci-token"
+npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http --header "Authorization: Bearer ${CIRCLECI_TOKEN}"
+```
+
+Make it executable:
+
+```bash
+chmod +x circleci-remote-mcp.sh
+```
+
+Then add it to the Q Developer in your IDE:
+
+Access the MCP configuration UI (https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/mcp-ide.html#mcp-ide-configuration-access-ui).
+
+Choose the plus (+) symbol.
+
+Select the scope: global or local.
+
+If you select global scope, the MCP server configuration is stored in ~/.aws/amazonq/mcp.json and available across all your projects. If you select local scope, the configuration is stored in .amazonq/mcp.json within your current project.
+
+In the Name field, enter the name of the CircleCI remote MCP server (e.g. circleci-remote-mcp).
+
+Select the transport protocol.
+
+Currently, only stdio is supported.
+
+In the Command field, enter the shell command created previously that the MCP server will run when it initializes (e.g. /full/path/to/circleci-remote-mcp.sh).
+
+Click the Save button.
+
+
 ### Cursor
 
-#### Using NPX
+
+#### Using a Self-Managed Remote MCP Server
 
 Add the following to your cursor MCP config:
 
 ```json
 {
-  "mcpServers": {
-    "circleci-mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@circleci/mcp-server-circleci"],
-      "env": {
-        "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
-      }
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "circleci-token", 
+      "description": "CircleCI API Token",
+      "password": true
     }
-  }
-}
-```
-To locate this file:
-
-macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-
-Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-
-[Claude Desktop setup](https://modelcontextprotocol.io/quickstart/user)
-
-
-#### Using Docker
-
-Add the following to your cursor MCP config:
-
-```json
-{
-  "mcpServers": {
-    "circleci-mcp-server": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e",
-        "CIRCLECI_TOKEN",
-        "-e",
-        "CIRCLECI_BASE_URL",
-        "circleci:mcp-server-circleci"
-      ],
-      "env": {
-        "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
+  ],
+  "servers": {
+    "circleci-mcp-server-remote": {
+      "url": "http://your-circleci-remote-mcp-server-endpoint:8080/sse",
+      "headers": {
+        "Authorization": "Bearer MY_CIRCLECI_TOKEN"
       }
     }
   }
@@ -87,81 +118,28 @@ Add the following to your cursor MCP config:
 
 ### VS Code
 
-#### Using NPX
 
-To install CircleCI MCP Server for VS Code in `.vscode/mcp.json`:
 
-```json
-{
-  // 💡 Inputs are prompted on first server start, then stored securely by VS Code.
-  "inputs": [
-    {
-      "type": "promptString",
-      "id": "circleci-token",
-      "description": "CircleCI API Token",
-      "password": true
-    },
-    {
-      "type": "promptString",
-      "id": "circleci-base-url",
-      "description": "CircleCI Base URL",
-      "default": "https://circleci.com"
-    }
-  ],
-  "servers": {
-    // https://github.com/ppl-ai/modelcontextprotocol/
-    "circleci-mcp-server": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@circleci/mcp-server-circleci"],
-      "env": {
-        "CIRCLECI_TOKEN": "${input:circleci-token}",
-        "CIRCLECI_BASE_URL": "${input:circleci-base-url}"
-      }
-    }
-  }
-}
-```
+#### Using Self-Managed Remote MCP Server
 
-#### Using Docker
-
-To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using Docker:
+To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using a self-managed remote MCP server:
 
 ```json
 {
-  // 💡 Inputs are prompted on first server start, then stored securely by VS Code.
   "inputs": [
     {
       "type": "promptString",
-      "id": "circleci-token",
+      "id": "circleci-token", 
       "description": "CircleCI API Token",
       "password": true
-    },
-    {
-      "type": "promptString",
-      "id": "circleci-base-url",
-      "description": "CircleCI Base URL",
-      "default": "https://circleci.com"
     }
   ],
   "servers": {
-    // https://github.com/ppl-ai/modelcontextprotocol/
-    "circleci-mcp-server": {
-      "type": "stdio",
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e",
-        "CIRCLECI_TOKEN",
-        "-e",
-        "CIRCLECI_BASE_URL",
-        "circleci:mcp-server-circleci"
-      ],
-      "env": {
-        "CIRCLECI_TOKEN": "${input:circleci-token}",
-        "CIRCLECI_BASE_URL": "${input:circleci-base-url}"
+    "circleci-mcp-server-remote": {
+      "type": "sse",
+      "url": "http://your-circleci-remote-mcp-server-endpoint:8080/sse",
+      "headers": {
+        "Authorization": "Bearer ${input:circleci-token}"
       }
     }
   }
@@ -170,48 +148,31 @@ To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using Docker:
 
 ### Claude Desktop
 
-#### Using NPX
+#### Using a Self-Managed Remote MCP Server
 
-Add the following to your claude_desktop_config.json:
+Create a wrapper script first
 
-```json
-{
-  "mcpServers": {
-    "circleci-mcp-server": {
-      "command": "npx",
-      "args": ["-y", "@circleci/mcp-server-circleci"],
-      "env": {
-        "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
-      }
-    }
-  }
-}
+Create a script file such as 'circleci-remote-mcp.sh':
+
+```bash
+#!/bin/bash
+export CIRCLECI_TOKEN="your-circleci-token"
+npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http --header "Authorization: Bearer ${CIRCLECI_TOKEN}"
 ```
 
-#### Using Docker
+Make it executable:
 
-Add the following to your claude_desktop_config.json:
+```bash
+chmod +x circleci-remote-mcp.sh
+```
+
+Then add the following to your claude_desktop_config.json:
 
 ```json
 {
   "mcpServers": {
-    "circleci-mcp-server": {
-      "command": "docker",
-      "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e",
-        "CIRCLECI_TOKEN",
-        "-e",
-        "CIRCLECI_BASE_URL",
-        "circleci:mcp-server-circleci"
-      ],
-      "env": {
-        "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
-      }
+    "circleci-remote-mcp-server": {
+      "command": "/full/path/to/circleci-remote-mcp.sh"
     }
   }
 }
@@ -229,20 +190,13 @@ https://modelcontextprotocol.io/quickstart/user
 
 ### Claude Code
 
-#### Using NPX
+
+#### Using Self-Managed Remote MCP Server
 
 After installing Claude Code, run the following command:
 
 ```bash
-claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -- npx -y @circleci/mcp-server-circleci
-```
-
-#### Using Docker
-
-After installing Claude Code, run the following command:
-
-```bash
-claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -e CIRCLECI_BASE_URL=https://circleci.com -- docker run --rm -i -e CIRCLECI_TOKEN -e CIRCLECI_BASE_URL circleci:mcp-server-circleci
+claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -- npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http --header "Authorization: Bearer $CIRCLECI_TOKEN"
 ```
 
 See the guide below for more information on using MCP servers with Claude Code:
@@ -250,48 +204,27 @@ https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up
 
 ### Windsurf
 
-#### Using NPX
+
+#### Using Self-Managed Remote MCP Server
 
 Add the following to your windsurf mcp_config.json:
 
 ```json
 {
   "mcpServers": {
-    "circleci-mcp-server": {
+    "circleci": {
       "command": "npx",
-      "args": ["-y", "@circleci/mcp-server-circleci"],
-      "env": {
-        "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
-      }
-    }
-  }
-}
-```
-
-#### Using Docker
-
-Add the following to your windsurf mcp_config.json:
-
-```json
-{
-  "mcpServers": {
-    "circleci-mcp-server": {
-      "command": "docker",
       "args": [
-        "run",
-        "--rm",
-        "-i",
-        "-e",
-        "CIRCLECI_TOKEN",
-        "-e",
-        "CIRCLECI_BASE_URL",
-        "circleci:mcp-server-circleci"
+        "mcp-remote",
+        "http://your-circleci-remote-mcp-server-endpoint:8080/sse",
+        "--allow-http"
       ],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
-      }
+        "CIRCLECI_BASE_URL": "https://circleci.com"
+      },
+      "disabled": false,
+      "alwaysAllow": []
     }
   }
 }
@@ -300,13 +233,6 @@ Add the following to your windsurf mcp_config.json:
 See the guide below for more information on using MCP servers with windsurf:
 https://docs.windsurf.com/windsurf/mcp
 
-### Installing via Smithery
-
-To install CircleCI MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@CircleCI-Public/mcp-server-circleci):
-
-```bash
-npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claude
-```
 
 # Features
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Create a script file such as 'circleci-remote-mcp.sh':
 
 ```bash
 #!/bin/bash
-export CIRCLECI_TOKEN="your-circleci-token"
 npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http
 ```
 
@@ -96,14 +95,6 @@ Add the following to your cursor MCP config:
 
 ```json
 {
-  "inputs": [
-    {
-      "type": "promptString",
-      "id": "circleci-token", 
-      "description": "CircleCI API Token",
-      "password": true
-    }
-  ],
   "servers": {
     "circleci-mcp-server-remote": {
       "url": "http://your-circleci-remote-mcp-server-endpoint:8080/sse"
@@ -141,7 +132,6 @@ Create a script file such as 'circleci-remote-mcp.sh':
 
 ```bash
 #!/bin/bash
-export CIRCLECI_TOKEN="your-circleci-token"
 npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http 
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Create a script file such as 'circleci-remote-mcp.sh':
 ```bash
 #!/bin/bash
 export CIRCLECI_TOKEN="your-circleci-token"
-npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http --header "Authorization: Bearer ${CIRCLECI_TOKEN}"
+npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http
 ```
 
 Make it executable:
@@ -57,8 +57,7 @@ Create a script file such as 'circleci-remote-mcp.sh':
 
 ```bash
 #!/bin/bash
-export CIRCLECI_TOKEN="your-circleci-token"
-npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http --header "Authorization: Bearer ${CIRCLECI_TOKEN}"
+npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http
 ```
 
 Make it executable:
@@ -107,10 +106,7 @@ Add the following to your cursor MCP config:
   ],
   "servers": {
     "circleci-mcp-server-remote": {
-      "url": "http://your-circleci-remote-mcp-server-endpoint:8080/sse",
-      "headers": {
-        "Authorization": "Bearer MY_CIRCLECI_TOKEN"
-      }
+      "url": "http://your-circleci-remote-mcp-server-endpoint:8080/sse"
     }
   }
 }
@@ -126,21 +122,10 @@ To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using a self-ma
 
 ```json
 {
-  "inputs": [
-    {
-      "type": "promptString",
-      "id": "circleci-token", 
-      "description": "CircleCI API Token",
-      "password": true
-    }
-  ],
   "servers": {
     "circleci-mcp-server-remote": {
       "type": "sse",
-      "url": "http://your-circleci-remote-mcp-server-endpoint:8080/sse",
-      "headers": {
-        "Authorization": "Bearer ${input:circleci-token}"
-      }
+      "url": "http://your-circleci-remote-mcp-server-endpoint:8080/sse"
     }
   }
 }
@@ -157,7 +142,7 @@ Create a script file such as 'circleci-remote-mcp.sh':
 ```bash
 #!/bin/bash
 export CIRCLECI_TOKEN="your-circleci-token"
-npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http --header "Authorization: Bearer ${CIRCLECI_TOKEN}"
+npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http 
 ```
 
 Make it executable:
@@ -196,7 +181,7 @@ https://modelcontextprotocol.io/quickstart/user
 After installing Claude Code, run the following command:
 
 ```bash
-claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -- npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http --header "Authorization: Bearer $CIRCLECI_TOKEN"
+claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -- npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8080/sse --allow-http
 ```
 
 See the guide below for more information on using MCP servers with Claude Code:
@@ -219,10 +204,6 @@ Add the following to your windsurf mcp_config.json:
         "http://your-circleci-remote-mcp-server-endpoint:8080/sse",
         "--allow-http"
       ],
-      "env": {
-        "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com"
-      },
       "disabled": false,
       "alwaysAllow": []
     }

--- a/package.json
+++ b/package.json
@@ -39,12 +39,14 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.8.0",
+    "express": "^4.19.2",
     "parse-github-url": "^1.0.3",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
+    "@types/express": "5.0.3",
     "@types/node": "^22",
     "@types/parse-github-url": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^8.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.8.0
         version: 1.8.0
+      express:
+        specifier: ^4.19.2
+        version: 4.21.2
       parse-github-url:
         specifier: ^1.0.3
         version: 1.0.3
@@ -24,6 +27,9 @@ importers:
       '@eslint/js':
         specifier: ^9.21.0
         version: 9.23.0
+      '@types/express':
+        specifier: 5.0.3
+        version: 5.0.3
       '@types/node':
         specifier: ^22
         version: 22.13.13
@@ -404,17 +410,47 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/express-serve-static-core@5.0.6':
+    resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
+
+  '@types/express@5.0.3':
+    resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
   '@types/node@22.13.13':
     resolution: {integrity: sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==}
 
   '@types/parse-github-url@1.0.3':
     resolution: {integrity: sha512-7sTbCVmSVzK/iAsHGIxoqiyAnqix9opZm68lOvaU6DBx9EQ9kHMSp0y7Criu2OCsZ9wDllEyCRU+LU4hPRxXUA==}
+
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@0.17.5':
+    resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
+
+  '@types/serve-static@1.15.8':
+    resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
 
   '@typescript-eslint/eslint-plugin@8.29.0':
     resolution: {integrity: sha512-PAIpk/U7NIS6H7TEtN45SPGLQaHNgB7wSjsQV/8+KYokAb2T/gloOA/Bee2yd4/yKVhPKe5LlaUGhAZk5zmSaQ==}
@@ -492,6 +528,10 @@ packages:
   '@vitest/utils@3.1.1':
     resolution: {integrity: sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -520,6 +560,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -530,6 +573,10 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  body-parser@1.20.3:
+    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   body-parser@2.1.0:
     resolution: {integrity: sha512-/hPxh61E+ll0Ujp24Ilm64cykicul1ypfwjVttduAiEdtnJFvLePSrIPk+HMImtNv5270wOGCb1Tns2rybMkoQ==}
@@ -591,6 +638,10 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   content-disposition@1.0.0:
     resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
     engines: {node: '>= 0.6'}
@@ -598,6 +649,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -618,6 +672,14 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.3.6:
     resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
@@ -658,6 +720,10 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -784,6 +850,10 @@ packages:
     peerDependencies:
       express: ^4.11 || 5 || ^5.0.0-beta.1
 
+  express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
+    engines: {node: '>= 0.10.0'}
+
   express@5.0.1:
     resolution: {integrity: sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==}
     engines: {node: '>= 18'}
@@ -814,6 +884,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@1.3.1:
+    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
+    engines: {node: '>= 0.8'}
 
   finalhandler@2.1.0:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
@@ -903,6 +977,10 @@ packages:
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.5.2:
     resolution: {integrity: sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==}
@@ -1005,9 +1083,16 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -1041,6 +1126,11 @@ packages:
     resolution: {integrity: sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==}
     engines: {node: '>= 0.6'}
 
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -1050,6 +1140,9 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -1064,6 +1157,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -1144,6 +1241,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
   path-to-regexp@8.2.0:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
@@ -1212,6 +1312,10 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
+  raw-body@2.5.2:
+    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+
   raw-body@3.0.0:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
@@ -1267,9 +1371,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.0:
+    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
+    engines: {node: '>= 0.8.0'}
+
   send@1.1.0:
     resolution: {integrity: sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==}
     engines: {node: '>= 18'}
+
+  serve-static@1.16.2:
+    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
+    engines: {node: '>= 0.8.0'}
 
   serve-static@2.1.0:
     resolution: {integrity: sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==}
@@ -1415,6 +1527,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
 
   type-is@2.0.0:
     resolution: {integrity: sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==}
@@ -1788,9 +1904,35 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.38.0':
     optional: true
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.13.13
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.13.13
+
   '@types/estree@1.0.7': {}
 
+  '@types/express-serve-static-core@5.0.6':
+    dependencies:
+      '@types/node': 22.13.13
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 0.17.5
+
+  '@types/express@5.0.3':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.0.6
+      '@types/serve-static': 1.15.8
+
+  '@types/http-errors@2.0.5': {}
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/mime@1.3.5': {}
 
   '@types/node@22.13.13':
     dependencies:
@@ -1799,6 +1941,21 @@ snapshots:
   '@types/parse-github-url@1.0.3':
     dependencies:
       '@types/node': 22.13.13
+
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@0.17.5':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 22.13.13
+
+  '@types/serve-static@1.15.8':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.13.13
+      '@types/send': 0.17.5
 
   '@typescript-eslint/eslint-plugin@8.29.0(@typescript-eslint/parser@8.29.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)':
     dependencies:
@@ -1917,6 +2074,11 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.0
@@ -1946,11 +2108,30 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  array-flatten@1.1.1: {}
+
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
 
   binary-extensions@2.3.0: {}
+
+  body-parser@1.20.3:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.13.0
+      raw-body: 2.5.2
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   body-parser@2.1.0:
     dependencies:
@@ -2030,11 +2211,17 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-disposition@1.0.0:
     dependencies:
       safe-buffer: 5.2.1
 
   content-type@1.0.5: {}
+
+  cookie-signature@1.0.6: {}
 
   cookie-signature@1.2.2: {}
 
@@ -2058,6 +2245,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@4.3.6:
     dependencies:
@@ -2084,6 +2275,8 @@ snapshots:
       gopd: 1.2.0
 
   ee-first@1.1.1: {}
+
+  encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -2241,6 +2434,42 @@ snapshots:
     dependencies:
       express: 5.0.1
 
+  express@4.21.2:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.3
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.13.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.0
+      serve-static: 1.16.2
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.0.1:
     dependencies:
       accepts: 2.0.0
@@ -2305,6 +2534,18 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@1.3.1:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   finalhandler@2.1.0:
     dependencies:
@@ -2398,6 +2639,10 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.5.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -2478,7 +2723,11 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@0.3.0: {}
+
   media-typer@1.1.0: {}
+
+  merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
 
@@ -2503,6 +2752,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@1.6.0: {}
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -2513,6 +2764,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  ms@2.0.0: {}
+
   ms@2.1.2: {}
 
   ms@2.1.3: {}
@@ -2520,6 +2773,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
@@ -2591,6 +2846,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-to-regexp@0.1.12: {}
+
   path-to-regexp@8.2.0: {}
 
   pathe@2.0.3: {}
@@ -2642,6 +2899,13 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   range-parser@1.2.1: {}
+
+  raw-body@2.5.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   raw-body@3.0.0:
     dependencies:
@@ -2714,6 +2978,24 @@ snapshots:
 
   semver@7.7.1: {}
 
+  send@0.19.0:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   send@1.1.0:
     dependencies:
       debug: 4.4.0(supports-color@5.5.0)
@@ -2728,6 +3010,15 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.2:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2863,6 +3154,11 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
 
   type-is@2.0.0:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { CCI_HANDLERS, CCI_TOOLS, ToolHandler } from './circleci-tools.js';
+import express from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { CCI_HANDLERS, CCI_TOOLS, ToolHandler } from './circleci-tools.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -13,25 +15,14 @@ const packageJson = JSON.parse(
 );
 
 const server = new McpServer(
-  {
-    name: 'mcp-server-circleci',
-    version: packageJson.version,
-  },
-  {
-    capabilities: {
-      tools: {},
-      resources: {},
-    },
-  },
+  { name: 'mcp-server-circleci', version: packageJson.version },
+  { capabilities: { tools: {}, resources: {} } },
 );
 
-// Register tools
+// Register CircleCI tools
 CCI_TOOLS.forEach((tool) => {
   const handler = CCI_HANDLERS[tool.name];
-  if (!handler) {
-    throw new Error(`Handler for tool ${tool.name} not found`);
-  }
-
+  if (!handler) throw new Error(`Handler for tool ${tool.name} not found`);
   server.tool(
     tool.name,
     tool.description,
@@ -40,16 +31,68 @@ CCI_TOOLS.forEach((tool) => {
   );
 });
 
-/**
- * Start the server using stdio transport.
- * This allows the server to communicate via standard input/output streams.
- */
 async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  const app = express();
+  app.use(express.json());                                  
+
+  // Keep active transports per session
+  const transports: Record<string, SSEServerTransport> = {};
+
+  // GET /sse → SSE endpoint for establishing connection
+  app.get('/sse', async (req, res) => {
+    const transport = new SSEServerTransport('/invocations', res);
+    transports[transport.sessionId] = transport;
+    
+    // Connect the server to the transport (this calls start() automatically)
+    await server.connect(transport);
+  });
+
+  // POST /invocations → handle initialize + calls
+  // @ts-ignore - TypeScript inference issue with Express route handler
+  app.post('/invocations', async (req, res) => {
+    const sessionId = req.header('mcp-session-id') as string || req.query.sessionId as string;
+    
+    if (!sessionId || !transports[sessionId]) {
+      return res.status(400).json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Invalid or missing MCP session ID' },
+        id: req.body?.id || null,
+      });
+    }
+
+    const transport = transports[sessionId];
+    
+    try {
+      // handle the MCP request via transport
+      await transport.handlePostMessage(req, res, req.body);
+    } catch (error: any) {
+      console.error('MCP request error:', error);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32603,
+            message: 'Internal error',
+            data: error.message,
+          },
+          id: req.body?.id || null,
+        });
+      }
+    }
+  });
+
+  // GET /ping → simple health check
+  app.get('/ping', (_req, res) => {
+    res.json({ result: 'pong' });
+  });
+
+  const port = 8080;
+  app.listen(port, () => {
+    console.log(`CircleCI MCP server listening on http://0.0.0.0:${port}`);  
+  });
 }
 
-main().catch((error: unknown) => {
-  console.error('Server error:', error);
+main().catch((err) => {
+  console.error('Server error:', err);
   process.exit(1);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,16 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "paths": {
+      "@modelcontextprotocol/sdk/*": ["./node_modules/@modelcontextprotocol/sdk/dist/esm/*"]
+    },
+    "types": ["node"],
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts", "vitest.config.ts", "dist"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "vitest.config.ts", "dist"]
 }


### PR DESCRIPTION
Update to support implementation of CCI as a remote MCP Server using HTTP on port 8080.
In this update STDIO was replaced for a remote HTTP call on port 8080.
Also updated readme instructions including instructions for Amazon Q Developer