### PR TITLE
fix: prevent runRollbackPipeline tool from suggesting other projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2025-07-30
+
+### Fixed
+
+- Fixed `runRollbackPipeline` tool to not suggest other projects
+
 ## [0.12.0] - 2025-07-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/tools/runRollbackPipeline/handler.ts
+++ b/src/tools/runRollbackPipeline/handler.ts
@@ -76,7 +76,7 @@ export const runRollbackPipeline: ToolCallback<{
 
   if (!deploySettings || !deploySettings.rollback_pipeline_definition_id) {
     return mcpErrorOutput(
-      'No rollback pipeline defined for this project. See https://circleci.com/docs/deploy/rollback-a-project-using-the-rollback-pipeline/ for more information.',
+      'This project does not have a rollback pipeline configured. Rollback is not available for this specific project. To enable rollback functionality, a rollback pipeline must be configured in the project\'s CircleCI settings. See https://circleci.com/docs/deploy/set-up-rollbacks/',
     );
   }
 

--- a/src/tools/runRollbackPipeline/tool.ts
+++ b/src/tools/runRollbackPipeline/tool.ts
@@ -38,10 +38,19 @@ export const runRollbackPipelineTool = {
     - Never attempt to guess or construct project slugs or URLs; always use values provided by the user or from \`listFollowedProjects\`.
     - Do not prompt for missing parameters until versions have been listed.
     - Do not call this tool with incomplete parameters.
+    - If the selected project lacks rollback pipeline configuration, provide a definitive error message without suggesting alternative projects.
 
     **Returns:**
     - On success: The rollback ID.
     - On error: A clear message describing what is missing or what went wrong.
+    - If the selected project does not have a rollback pipeline configured: The tool will provide a clear error message specific to that project and will NOT suggest trying another project.
+
+    **Important Note:**
+    - This tool is designed to work only with the specific project provided by the user.
+    - If a project does not have rollback capability configured, the tool will NOT suggest alternatives or recommend trying other projects.
+    - The assistant should NOT suggest trying different projects when a project lacks rollback configuration.
+    - Each project must have its own rollback pipeline configuration to be eligible for rollback operations.
+    - When a project cannot be rolled back, provide only the configuration guidance for THAT specific project.
 
     If neither option is fully satisfied, prompt the user for the missing information before making the tool call.
   `,


### PR DESCRIPTION
as per title, it was sometimes suggesting to run other projects' rollback if the chosen project did not have a rollback pipeline defined. This is undesirable behaviour.