### PR TITLE
Add getJobArtifacts tool for retrieving CircleCI job artifacts

### DIFF
--- a/src/circleci-tools.ts
+++ b/src/circleci-tools.ts
@@ -23,6 +23,8 @@ import { rerunWorkflowTool } from './tools/rerunWorkflow/tool.js';
 import { rerunWorkflow } from './tools/rerunWorkflow/handler.js';
 import { analyzeDiffTool } from './tools/analyzeDiff/tool.js';
 import { analyzeDiff } from './tools/analyzeDiff/handler.js';
+import { getJobArtifactsTool } from './tools/getJobArtifacts/tool.js';
+import { getJobArtifacts } from './tools/getJobArtifacts/handler.js';
 
 // Define the tools with their configurations
 export const CCI_TOOLS = [
@@ -38,6 +40,7 @@ export const CCI_TOOLS = [
   runEvaluationTestsTool,
   rerunWorkflowTool,
   analyzeDiffTool,
+  getJobArtifactsTool,
 ];
 
 // Extract the tool names as a union type
@@ -65,4 +68,5 @@ export const CCI_HANDLERS = {
   run_evaluation_tests: runEvaluationTests,
   rerun_workflow: rerunWorkflow,
   analyze_diff: analyzeDiff,
+  get_job_artifacts: getJobArtifacts,
 } satisfies ToolHandlers;

--- a/src/clients/circleci/artifacts.ts
+++ b/src/clients/circleci/artifacts.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { HTTPClient } from './httpClient.js';
+
+// Schema for individual artifact
+const artifactSchema = z.object({
+  path: z.string().describe('The artifact file path'),
+  pretty_path: z.string().describe('The pretty artifact file path').optional(),
+  node_index: z.number().describe('The node that produced the artifact'),
+  url: z.string().describe('Download URL for the artifact'),
+});
+
+export type Artifact = z.infer<typeof artifactSchema>;
+
+// Schema for artifacts response
+const artifactsResponseSchema = z.object({
+  items: z.array(artifactSchema),
+  next_page_token: z.string().nullable().optional(),
+});
+
+export type ArtifactsResponse = z.infer<typeof artifactsResponseSchema>;
+
+export class ArtifactsAPI {
+  protected client: HTTPClient;
+
+  constructor(httpClient: HTTPClient) {
+    this.client = httpClient;
+  }
+
+  /**
+   * Get all artifacts for a job
+   * @param projectSlug The project slug
+   * @param jobNumber The job number
+   * @returns All artifacts from the job
+   */
+  async getAllJobArtifacts(
+    projectSlug: string,
+    jobNumber: number,
+  ): Promise<Artifact[]> {
+    const allArtifacts: Artifact[] = [];
+    let nextPageToken: string | null = null;
+
+    do {
+      const params: Record<string, any> = {};
+      if (nextPageToken) {
+        params['page-token'] = nextPageToken;
+      }
+
+      const response = await this.client.get<ArtifactsResponse>(
+        `/project/${projectSlug}/${jobNumber}/artifacts`,
+        params,
+      );
+
+      const validatedResponse = artifactsResponseSchema.parse(response);
+      allArtifacts.push(...validatedResponse.items);
+      nextPageToken = validatedResponse.next_page_token || null;
+    } while (nextPageToken);
+
+    return allArtifacts;
+  }
+}

--- a/src/clients/circleci/index.ts
+++ b/src/clients/circleci/index.ts
@@ -7,6 +7,7 @@ import { WorkflowsAPI } from './workflows.js';
 import { TestsAPI } from './tests.js';
 import { ConfigValidateAPI } from './configValidate.js';
 import { ProjectsAPI } from './projects.js';
+import { ArtifactsAPI } from './artifacts.js';
 export type TCircleCIClient = InstanceType<typeof CircleCIClients>;
 
 export const getBaseURL = (useAPISubdomain = false) => {
@@ -114,6 +115,7 @@ export class CircleCIClients {
   public tests: TestsAPI;
   public configValidate: ConfigValidateAPI;
   public projects: ProjectsAPI;
+  public artifacts: ArtifactsAPI;
 
   constructor({
     token,
@@ -141,5 +143,6 @@ export class CircleCIClients {
     this.tests = new TestsAPI(v2httpClient);
     this.configValidate = new ConfigValidateAPI(apiSubdomainV2httpClient);
     this.projects = new ProjectsAPI(v2httpClient);
+    this.artifacts = new ArtifactsAPI(v2httpClient);
   }
 }

--- a/src/tools/getJobArtifacts/handler.test.ts
+++ b/src/tools/getJobArtifacts/handler.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getJobArtifacts } from './handler.js';
+import * as projectDetection from '../../lib/project-detection/index.js';
+import * as clientModule from '../../clients/client.js';
+import type { Artifact } from '../../clients/circleci/artifacts.js';
+
+// Mock the dependencies
+vi.mock('../../lib/project-detection/index.js');
+vi.mock('../../clients/client.js');
+
+describe('getJobArtifacts', () => {
+  const mockArtifacts: Artifact[] = [
+    {
+      path: 'test-results/junit.xml',
+      pretty_path: 'test-results/junit.xml',
+      node_index: 0,
+      url: 'https://artifacts.circleci.com/0/test-results/junit.xml',
+    },
+    {
+      path: 'coverage/lcov.info',
+      pretty_path: 'coverage/lcov.info',
+      node_index: 0,
+      url: 'https://artifacts.circleci.com/0/coverage/lcov.info',
+    },
+    {
+      path: 'logs/app.log',
+      pretty_path: 'logs/app.log',
+      node_index: 1,
+      url: 'https://artifacts.circleci.com/1/logs/app.log',
+    },
+  ];
+
+  const mockCircleCIClient = {
+    artifacts: {
+      getAllJobArtifacts: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(clientModule, 'getCircleCIClient').mockReturnValue(
+      mockCircleCIClient as any,
+    );
+  });
+
+  describe('Input validation', () => {
+    it('should return error when no inputs are provided', async () => {
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        { params: {} },
+        { signal: controller.signal },
+      );
+
+      expect(result).toHaveProperty('isError', true);
+      expect(result.content[0].text).toContain('Invalid input combination');
+    });
+
+    it('should return error when projectSlug is provided without branch', async () => {
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        {
+          params: {
+            projectSlug: 'gh/org/repo',
+            jobNumber: 12345,
+          },
+        },
+        { signal: controller.signal },
+      );
+
+      expect(result).toHaveProperty('isError', true);
+      expect(result.content[0].text).toContain('Branch is required');
+    });
+
+    it('should return error when jobURL cannot be parsed', async () => {
+      vi.mocked(projectDetection.getProjectSlugFromURL).mockReturnValue('');
+
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        {
+          params: {
+            jobURL: 'https://invalid.url.com',
+          },
+        },
+        { signal: controller.signal },
+      );
+
+      expect(result).toHaveProperty('isError', true);
+      expect(result.content[0].text).toContain(
+        'Failed to extract project information',
+      );
+    });
+
+    it('should return error when job number cannot be extracted from URL', async () => {
+      vi.mocked(projectDetection.getProjectSlugFromURL).mockReturnValue(
+        'gh/org/repo',
+      );
+      vi.mocked(projectDetection.getJobNumberFromURL).mockReturnValue(undefined);
+
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        {
+          params: {
+            jobURL: 'https://app.circleci.com/pipelines/gh/org/repo',
+          },
+        },
+        { signal: controller.signal },
+      );
+
+      expect(result).toHaveProperty('isError', true);
+      expect(result.content[0].text).toContain('Failed to extract job number');
+    });
+  });
+
+  describe('Success cases', () => {
+    it('should fetch artifacts using projectSlug and jobNumber', async () => {
+      mockCircleCIClient.artifacts.getAllJobArtifacts.mockResolvedValue(
+        mockArtifacts,
+      );
+
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        {
+          params: {
+            projectSlug: 'gh/org/repo',
+            branch: 'main',
+            jobNumber: 12345,
+          },
+        },
+        { signal: controller.signal },
+      );
+
+      expect(
+        mockCircleCIClient.artifacts.getAllJobArtifacts,
+      ).toHaveBeenCalledWith('gh/org/repo', 12345);
+
+      expect(result).toHaveProperty('content');
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('# Artifacts for Job #12345');
+      expect(result.content[0].text).toContain('Found 3 artifacts:');
+      expect(result.content[0].text).toContain('test-results/junit.xml');
+      expect(result.content[0].text).toContain('coverage/lcov.info');
+      expect(result.content[0].text).toContain('logs/app.log');
+    });
+
+    it('should fetch artifacts using job URL', async () => {
+      vi.mocked(projectDetection.getProjectSlugFromURL).mockReturnValue(
+        'gh/org/repo',
+      );
+      vi.mocked(projectDetection.getJobNumberFromURL).mockReturnValue(12345);
+      mockCircleCIClient.artifacts.getAllJobArtifacts.mockResolvedValue(
+        mockArtifacts,
+      );
+
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        {
+          params: {
+            jobURL:
+              'https://app.circleci.com/pipelines/gh/org/repo/123/workflows/abc/jobs/12345',
+          },
+        },
+        { signal: controller.signal },
+      );
+
+      expect(
+        mockCircleCIClient.artifacts.getAllJobArtifacts,
+      ).toHaveBeenCalledWith('gh/org/repo', 12345);
+
+      expect(result.content[0].text).toContain('# Artifacts for Job #12345');
+      expect(result.content[0].text).toContain('Found 3 artifacts:');
+    });
+
+    it('should fetch artifacts using workspace detection', async () => {
+      vi.mocked(projectDetection.identifyProjectSlug).mockResolvedValue(
+        'gh/org/repo',
+      );
+      mockCircleCIClient.artifacts.getAllJobArtifacts.mockResolvedValue(
+        mockArtifacts,
+      );
+
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        {
+          params: {
+            workspaceRoot: '/Users/test/project',
+            gitRemoteURL: 'https://github.com/org/repo.git',
+            jobNumber: 12345,
+          },
+        },
+        { signal: controller.signal },
+      );
+
+      expect(projectDetection.identifyProjectSlug).toHaveBeenCalledWith({
+        gitRemoteURL: 'https://github.com/org/repo.git',
+      });
+      expect(
+        mockCircleCIClient.artifacts.getAllJobArtifacts,
+      ).toHaveBeenCalledWith('gh/org/repo', 12345);
+
+      expect(result.content[0].text).toContain('Branch: main');
+    });
+
+    it('should filter artifacts by path prefix', async () => {
+      mockCircleCIClient.artifacts.getAllJobArtifacts.mockResolvedValue(
+        mockArtifacts,
+      );
+
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        {
+          params: {
+            projectSlug: 'gh/org/repo',
+            branch: 'main',
+            jobNumber: 12345,
+            artifactPath: 'coverage/',
+          },
+        },
+        { signal: controller.signal },
+      );
+
+      expect(result.content[0].text).toContain('Filter: coverage/');
+      expect(result.content[0].text).toContain('Found 1 artifact:');
+      expect(result.content[0].text).toContain('coverage/lcov.info');
+      expect(result.content[0].text).not.toContain('test-results/junit.xml');
+      expect(result.content[0].text).not.toContain('logs/app.log');
+    });
+
+    it('should handle empty artifact list', async () => {
+      mockCircleCIClient.artifacts.getAllJobArtifacts.mockResolvedValue([]);
+
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        {
+          params: {
+            projectSlug: 'gh/org/repo',
+            branch: 'main',
+            jobNumber: 12345,
+          },
+        },
+        { signal: controller.signal },
+      );
+
+      expect(result.content[0].text).toBe('No artifacts found for job #12345');
+    });
+
+    it('should handle empty filtered artifact list', async () => {
+      mockCircleCIClient.artifacts.getAllJobArtifacts.mockResolvedValue(
+        mockArtifacts,
+      );
+
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        {
+          params: {
+            projectSlug: 'gh/org/repo',
+            branch: 'main',
+            jobNumber: 12345,
+            artifactPath: 'nonexistent/',
+          },
+        },
+        { signal: controller.signal },
+      );
+
+      expect(result.content[0].text).toBe(
+        'No artifacts found matching path prefix "nonexistent/" for job #12345',
+      );
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle API errors gracefully', async () => {
+      mockCircleCIClient.artifacts.getAllJobArtifacts.mockRejectedValue(
+        new Error('API request failed: 404 Not Found'),
+      );
+
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        {
+          params: {
+            projectSlug: 'gh/org/repo',
+            branch: 'main',
+            jobNumber: 12345,
+          },
+        },
+        { signal: controller.signal },
+      );
+
+      expect(result).toHaveProperty('isError', true);
+      expect(result.content[0].text).toContain('Failed to fetch artifacts');
+      expect(result.content[0].text).toContain(
+        'API request failed: 404 Not Found',
+      );
+      expect(result.content[0].text).toContain('Please ensure:');
+    });
+
+    it('should handle workspace detection error without gitRemoteURL', async () => {
+      const controller = new AbortController();
+      const result = await getJobArtifacts(
+        {
+          params: {
+            workspaceRoot: '/Users/test/project',
+            jobNumber: 12345,
+          },
+        },
+        { signal: controller.signal },
+      );
+
+      expect(result).toHaveProperty('isError', true);
+      expect(result.content[0].text).toContain('Git remote URL is required');
+    });
+  });
+});

