### PR TITLE
Changes for compatibility with Amazon Bedrock AgentCore Runtime and IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,20 +78,48 @@ Add the following to your cursor MCP config:
 }
 ```
 
-#### Using a Self-Managed Remote MCP Server
+#### Using Amazon Bedrock AgentCore Runtime to host your CircleCI MCP Server:
+
+Use [JSON Web Token (JWT) as the authentication inbound identity type](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-oauth.html) and add the following environment variables to Amazon Bedrock AgentCore Runtime when creating or updating the runtime [Learn more](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-getting-started.html):
+
+```bash
+CIRCLECI_TOKEN="your-circleci-token"
+start="remote"
+CIRCLECI_BASE_URL="https://circleci.com" # Optional - required for on-prem customers only
+debug="true" # Optional - for debugging requests and responses made to the mcp server
+```
+
+Add the following to your cursor MCP config json replacing the placeholders under with your values <>:
+
+```json
+{
+  "mcpServers": {
+    "circleci-mcp-server-bedrock": {
+      "url": "https://bedrock-agentcore.<AWS-REGION>.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3A<AWS-REGION>%3A<YOUR-AWS-ACCOUNT-ID>%3Aruntime%2F<YOUR-BEDROCK-AGENTCORE-RUNTIME-ID>/invocations?qualifier=<YOUR-BEDROCK-AGENTCORE-RUNTIME-ENDPOINT-NAME-OR-USE-DEFAULT>",
+      "headers": {
+        "Authorization": "Bearer <YOUR_OAUTH_TOKEN_FOR_AWS_BEDROCK_AGENTCORE_RUNTIME>"
+      }
+    }
+  }
+}
+```
+
+#### Using a Self-Managed Container Runtime to host your CircleCI MCP Server:
+
+Add the following environment variables to your self-managed container execution environment:
+
+```bash
+CIRCLECI_TOKEN="your-circleci-token"
+start="remote"
+CIRCLECI_BASE_URL="https://circleci.com" # Optional - required for on-prem customers only
+debug="true" # Optional - for debugging requests and responses made to the mcp server
+port="8000" # Optional - for specifying the port to use
+```
 
 Add the following to your cursor MCP config:
 
 ```json
 {
-  "inputs": [
-    {
-      "type": "promptString",
-      "id": "circleci-token", 
-      "description": "CircleCI API Token",
-      "password": true
-    }
-  ],
   "servers": {
     "circleci-mcp-server-remote": {
       "url": "http://your-circleci-remote-mcp-server-endpoint:8000/mcp"
@@ -160,7 +188,6 @@ To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using Docker:
     }
   ],
   "servers": {
-    // https://github.com/ppl-ai/modelcontextprotocol/
     "circleci-mcp-server": {
       "type": "stdio",
       "command": "docker",
@@ -183,15 +210,51 @@ To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using Docker:
 }
 ```
 
-#### Using a Self-Managed Remote MCP Server
+#### Using Amazon Bedrock AgentCore Runtime to host your CircleCI MCP Server:
 
-To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using a self-managed remote MCP server:
+Use [JSON Web Token (JWT) as the authentication inbound identity type](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-oauth.html) and add the following environment variables to Amazon Bedrock AgentCore Runtime when creating or updating the runtime [Learn more](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-getting-started.html):
+
+```bash
+CIRCLECI_TOKEN="your-circleci-token"
+start="remote"
+CIRCLECI_BASE_URL="https://circleci.com" # Optional - required for on-prem customers only
+debug="true" # Optional - for debugging requests and responses made to the mcp server
+```
+
+Add the following to your VS Code MCP config in `.vscode/mcp.json` replacing the placeholders under with your values <>:
+
+```json
+{
+  "servers": {
+    "circleci-mcp-server-bedrock": {
+      "url": "https://bedrock-agentcore.<AWS-REGION>.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3A<AWS-REGION>%3A<YOUR-AWS-ACCOUNT-ID>%3Aruntime%2F<YOUR-BEDROCK-AGENTCORE-RUNTIME-ID>/invocations?qualifier=<YOUR-BEDROCK-AGENTCORE-RUNTIME-ENDPOINT-NAME-OR-USE-DEFAULT>",
+      "headers": {
+        "Authorization": "Bearer <YOUR_OAUTH_TOKEN_FOR_AWS_BEDROCK_AGENTCORE_RUNTIME>"
+      }
+    }
+  }
+}
+```
+
+#### Using a Self-Managed Container Runtime to host your CircleCI MCP Server:
+
+Add the following environment variables to your self-managed container execution environment:
+
+```bash
+CIRCLECI_TOKEN="your-circleci-token"
+start="remote"
+CIRCLECI_BASE_URL="https://circleci.com" # Optional - required for on-prem customers only
+debug="true" # Optional - for debugging requests and responses made to the mcp server
+port="8000" # Optional - for specifying the port to use
+```
+
+Add the following to your VS Code MCP config in `.vscode/mcp.json`:
 
 ```json
 {
   "servers": {
     "circleci-mcp-server-remote": {
-      "type": "sse",
+      "type": "http",
       "url": "http://your-circleci-remote-mcp-server-endpoint:8000/mcp"
     }
   }
@@ -266,6 +329,43 @@ This will create a configuration file at:
 See the guide below for more information on using MCP servers with Claude Desktop:
 https://modelcontextprotocol.io/quickstart/user
 
+#### Using Amazon Bedrock AgentCore Runtime to host your CircleCI MCP Server:
+
+Use [JSON Web Token (JWT) as the authentication inbound identity type](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-oauth.html) and add the following environment variables to Amazon Bedrock AgentCore Runtime when creating or updating the runtime [Learn more](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-getting-started.html):
+
+```bash
+CIRCLECI_TOKEN="your-circleci-token"
+start="remote"
+CIRCLECI_BASE_URL="https://circleci.com" # Optional - required for on-prem customers only
+debug="true" # Optional - for debugging requests and responses made to the mcp server
+```
+
+Add the following to your Q Developer MCP config json replacing the placeholders under with your values <>:
+
+```json
+{
+  "mcpServers": {
+    "circleci-mcp-bedrock-agentcore": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "https://bedrock-agentcore.<AWS-REGION>.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3A<AWS-REGION>%3A<YOUR-AWS-ACCOUNT-ID>%3Aruntime%2F<YOUR-BEDROCK-AGENTCORE-RUNTIME-ID>/invocations?qualifier=<YOUR-BEDROCK-AGENTCORE-RUNTIME-ENDPOINT-NAME-OR-USE-DEFAULT>",
+        "--allow-http",
+        "--header",
+        "Content-Type: application/json",
+        "--header",
+        "Accept: application/json, text/event-stream",
+        "--header",
+        "Authorization: Bearer <YOUR_OAUTH_TOKEN_FOR_AWS_BEDROCK_AGENTCORE_RUNTIME>"
+      ],
+      "env": {},
+      "disabled": false
+    }
+  }
+}
+```
+
 #### Using a Self-Managed Remote MCP Server
 
 Create a wrapper script first
@@ -326,6 +426,23 @@ claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -e CIRC
 
 See the guide below for more information on using MCP servers with Claude Code:
 https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp
+
+#### Using Amazon Bedrock AgentCore Runtime to host your CircleCI MCP Server:
+
+Use [JSON Web Token (JWT) as the authentication inbound identity type](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-oauth.html) and add the following environment variables to Amazon Bedrock AgentCore Runtime when creating or updating the runtime [Learn more](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-getting-started.html):
+
+```bash
+CIRCLECI_TOKEN="your-circleci-token"
+start="remote"
+CIRCLECI_BASE_URL="https://circleci.com" # Optional - required for on-prem customers only
+debug="true" # Optional - for debugging requests and responses made to the mcp server
+```
+
+Execute the following command to add the CircleCI MCP Server to Claude Code replacing the placeholders under with your values <>:
+
+```bash
+claude mcp add --transport http secure-server https://bedrock-agentcore.<AWS-REGION>.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3A<AWS-REGION>%3A<YOUR-AWS-ACCOUNT-ID>%3Aruntime%2F<YOUR-BEDROCK-AGENTCORE-RUNTIME-ID>/invocations?qualifier=<YOUR-BEDROCK-AGENTCORE-RUNTIME-ENDPOINT-NAME-OR-USE-DEFAULT> --header "Authorization: Bearer <YOUR_OAUTH_TOKEN_FOR_AWS_BEDROCK_AGENTCORE_RUNTIME>"
+```
 
 #### Using Self-Managed Remote MCP Server
 
@@ -454,6 +571,43 @@ Edit your global configuration file ~/.aws/amazonq/mcp.json or create a new one 
 }
 ```
 
+#### Using Amazon Bedrock AgentCore Runtime to host your CircleCI MCP Server:
+
+Use [JSON Web Token (JWT) as the authentication inbound identity type](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-oauth.html) and add the following environment variables to Amazon Bedrock AgentCore Runtime when creating or updating the runtime [Learn more](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-getting-started.html):
+
+```bash
+CIRCLECI_TOKEN="your-circleci-token"
+start="remote"
+CIRCLECI_BASE_URL="https://circleci.com" # Optional - required for on-prem customers only
+debug="true" # Optional - for debugging requests and responses made to the mcp server
+```
+
+Add the following to your Q Developer MCP config json replacing the placeholders under with your values <>:
+
+```json
+{
+  "mcpServers": {
+    "circleci-mcp-bedrock-agentcore": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "https://bedrock-agentcore.<AWS-REGION>.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3A<AWS-REGION>%3A<YOUR-AWS-ACCOUNT-ID>%3Aruntime%2F<YOUR-BEDROCK-AGENTCORE-RUNTIME-ID>/invocations?qualifier=<YOUR-BEDROCK-AGENTCORE-RUNTIME-ENDPOINT-NAME-OR-USE-DEFAULT>",
+        "--allow-http",
+        "--header",
+        "Content-Type: application/json",
+        "--header",
+        "Accept: application/json, text/event-stream",
+        "--header",
+        "Authorization: Bearer <YOUR_OAUTH_TOKEN_FOR_AWS_BEDROCK_AGENTCORE_RUNTIME>"
+      ],
+      "env": {},
+      "disabled": false
+    }
+  }
+}
+```
+
 #### Using a Self-Managed Remote MCP Server
 
 Create a wrapper script first
@@ -498,6 +652,43 @@ Edit your global configuration file ~/.aws/amazonq/mcp.json or create a new one 
         "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
       },
       "timeout": 60000
+    }
+  }
+}
+```
+
+#### Using Amazon Bedrock AgentCore Runtime to host your CircleCI MCP Server:
+
+Use [JSON Web Token (JWT) as the authentication inbound identity type](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-oauth.html) and add the following environment variables to Amazon Bedrock AgentCore Runtime when creating or updating the runtime [Learn more](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-getting-started.html):
+
+```bash
+CIRCLECI_TOKEN="your-circleci-token"
+start="remote"
+CIRCLECI_BASE_URL="https://circleci.com" # Optional - required for on-prem customers only
+debug="true" # Optional - for debugging requests and responses made to the mcp server
+```
+
+Add the following to your Q Developer MCP config json replacing the placeholders under with your values <>:
+
+```json
+{
+  "mcpServers": {
+    "circleci-mcp-bedrock-agentcore": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "https://bedrock-agentcore.<AWS-REGION>.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3A<AWS-REGION>%3A<YOUR-AWS-ACCOUNT-ID>%3Aruntime%2F<YOUR-BEDROCK-AGENTCORE-RUNTIME-ID>/invocations?qualifier=<YOUR-BEDROCK-AGENTCORE-RUNTIME-ENDPOINT-NAME-OR-USE-DEFAULT>",
+        "--allow-http",
+        "--header",
+        "Content-Type: application/json",
+        "--header",
+        "Accept: application/json, text/event-stream",
+        "--header",
+        "Authorization: Bearer <YOUR_OAUTH_TOKEN_FOR_AWS_BEDROCK_AGENTCORE_RUNTIME>"
+      ],
+      "env": {},
+      "disabled": false
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.12.0",
+  "version": "0.11.2",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
-    "@types/express": "5.0.3",
+    "@types/express": "^4.17.21",
     "@types/node": "^22",
     "@types/parse-github-url": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^8.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^9.21.0
         version: 9.23.0
       '@types/express':
-        specifier: 5.0.3
-        version: 5.0.3
+        specifier: ^4.17.21
+        version: 4.17.23
       '@types/node':
         specifier: ^22
         version: 22.13.13
@@ -419,11 +419,11 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
-  '@types/express-serve-static-core@5.0.6':
-    resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
+  '@types/express-serve-static-core@4.19.6':
+    resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
 
-  '@types/express@5.0.3':
-    resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
+  '@types/express@4.17.23':
+    resolution: {integrity: sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==}
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
@@ -1918,17 +1918,18 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
-  '@types/express-serve-static-core@5.0.6':
+  '@types/express-serve-static-core@4.19.6':
     dependencies:
       '@types/node': 22.13.13
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
 
-  '@types/express@5.0.3':
+  '@types/express@4.17.23':
     dependencies:
       '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 5.0.6
+      '@types/express-serve-static-core': 4.19.6
+      '@types/qs': 6.14.0
       '@types/serve-static': 1.15.8
 
   '@types/http-errors@2.0.5': {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,84 +1,106 @@
 #!/usr/bin/env node
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-
 import { CCI_HANDLERS, CCI_TOOLS } from './circleci-tools.js';
 import { createUnifiedTransport } from './transports/unified.js';
 import { createStdioTransport } from './transports/stdio.js';
 
-const server = new McpServer(
-  { name: 'mcp-server-circleci', version: '1.0.0' },
-  { capabilities: { tools: {}, resources: {} } },
-);
-
-// ---- DEBUG WRAPPERS --------------------------------------------------
-if (process.env.debug === 'true') {
-  const srv: any = server;
-
-  if (typeof srv.notification === 'function') {
-    const origNotify = srv.notification.bind(server);
-    srv.notification = async (...args: any[]) => {
-      try {
-        const [{ method, params }] = args;
-        console.log(
-          '[DEBUG] outgoing notification:',
-          method,
-          JSON.stringify(params),
-        );
-      } catch {
-        /* ignore */
-      }
-      return origNotify(...args);
-    };
-  }
-
-  if (typeof srv.request === 'function') {
-    const origRequest = srv.request.bind(server);
-    srv.request = async (...args: any[]) => {
-      const [payload] = args;
-      const result = await origRequest(...args);
-      console.log(
-        '[DEBUG] response to',
-        payload?.method,
-        JSON.stringify(result).slice(0, 200),
-      );
-      return result;
-    };
-  }
-}
-
-// Register all CircleCI tools once
-if (process.env.debug === 'true') {
-  console.log('[DEBUG] [Startup] Registering CircleCI MCP tools...');
-}
-// Ensure we advertise support for tools/list in capabilities (SDK only sets listChanged)
-(server as any).server.registerCapabilities({ tools: { list: true } });
-
-CCI_TOOLS.forEach((tool) => {
-  const handler = CCI_HANDLERS[tool.name];
-  if (!handler) throw new Error(`Handler for tool ${tool.name} not found`);
-  if (process.env.debug === 'true') {
-    console.log(`[DEBUG] [Startup] Registering tool: ${tool.name}`);
-  }
-  server.tool(
-    tool.name,
-    tool.description,
-    { params: tool.inputSchema.optional() },
-    handler as any,
-  );
-});
-
 async function main() {
+  // Start the appropriate transport
   if (process.env.start === 'remote') {
-    console.log('Starting CircleCI MCP unified HTTP+SSE server...');
-    createUnifiedTransport(server);
+    console.log('Starting CircleCI MCP remote server...');
+    // In stateless mode, the transport handles server creation.
+    await createUnifiedTransport();
   } else {
     console.log('Starting CircleCI MCP server in stdio mode...');
-    createStdioTransport(server);
+    // In stateful stdio mode, create and configure a single server instance.
+    const server = new McpServer(
+      { name: 'mcp-server-circleci', version: '1.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+
+    // ---- DEBUG WRAPPERS --------------------------------------------------
+    if (process.env.debug === 'true') {
+      const srv: any = server;
+
+      if (typeof srv.notification === 'function') {
+        const origNotify = srv.notification.bind(server);
+        srv.notification = async (...args: any[]) => {
+          try {
+            const [{ method, params }] = args;
+            console.log(
+              '[DEBUG] outgoing notification:',
+              method,
+              JSON.stringify(params),
+            );
+          } catch {
+            /* ignore */
+          }
+          return origNotify(...args);
+        };
+      }
+
+      if (typeof srv.request === 'function') {
+        const origRequest = srv.request.bind(server);
+        srv.request = async (...args: any[]) => {
+          const [payload] = args;
+          const result = await origRequest(...args);
+          console.log(
+            '[DEBUG] response to',
+            payload?.method,
+            JSON.stringify(result).slice(0, 200),
+          );
+          return result;
+        };
+      }
+    }
+
+    // Register all CircleCI tools once
+    if (process.env.debug === 'true') {
+      console.log('[DEBUG] [Startup] Registering CircleCI MCP tools...');
+    }
+    
+    // Ensure we advertise support for tools/list in capabilities (SDK only sets listChanged)
+    (server as any).server.registerCapabilities({ tools: { list: true } });
+
+    CCI_TOOLS.forEach((tool) => {
+      const handler = CCI_HANDLERS[tool.name as keyof typeof CCI_HANDLERS];
+      if (!handler) {
+        console.error(`[ERROR] Handler not found for tool: ${tool.name}`);
+        console.error(`[ERROR] Available handlers:`, Object.keys(CCI_HANDLERS));
+        throw new Error(`Handler for tool ${tool.name} not found`);
+      }
+      
+      if (process.env.debug === 'true') {
+        console.log(`[DEBUG] [Startup] Registering tool: ${tool.name}`);
+      }
+      
+      // Register with server.tool() - it will add the 'tools/' prefix internally
+      server.tool(
+        tool.name,
+        tool.description,
+        { params: tool.inputSchema.optional() },
+        handler as any,
+      );
+    });
+
+    await createStdioTransport(server);
   }
 }
 
+// Error handling for uncaught exceptions
+process.on('uncaughtException', (error) => {
+  console.error('[FATAL] Uncaught exception:', error);
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('[FATAL] Unhandled rejection at:', promise, 'reason:', reason);
+  process.exit(1);
+});
+
+// Start the server
 main().catch((err) => {
-  console.error('Server error:', err);
+  console.error('[FATAL] Server error:', err);
   process.exit(1);
 });

--- a/src/transports/unified.ts
+++ b/src/transports/unified.ts
@@ -1,138 +1,224 @@
 import express from 'express';
+import type { Request, Response } from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { CCI_HANDLERS, CCI_TOOLS } from '../circleci-tools.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import type { Response } from 'express';
 
-// Debug subclass that logs every payload sent over SSE
-class DebugSSETransport extends SSEServerTransport {
-  constructor(path: string, res: Response) {
-    super(path, res);
-  }
-  override async send(payload: any) {
-    if (process.env.debug === 'true') {
-      console.log('[DEBUG] SSE out ->', JSON.stringify(payload));
+// Augment the express request type to include our custom properties
+declare global {
+  namespace Express {
+    interface Request {
+      requestId?: string;
     }
-    return super.send(payload);
   }
 }
 
+// Enhanced debugging middleware
+const createDebugMiddleware = () => {
+  return (req: Request, res: Response, next: any) => {
+    if (process.env.debug === 'true') {
+      const timestamp = new Date().toISOString();
+      const requestId = Math.random().toString(36).substring(7);
+      
+      console.log(`\n[DEBUG] [${timestamp}] [REQ-${requestId}] ======== INCOMING REQUEST ========`);
+      console.log(`[DEBUG] [REQ-${requestId}] Method: ${req.method}`);
+      console.log(`[DEBUG] [REQ-${requestId}] URL: ${req.url}`);
+      console.log(`[DEBUG] [REQ-${requestId}] Headers:`, req.headers);
+      console.log(`[DEBUG] [REQ-${requestId}] Body:`, req.body);
+      
+      // Add request ID to req for tracking
+      req.requestId = requestId;
+      
+      // Capture response body for logging
+      const chunks: any[] = [];
+      const originalWrite = res.write;
+      const originalEnd = res.end;
+
+      res.write = function(chunk: any, ...args: any[]) {
+        chunks.push(Buffer.from(chunk));
+        return (originalWrite as Function).apply(res, [chunk, ...args]);
+      };
+
+      res.end = function(chunk?: any, ...args: any[]) {
+        if (chunk) {
+          chunks.push(Buffer.from(chunk));
+        }
+        return (originalEnd as Function).apply(res, [chunk, ...args]);
+      };
+      
+      // Log response when it's finished
+      res.on('finish', () => {
+        if (process.env.debug === 'true') {
+          const body = Buffer.concat(chunks).toString('utf8');
+          console.log(`[DEBUG] [REQ-${req.requestId}] ======== RESPONSE SENT ========`);
+          console.log(`[DEBUG] [REQ-${req.requestId}] Status: ${res.statusCode}`);
+          console.log(`[DEBUG] [REQ-${req.requestId}] Headers:`, res.getHeaders());
+          console.log(`[DEBUG] [REQ-${req.requestId}] Body:`, body);
+        }
+      });
+    }
+    next();
+  };
+};
+
 /**
- * Unified MCP transport: Streamable HTTP + SSE on same app/port/session.
- * - POST /mcp: JSON-RPC (single or chunked JSON)
- * - GET /mcp: SSE stream (server-initiated notifications)
- * - DELETE /mcp: Session termination
+ * Stateless MCP transport using StreamableHTTPServerTransport
+ * In stateless mode, we create a new transport and server instance for each request
+ * to ensure complete isolation. No session management or SSE streams.
  */
-export const createUnifiedTransport = (server: McpServer) => {
+/**
+ * Creates a new McpServer instance, configured with CircleCI tools.
+ * This factory is used to create a fresh server for each request in stateless mode.
+ */
+const getServer = () => {
+  const server = new McpServer(
+    { name: 'mcp-server-circleci', version: '1.0.0' },
+    // Disable client-side namespacing for tool names
+    { capabilities: { namespace: false, tools: {}, resources: {} } },
+  );
+
+  // Ensure we advertise support for tools/list in capabilities
+  (server as any).server.registerCapabilities({ tools: { list: true } });
+
+  // Register all CircleCI tools
+  CCI_TOOLS.forEach((tool) => {
+    const handler = CCI_HANDLERS[tool.name as keyof typeof CCI_HANDLERS];
+    if (!handler) {
+      console.error(`[ERROR] Handler not found for tool: ${tool.name}`);
+      throw new Error(`Handler for tool ${tool.name} not found`);
+    }
+    server.tool(
+      tool.name,
+      tool.description,
+      { params: tool.inputSchema.optional() },
+      handler as any,
+    );
+  });
+
+  return server;
+};
+
+/**
+ * Stateless MCP transport using StreamableHTTPServerTransport
+ * In stateless mode, we create a new transport and server instance for each request
+ * to ensure complete isolation. No session management or SSE streams.
+ */
+export const createUnifiedTransport = async () => {
   const app = express();
+  
+  // Parse JSON bodies first, so it's available in the debugger
   app.use(express.json());
 
-  // Stateless: No in-memory session or transport store
+  // Add debugging middleware
+  app.use(createDebugMiddleware());
 
-  // Health check
-  app.get('/ping', (_req, res) => {
-    res.json({ result: 'pong' });
-  });
-
-  // GET /mcp → open SSE stream, assign session if needed (stateless)
-  app.get('/mcp', (req, res) => {
-    (async () => {
-      if (process.env.debug === 'true') {
-        const sessionId =
-          req.header('Mcp-Session-Id') ||
-          req.header('mcp-session-id') ||
-          (req.query.sessionId as string);
-        console.log(`[DEBUG] [GET /mcp] Incoming session:`, sessionId);
-      }
-      // Create SSE transport (stateless)
-      const transport = new DebugSSETransport('/mcp', res);
-      if (process.env.debug === 'true') {
-        console.log(`[DEBUG] [GET /mcp] Created SSE transport.`);
-      }
-      await server.connect(transport);
-      // Notify newly connected client of current tool catalogue
-      await server.sendToolListChanged();
-      // SSE connection will be closed by client or on disconnect
-    })().catch((err) => {
-      console.error('GET /mcp error:', err);
-      if (!res.headersSent) res.status(500).end();
+  // Health check - AgentCore compatible (supports GET and POST)
+  const handlePing = (req: Request, res: Response) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(200).json({
+      status: 'Healthy',
+      time_of_last_update: Math.floor(Date.now() / 1000)
     });
-  });
-
-  // POST /mcp → Streamable HTTP, session-aware
-  app.post('/mcp', (req, res) => {
-    (async () => {
-      try {
-        if (process.env.debug === 'true') {
-          const names = Object.keys((server as any)._registeredTools ?? {});
-          console.log(`[DEBUG] visible tools:`, names);
-          console.log(
-            `[DEBUG] incoming request body:`,
-            JSON.stringify(req.body),
-          );
-        }
-
-        // For each POST, create a temporary, stateless transport to handle the request/response cycle.
-        const httpTransport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: undefined, // Ensures stateless operation
-        });
-
-        // Connect the server to the transport. This wires the server's internal `_handleRequest`
-        // method to the transport's `onmessage` event.
-        await server.connect(httpTransport);
-
-        // Handle the request. The transport will receive the request, pass it to the server via
-        // `onmessage`, receive the response from the server via its `send` method, and then
-        // write the response back to the client over the HTTP connection.
-        await httpTransport.handleRequest(req, res, req.body);
-
-        // After responding to initialize, send tool catalogue again so the freshly initialised
-        // client is guaranteed to see it (the first notification may have been sent before it
-        // started listening on the SSE stream).
-        if (req.body?.method === 'initialize') {
-          if (process.env.debug === 'true') {
-            console.log(
-              '[DEBUG] initialize handled -> sending tools/list_changed again',
-            );
-          }
-          await server.sendToolListChanged();
-        }
-      } catch (error: any) {
-        console.error('Error handling MCP request:', error);
-        if (!res.headersSent) {
-          res.status(500).json({
-            jsonrpc: '2.0',
-            error: {
-              code: -32603,
-              message: 'Internal server error',
-              data: error.message,
-            },
-            id: req.body?.id || null,
-          });
-        }
-      }
-    })().catch((err) => {
-      console.error('POST /mcp error:', err);
-      if (!res.headersSent) res.status(500).end();
-    });
-  });
-
-  // DELETE /mcp → stateless: acknowledge only
-  app.delete('/mcp', (req, res) => {
-    const sessionId =
-      req.header('Mcp-Session-Id') ||
-      req.header('mcp-session-id') ||
-      (req.query.sessionId as string);
+    
     if (process.env.debug === 'true') {
-      console.log(`[DEBUG] [DELETE /mcp] Incoming sessionId:`, sessionId);
+      console.log(`[DEBUG] [PING] Health check responded for ${req.method} /ping`);
     }
-    res.status(204).end();
+  };
+
+  app.get('/ping', handlePing);
+  app.post('/ping', handlePing);
+
+  // POST /mcp - Handle JSON-RPC requests in stateless mode
+  app.post('/mcp', async (req: Request, res: Response) => {
+    // Handle Bedrock AgentCore's JSON-RPC ping before it hits the main MCP handler
+    if (req.body && req.body.method === 'ping') {
+      if (process.env.debug === 'true') {
+        console.log(`[DEBUG] [PING] Handled JSON-RPC ping`);
+      }
+      return res.status(200).json({
+        jsonrpc: '2.0',
+        result: { status: 'Healthy' , time_of_last_update: Math.floor(Date.now() / 1000)},
+        id: req.body.id,
+      });
+    }
+
+    // In stateless mode, create a new instance of transport and server for each request
+    // to ensure complete isolation. A single instance would cause request ID collisions
+    // when multiple clients connect concurrently.
+    try {
+      const server = getServer();
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+      });
+
+      res.on('close', () => {
+        if (process.env.debug === 'true') {
+          console.log('Request closed');
+        }
+        transport.close();
+        server.close();
+      });
+
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      console.error('Error handling MCP request:', error);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32603,
+            message: 'Internal server error',
+          },
+          id: null,
+        });
+      }
+    }
+  });
+
+  // GET /mcp - SSE notifications not supported in stateless mode
+  app.get('/mcp', async (req: Request, res: Response) => {
+    if (process.env.debug === 'true') {
+      console.log('Received GET MCP request');
+    }
+    res.writeHead(405).end(JSON.stringify({
+      jsonrpc: "2.0",
+      error: {
+        code: -32000,
+        message: "Method not allowed."
+      },
+      id: null
+    }));
+  });
+
+  // DELETE /mcp - Session termination not needed in stateless mode
+  app.delete('/mcp', async (req: Request, res: Response) => {
+    if (process.env.debug === 'true') {
+      console.log('Received DELETE MCP request');
+    }
+    res.writeHead(405).end(JSON.stringify({
+      jsonrpc: "2.0",
+      error: {
+        code: -32000,
+        message: "Method not allowed."
+      },
+      id: null
+    }));
   });
 
   const port = process.env.port || 8000;
   app.listen(port, () => {
-    console.log(
-      `CircleCI MCP unified HTTP+SSE server listening on http://0.0.0.0:${port}`,
-    );
+    console.log(`CircleCI MCP server listening on http://0.0.0.0:${port}`);
+    
+    if (process.env.debug === 'true') {
+      console.log('\n[DEBUG] ======== DEBUG MODE ENABLED ========');
+      console.log('[DEBUG] MCP Server using StreamableHTTPServerTransport');
+      console.log('[DEBUG] Endpoints:');
+      console.log(`[DEBUG]   GET  /ping - Health check`);
+      console.log(`[DEBUG]   POST /mcp  - JSON-RPC requests`);
+      console.log(`[DEBUG]   GET  /mcp  - SSE stream (if supported by client)`);
+      console.log(`[DEBUG]   DELETE /mcp - Close session`);
+      console.log('[DEBUG] =====================================\n');
+    }
   });
 };


### PR DESCRIPTION
Changes to fix streamable http to be compatible with the MCP server being deployed on Amazon Bedrock AgentCore Runtime to work with IDEs that would be calling it directly