### PR TITLE
Dockerfile: Use CMD for cli arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,5 @@ COPY --from=build /app/node_modules /app/node_modules
 EXPOSE 8080
 
 # Command to run the MCP server
-ENTRYPOINT ["node", "dist/index.js", "start:sse"]
+ENTRYPOINT ["node", "dist/index.js"]
+CMD ["start:sse"]


### PR DESCRIPTION
This moves `start:sse` to `CMD` in the Dockerfile so that it can be overridden in case a user wants to use `stdio` instead. E.g. `docker run --rm mcp/circleci stdio`

Also, stdio is needed (for now) for us to update the entry in the Docker catalog: https://hub.docker.com/mcp/server/circleci/overview