--- a/src/tools/getJobArtifacts/handler.ts
+++ b/src/tools/getJobArtifacts/handler.ts
@@ -1,0 +1,161 @@
+import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getJobArtifactsInputSchema } from './inputSchema.js';
+import { getCircleCIClient } from '../../clients/client.js';
+import {
+  getProjectSlugFromURL,
+  getJobNumberFromURL,
+  identifyProjectSlug,
+} from '../../lib/project-detection/index.js';
+import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
+
+export const getJobArtifacts: ToolCallback<{
+  params: typeof getJobArtifactsInputSchema;
+}> = async (args) => {
+  const {
+    projectSlug: inputProjectSlug,
+    branch: inputBranch,
+    jobNumber: inputJobNumber,
+    jobURL,
+    workspaceRoot,
+    gitRemoteURL,
+    artifactPath,
+  } = args.params;
+
+  let projectSlug: string;
+  let jobNumber: number;
+  let branch = inputBranch;
+
+  // Determine project slug and job number based on input method
+  if (inputProjectSlug && inputJobNumber) {
+    // Option 1: Direct project slug and job number
+    if (!inputBranch) {
+      return mcpErrorOutput(
+        'Branch is required when using projectSlug. Please provide the branch parameter.',
+      );
+    }
+    projectSlug = inputProjectSlug;
+    jobNumber = inputJobNumber;
+  } else if (jobURL) {
+    // Option 2: Extract from job URL
+    const slugFromURL = getProjectSlugFromURL(jobURL);
+    const jobNumberFromURL = getJobNumberFromURL(jobURL);
+
+    if (!slugFromURL) {
+      return mcpErrorOutput(
+        'Failed to extract project information from the provided job URL. Please check the URL format.',
+      );
+    }
+
+    if (!jobNumberFromURL) {
+      return mcpErrorOutput(
+        'Failed to extract job number from the provided job URL. Please check the URL format.',
+      );
+    }
+
+    projectSlug = slugFromURL;
+    jobNumber = jobNumberFromURL;
+  } else if (workspaceRoot && inputJobNumber) {
+    // Option 3: Workspace detection
+    if (!gitRemoteURL) {
+      return mcpErrorOutput(
+        'Git remote URL is required when using workspace detection. Please provide the gitRemoteURL parameter.',
+      );
+    }
+
+    const detectedSlug = await identifyProjectSlug({ gitRemoteURL });
+    if (!detectedSlug) {
+      return mcpErrorOutput(
+        'Failed to identify project from git remote URL. Please check the URL format.',
+      );
+    }
+    projectSlug = detectedSlug;
+    jobNumber = inputJobNumber;
+
+    if (!branch) {
+      branch = 'main';
+    }
+  } else {
+    return mcpErrorOutput(
+      'Invalid input combination. Please provide either:\n' +
+        '1. projectSlug + branch + jobNumber\n' +
+        '2. jobURL\n' +
+        '3. workspaceRoot + gitRemoteURL + jobNumber',
+    );
+  }
+
+  try {
+    // Get CircleCI client
+    const circleci = getCircleCIClient();
+
+    // Fetch artifacts for the job
+    const artifacts = await circleci.artifacts.getAllJobArtifacts(
+      projectSlug,
+      jobNumber,
+    );
+
+    // Filter artifacts if path filter is provided
+    let filteredArtifacts = artifacts;
+    if (artifactPath) {
+      filteredArtifacts = artifacts.filter((artifact) =>
+        artifact.path.startsWith(artifactPath),
+      );
+    }
+
+    // Format output
+    if (filteredArtifacts.length === 0) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: artifactPath
+              ? `No artifacts found matching path prefix "${artifactPath}" for job #${jobNumber}`
+              : `No artifacts found for job #${jobNumber}`,
+          },
+        ],
+      };
+    }
+
+    // Create formatted output
+    const output = [
+      `# Artifacts for Job #${jobNumber}`,
+      `Project: ${projectSlug}`,
+      branch ? `Branch: ${branch}` : '',
+      artifactPath ? `Filter: ${artifactPath}` : '',
+      '',
+      `Found ${filteredArtifacts.length} artifact${filteredArtifacts.length === 1 ? '' : 's'}:`,
+      '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    // Add artifact details
+    const artifactDetails = filteredArtifacts
+      .map((artifact, index) => {
+        return [
+          `## ${index + 1}. ${artifact.path}`,
+          `   Node: ${artifact.node_index}`,
+          `   URL: ${artifact.url}`,
+        ].join('\n');
+      })
+      .join('\n\n');
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: output + artifactDetails,
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error occurred';
+    return mcpErrorOutput(
+      `Failed to fetch artifacts: ${errorMessage}\n\n` +
+        'Please ensure:\n' +
+        '1. The job number is correct\n' +
+        '2. The project slug is in the correct format (e.g., gh/org/repo)\n' +
+        '3. You have the necessary permissions to access this job',
+    );
+  }
+};

--- a/src/tools/getJobArtifacts/inputSchema.ts
+++ b/src/tools/getJobArtifacts/inputSchema.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import {
+  branchDescription,
+  projectSlugDescription,
+} from '../shared/constants.js';
+
+export const getJobArtifactsInputSchema = z.object({
+  // Option 1: Direct parameters
+  projectSlug: z.string().describe(projectSlugDescription).optional(),
+  branch: z.string().describe(branchDescription).optional(),
+  jobNumber: z
+    .number()
+    .describe(
+      'The job number to fetch artifacts from. Required when using projectSlug.',
+    )
+    .optional(),
+
+  // Option 2: Job URL
+  jobURL: z
+    .string()
+    .describe(
+      'The URL of the CircleCI job. Can be in these formats:\n' +
+        '- Job URL: https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc-def/jobs/456\n' +
+        '- Legacy job URL: https://circleci.com/gh/organization/project/456',
+    )
+    .optional(),
+
+  // Option 3: Workspace detection
+  workspaceRoot: z
+    .string()
+    .describe(
+      'The absolute path to the root directory of your project workspace. ' +
+        'This should be the top-level folder containing your source code, configuration files, and dependencies. ' +
+        'For example: "/home/user/my-project" or "C:\\Users\\user\\my-project"',
+    )
+    .optional(),
+  gitRemoteURL: z
+    .string()
+    .describe(
+      'The URL of the remote git repository. This should be the URL of the repository that you cloned to your local workspace. ' +
+        'For example: "https://github.com/user/my-project.git"',
+    )
+    .optional(),
+
+  // Optional filters
+  artifactPath: z
+    .string()
+    .describe(
+      'Filter artifacts by path prefix (e.g., "coverage/", "test-results/")',
+    )
+    .optional(),
+});

--- a/src/tools/getJobArtifacts/tool.ts
+++ b/src/tools/getJobArtifacts/tool.ts
@@ -1,0 +1,66 @@
+import { getJobArtifactsInputSchema } from './inputSchema.js';
+
+export const getJobArtifactsTool = {
+  name: 'get_job_artifacts' as const,
+  description: `
+  Retrieves the list of artifacts from a specific CircleCI job.
+
+  This tool supports multiple ways to specify which job's artifacts to retrieve:
+
+  1. **Using project slug and job number**:
+     - Provide projectSlug, branch, and jobNumber
+     - projectSlug format: {vcs-provider}/{organization}/{project} (e.g., gh/circleci/circleci-docs)
+
+  2. **Using a job URL**:
+     - Provide the full CircleCI job URL
+     - Supports both modern and legacy URL formats
+
+  3. **Using workspace detection**:
+     - Provide workspaceRoot (absolute path to project directory)
+     - Optionally provide gitRemoteURL and branch
+     - The tool will automatically detect project information
+
+  Parameters:
+  - params: An object that can contain:
+    - projectSlug: The project identifier in format {vcs-provider}/{organization}/{project}
+    - branch: The branch name (required with projectSlug)
+    - jobNumber: The job number to fetch artifacts from (required with projectSlug)
+    - jobURL: Full URL to the CircleCI job
+    - workspaceRoot: Absolute path to the project directory
+    - gitRemoteURL: URL of the git remote
+    - artifactPath: Filter artifacts by path prefix (optional)
+
+  Example usage:
+  1. With project slug:
+     {
+       "params": {
+         "projectSlug": "gh/circleci/circleci-docs",
+         "branch": "master",
+         "jobNumber": 12345
+       }
+     }
+
+  2. With job URL:
+     {
+       "params": {
+         "jobURL": "https://app.circleci.com/pipelines/gh/circleci/circleci-docs/123/workflows/abc-def/jobs/12345"
+       }
+     }
+
+  3. With workspace detection:
+     {
+       "params": {
+         "workspaceRoot": "/Users/username/projects/my-project",
+         "jobNumber": 12345
+       }
+     }
+
+  Returns:
+  - A list of artifacts with their paths, URLs, and node indices
+  - Each artifact contains:
+    - path: The artifact file path
+    - url: Download URL for the artifact
+    - node_index: The node that produced the artifact
+  `,
+  inputSchema: getJobArtifactsInputSchema,
+};


### PR DESCRIPTION
Our builds @ CircleCI exceeds the amount of logs that can be streamed so the agent couldn't have access to the tail of the logs. 

Those are saved into artifacts in our current setup, this action provide a tool to fetch the artifact URLs out of a build.

The URL can be passed to a `curl` for the agent to download. 