### PR TITLE
[REL-4165] Splitting part of the rollback tool logic into a new list component versions tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.12.0] - 2025-08-01
+## [0.13.0] - 2025-08-05
+
+### Added
+
+- Added `listComponentVersions` tool to list all versions for a CircleCI component
+
+### Changed
+
+- Simplified `runRollbackPipeline` tool by moving part of its inner logic to `listComponentVersions`.
+
+## [0.12.2] - 2025-08-01
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -855,39 +855,35 @@ Click the Save button.
 
 - `run_rollback_pipeline`
 
-  Run a rollback pipeline for a CircleCI project. This tool guides you through the full rollback process, adapting to the information you provide and prompting for any missing details.
+  This tool allows for triggering a rollback for a project.
+  It requires the following parameters;
 
-  **Initial Step:**
-  - First, call the `list_followed_projects` tool to retrieve the list of projects the user follows.
-  - Then, ask the user to select a project by providing either a `projectID` or the exact `projectSlug` as returned by `list_followed_projects`.
+  - `project_id` - The ID of the CircleCI project (UUID)
+  - `environmentName` - The environment name
+  - `componentName` - The component name
+  - `currentVersion` - The current version
+  - `targetVersion` - The target version
+  - `namespace` - The namespace of the component
+  - `reason` - The reason for the rollback (optional)
+  - `parameters` - The extra parameters for the rollback pipeline (optional)
 
-    **Typical Flow:**
-    1. **Start:** User initiates a rollback request.
-    2. **Project Selection:** If a \`projectSlug\` or \`projectID\` is not provided, call \`listFollowedProjects\` and prompt the user to select a project using the exact value returned.
-    3. **Execute the tool and list the versions.**
-    4. **Workflow Rerun:** 
-       - Inform the user of the fact that no rollback pipeline is defined for this project.
-       - Ask the user if they want to rerun a workflow.
-       - If the user wants to rerun a workflow, execute the tool with rollback_type set to \`WORKFLOW_RERUN\`. Do not propose to choose another project.
-    6. **Component Selection:** 
-       - If the project has multiple components, present up to 20 options for the user to choose from.
-       - If there is only one component, proceed automatically and do not ask the user to select a component.
-    7. **Environment Selection:** 
-       - If the project has multiple environments, present up to 20 options for the user to choose from.
-       - If there is only one environment, proceed automatically and do not ask the user to select an environment.
-    8. **Version Selection:** 
-       - Present the user with available versions to rollback to, based on the selected environment and component. Include the namespace for each version.
-       - Ask for both the current deployed version and the target version to rollback to.
-    9. **Optional Details:** 
-       - If the rollback type is \`PIPELINE\`, prompt the user for an optional reason for the rollback (e.g., "Critical bug fix").
-       - If the rollback type is \`WORKFLOW_RERUN\`, provide the workflow ID of the selected version to the tool.
-       - provide the namespace for the selected version to the tool.
-    10. **Confirmation:** 
-       - Summarize the rollback request and confirm with the user before submitting.
+  If not all the parameters are provided right away, the toll will make use of other tools to try and retrieve all the required info.
+  The rollback can be performed in two different way, depending on whether a rollback pipeline definition has been configured for the project:
 
-  **Returns:**
-  - On success: The rollback ID or a confirmation in case of workflow rerun.
-  - On error: A clear message describing what is missing or what went wrong.
+  - Pipeline Rollback: will trigger the rollback pipeline.
+  - Workflow Rerun: will trigger the rerun of a previous workflow.
+
+  A typical interaction with this tool will follow this pattern:
+
+  1. Project Selection - Retrieve list of followed projects and prompt user to select one
+  2. Environment Selection - List available environments and select target (auto-select if only one exists)
+  3. Component Selection - List available components and select target (auto-select if only one exists)
+  4. Version Selection - Display available versions, user selects non-live version for rollback
+  5. Rollback Mode Detection - Check if rollback pipeline is configured for the selected project
+  6. Execute Rollback - Two options available:
+    - Pipeline Rollback: Prompt for optional reason, execute rollback pipeline
+    - Workflow Rerun**: Rerun workflow using selected version's workflow ID
+  7. Confirmation - Summarize rollback request and confirm before execution
 
 - `rerun_workflow`
 
@@ -935,6 +931,52 @@ Click the Save button.
   - Catching rule violations before code review
 
   The tool integrates with your existing cursor rules setup and provides immediate feedback on code quality, helping you catch issues early in the development process.
+
+- `list_component_versions`
+
+  Lists all versions for a specific CircleCI component in an environment. This tool retrieves version history including deployment status, commit information, and timestamps for a component.
+  The tool will prompt the user to select the component and environment from a list if not provided.
+
+  Example output:
+
+  ```
+  Versions for the component: {
+    "items": [
+      {
+        "name": "v1.2.0",
+        "namespace": "production",
+        "environment_id": "env-456def",
+        "is_live": true,
+        "pipeline_id": "12345678-1234-1234-1234-123456789abc",
+        "workflow_id": "87654321-4321-4321-4321-cba987654321",
+        "job_id": "11111111-1111-1111-1111-111111111111",
+        "job_number": 42,
+        "last_deployed_at": "2023-01-01T00:00:00Z"
+      },
+      {
+        "name": "v1.1.0",
+        "namespace": "production", 
+        "environment_id": "env-456def",
+        "is_live": false,
+        "pipeline_id": "22222222-2222-2222-2222-222222222222",
+        "workflow_id": "33333333-3333-3333-3333-333333333333",
+        "job_id": "44444444-4444-4444-4444-444444444444",
+        "job_number": 38,
+        "last_deployed_at": "2023-01-03T00:00:00Z"
+      }
+    ]
+  }
+  ```
+
+  This is useful for:
+
+  - Identifying which versions were deployed for a component
+  - Finding the currently live version in an environment
+  - Selecting target versions for rollback operations
+  - Getting deployment details like pipeline, workflow, and job information
+  - Listing all environments
+  - Listing all components
+
 
 # Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/circleci-tools.ts
+++ b/src/circleci-tools.ts
@@ -26,6 +26,9 @@ import { analyzeDiff } from './tools/analyzeDiff/handler.js';
 import { runRollbackPipelineTool } from './tools/runRollbackPipeline/tool.js';
 import { runRollbackPipeline } from './tools/runRollbackPipeline/handler.js';
 
+import { listComponentVersionsTool } from './tools/listComponentVersions/tool.js';
+import { listComponentVersions } from './tools/listComponentVersions/handler.js';
+
 // Define the tools with their configurations
 export const CCI_TOOLS = [
   getBuildFailureLogsTool,
@@ -41,6 +44,7 @@ export const CCI_TOOLS = [
   rerunWorkflowTool,
   analyzeDiffTool,
   runRollbackPipelineTool,
+  listComponentVersionsTool,
 ];
 
 // Extract the tool names as a union type
@@ -69,4 +73,5 @@ export const CCI_HANDLERS = {
   rerun_workflow: rerunWorkflow,
   analyze_diff: analyzeDiff,
   run_rollback_pipeline: runRollbackPipeline,
+  list_component_versions: listComponentVersions,
 } satisfies ToolHandlers;

--- a/src/clients/circleci/deploys.ts
+++ b/src/clients/circleci/deploys.ts
@@ -34,7 +34,6 @@ export class DeploysAPI {
   }: {
     componentID: string;
     environmentID: string;
-    workflowID?: string;
   }): Promise<DeployComponentVersionsResponse> {
     const rawResult = await this.client.get<unknown>(
       `/deploy/components/${componentID}/versions?environment-id=${environmentID}`

--- a/src/tools/listComponentVersions/handler.test.ts
+++ b/src/tools/listComponentVersions/handler.test.ts
@@ -1,0 +1,512 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listComponentVersions } from './handler.js';
+import * as clientModule from '../../clients/client.js';
+
+vi.mock('../../clients/client.js');
+
+describe('listComponentVersions handler', () => {
+  const mockCircleCIClient = {
+    deploys: {
+      fetchComponentVersions: vi.fn(),
+      fetchEnvironments: vi.fn(),
+      fetchProjectComponents: vi.fn(),
+    },
+    projects: {
+      getProject: vi.fn(),
+      getProjectByID: vi.fn(),
+    },
+  };
+
+  const mockExtra = {
+    signal: new AbortController().signal,
+    requestId: 'test-id',
+    sendNotification: vi.fn(),
+    sendRequest: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(clientModule, 'getCircleCIClient').mockReturnValue(
+      mockCircleCIClient as any,
+    );
+  });
+
+  it('should return the formatted component versions when found', async () => {
+    const mockComponentVersions = {
+      items: [
+        {
+          id: 'version-1',
+          component_id: 'test-component-id',
+          environment_id: 'test-environment-id',
+          version: '1.0.0',
+          sha: 'abc123',
+          created_at: '2023-01-01T00:00:00Z',
+          updated_at: '2023-01-02T00:00:00Z',
+          is_live: true,
+        },
+        {
+          id: 'version-2',
+          component_id: 'test-component-id',
+          environment_id: 'test-environment-id',
+          version: '1.1.0',
+          sha: 'def456',
+          created_at: '2023-01-03T00:00:00Z',
+          updated_at: '2023-01-04T00:00:00Z',
+          is_live: false,
+        },
+      ],
+      next_page_token: null,
+    };
+
+    // Mock project resolution
+    mockCircleCIClient.projects.getProject.mockResolvedValue({
+      id: 'test-project-id',
+      organization_id: 'test-org-id',
+    });
+
+    mockCircleCIClient.deploys.fetchComponentVersions.mockResolvedValue(mockComponentVersions);
+
+    const args = {
+      params: {
+        projectSlug: 'gh/test-org/test-repo',
+        componentID: 'test-component-id',
+        environmentID: 'test-environment-id',
+      },
+    } as any;
+
+    const response = await listComponentVersions(args, mockExtra);
+
+    expect(response).toHaveProperty('content');
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+    expect(response.content[0].text).toContain('Versions for the component:');
+    expect(response.content[0].text).toContain(JSON.stringify(mockComponentVersions));
+    
+    expect(mockCircleCIClient.projects.getProject).toHaveBeenCalledTimes(1);
+    expect(mockCircleCIClient.projects.getProject).toHaveBeenCalledWith({
+      projectSlug: 'gh/test-org/test-repo',
+    });
+    expect(mockCircleCIClient.deploys.fetchComponentVersions).toHaveBeenCalledTimes(1);
+    expect(mockCircleCIClient.deploys.fetchComponentVersions).toHaveBeenCalledWith({
+        componentID: 'test-component-id',
+        environmentID: 'test-environment-id',
+      });
+  });
+
+  it('should return "No component versions found" when component versions list is empty', async () => {
+    // Mock project resolution
+    mockCircleCIClient.projects.getProject.mockResolvedValue({
+      id: 'test-project-id',
+      organization_id: 'test-org-id',
+    });
+
+    mockCircleCIClient.deploys.fetchComponentVersions.mockResolvedValue({
+      items: [],
+      next_page_token: null,
+    });
+
+    const args = {
+      params: {
+        projectSlug: 'gh/test-org/test-repo',
+        componentID: 'test-component-id',
+        environmentID: 'test-environment-id',
+      },
+    } as any;
+
+    const response = await listComponentVersions(args, mockExtra);
+
+    expect(response).toHaveProperty('content');
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+    expect(response.content[0].text).toBe('No component versions found');
+  });
+
+  it('should handle API errors gracefully', async () => {
+    const errorMessage = 'Component versions API request failed';
+    
+    // Mock project resolution
+    mockCircleCIClient.projects.getProject.mockResolvedValue({
+      id: 'test-project-id',
+      organization_id: 'test-org-id',
+    });
+
+    mockCircleCIClient.deploys.fetchComponentVersions.mockRejectedValue(
+      new Error(errorMessage),
+    );
+
+    const args = {
+      params: {
+        projectSlug: 'gh/test-org/test-repo',
+        componentID: 'test-component-id',
+        environmentID: 'test-environment-id',
+      },
+    } as any;
+
+    const response = await listComponentVersions(args, mockExtra);
+
+    expect(response).toHaveProperty('content');
+    expect(response).toHaveProperty('isError', true);
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+    expect(response.content[0].text).toContain('Failed to list component versions:');
+    expect(response.content[0].text).toContain(errorMessage);
+  });
+
+  it('should handle non-Error exceptions gracefully', async () => {
+    // Mock project resolution
+    mockCircleCIClient.projects.getProject.mockResolvedValue({
+      id: 'test-project-id',
+      organization_id: 'test-org-id',
+    });
+
+    mockCircleCIClient.deploys.fetchComponentVersions.mockRejectedValue(
+      'Unexpected error',
+    );
+
+    const args = {
+      params: {
+        projectSlug: 'gh/test-org/test-repo',
+        componentID: 'test-component-id',
+        environmentID: 'test-environment-id',
+      },
+    } as any;
+
+    const response = await listComponentVersions(args, mockExtra);
+
+    expect(response).toHaveProperty('content');
+    expect(response).toHaveProperty('isError', true);
+    expect(Array.isArray(response.content)).toBe(true);
+    expect(response.content[0]).toHaveProperty('type', 'text');
+    expect(typeof response.content[0].text).toBe('string');
+    expect(response.content[0].text).toContain('Failed to list component versions:');
+    expect(response.content[0].text).toContain('Unknown error');
+  });
+
+  describe('Project resolution scenarios', () => {
+    it('should use projectID and orgID directly when both are provided', async () => {
+      const mockComponentVersions = {
+        items: [
+          {
+            id: 'version-1',
+            component_id: 'test-component-id',
+            environment_id: 'test-environment-id',
+            version: '1.0.0',
+            sha: 'abc123',
+            created_at: '2023-01-01T00:00:00Z',
+            updated_at: '2023-01-02T00:00:00Z',
+            is_live: true,
+          },
+        ],
+        next_page_token: null,
+      };
+
+      mockCircleCIClient.deploys.fetchComponentVersions.mockResolvedValue(mockComponentVersions);
+
+      const args = {
+        params: {
+          projectID: 'test-project-id',
+          orgID: 'test-org-id',
+          componentID: 'test-component-id',
+          environmentID: 'test-environment-id',
+        },
+      } as any;
+
+      const response = await listComponentVersions(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toContain('Versions for the component:');
+      
+      // Should not call project resolution methods when both IDs are provided
+      expect(mockCircleCIClient.projects.getProject).not.toHaveBeenCalled();
+      expect(mockCircleCIClient.projects.getProjectByID).not.toHaveBeenCalled();
+      expect(mockCircleCIClient.deploys.fetchComponentVersions).toHaveBeenCalledWith({
+        componentID: 'test-component-id',
+        environmentID: 'test-environment-id',
+      });
+    });
+
+    it('should resolve orgID from projectID when only projectID is provided', async () => {
+      const mockComponentVersions = {
+        items: [
+          {
+            id: 'version-1',
+            component_id: 'test-component-id',
+            environment_id: 'test-environment-id',
+            version: '1.0.0',
+            sha: 'abc123',
+            created_at: '2023-01-01T00:00:00Z',
+            updated_at: '2023-01-02T00:00:00Z',
+            is_live: true,
+          },
+        ],
+        next_page_token: null,
+      };
+
+      mockCircleCIClient.projects.getProjectByID.mockResolvedValue({
+        id: 'test-project-id',
+        organization_id: 'resolved-org-id',
+      });
+
+      mockCircleCIClient.deploys.fetchComponentVersions.mockResolvedValue(mockComponentVersions);
+
+      const args = {
+        params: {
+          projectID: 'test-project-id',
+          componentID: 'test-component-id',
+          environmentID: 'test-environment-id',
+        },
+      } as any;
+
+      const response = await listComponentVersions(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toContain('Versions for the component:');
+      
+      expect(mockCircleCIClient.projects.getProjectByID).toHaveBeenCalledWith({
+        projectID: 'test-project-id',
+      });
+      expect(mockCircleCIClient.projects.getProject).not.toHaveBeenCalled();
+    });
+
+    it('should handle project resolution errors for projectSlug', async () => {
+      const errorMessage = 'Project not found';
+      
+      mockCircleCIClient.projects.getProject.mockRejectedValue(
+        new Error(errorMessage),
+      );
+
+      const args = {
+        params: {
+          projectSlug: 'gh/invalid/repo',
+          componentID: 'test-component-id',
+          environmentID: 'test-environment-id',
+        },
+      } as any;
+
+      const response = await listComponentVersions(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response).toHaveProperty('isError', true);
+      expect(response.content[0].text).toContain('Failed to resolve project information for gh/invalid/repo');
+      expect(response.content[0].text).toContain(errorMessage);
+    });
+
+    it('should handle project resolution errors for projectID', async () => {
+      const errorMessage = 'Project ID not found';
+      
+      mockCircleCIClient.projects.getProjectByID.mockRejectedValue(
+        new Error(errorMessage),
+      );
+
+      const args = {
+        params: {
+          projectID: 'invalid-project-id',
+          componentID: 'test-component-id',
+          environmentID: 'test-environment-id',
+        },
+      } as any;
+
+      const response = await listComponentVersions(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response).toHaveProperty('isError', true);
+      expect(response.content[0].text).toContain('Failed to resolve project information for project ID invalid-project-id');
+      expect(response.content[0].text).toContain(errorMessage);
+    });
+
+    it('should return error when neither projectSlug nor projectID is provided', async () => {
+      const args = {
+        params: {
+          componentID: 'test-component-id',
+          environmentID: 'test-environment-id',
+        },
+      } as any;
+
+      const response = await listComponentVersions(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response).toHaveProperty('isError', true);
+      expect(response.content[0].text).toContain('Invalid request. Please specify either a project slug or a project ID.');
+    });
+  });
+
+  describe('Missing environmentID scenarios', () => {
+    it('should list environments when environmentID is not provided', async () => {
+      const mockEnvironments = {
+        items: [
+          { id: 'env-1', name: 'production' },
+          { id: 'env-2', name: 'staging' },
+        ],
+        next_page_token: null,
+      };
+
+      mockCircleCIClient.projects.getProject.mockResolvedValue({
+        id: 'test-project-id',
+        organization_id: 'test-org-id',
+      });
+
+      mockCircleCIClient.deploys.fetchEnvironments.mockResolvedValue(mockEnvironments);
+
+      const args = {
+        params: {
+          projectSlug: 'gh/test-org/test-repo',
+          componentID: 'test-component-id',
+        },
+      } as any;
+
+      const response = await listComponentVersions(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toContain('Please provide an environmentID. Available environments:');
+      expect(response.content[0].text).toContain('1. production (ID: env-1)');
+      expect(response.content[0].text).toContain('2. staging (ID: env-2)');
+      
+      expect(mockCircleCIClient.deploys.fetchEnvironments).toHaveBeenCalledWith({
+        orgID: 'test-org-id',
+      });
+    });
+
+    it('should handle empty environments list', async () => {
+      mockCircleCIClient.projects.getProject.mockResolvedValue({
+        id: 'test-project-id',
+        organization_id: 'test-org-id',
+      });
+
+      mockCircleCIClient.deploys.fetchEnvironments.mockResolvedValue({
+        items: [],
+        next_page_token: null,
+      });
+
+      const args = {
+        params: {
+          projectSlug: 'gh/test-org/test-repo',
+          componentID: 'test-component-id',
+        },
+      } as any;
+
+      const response = await listComponentVersions(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toBe('No environments found');
+    });
+
+    it('should handle fetchEnvironments API errors', async () => {
+      const errorMessage = 'Failed to fetch environments';
+
+      mockCircleCIClient.projects.getProject.mockResolvedValue({
+        id: 'test-project-id',
+        organization_id: 'test-org-id',
+      });
+
+      mockCircleCIClient.deploys.fetchEnvironments.mockRejectedValue(
+        new Error(errorMessage),
+      );
+
+      const args = {
+        params: {
+          projectSlug: 'gh/test-org/test-repo',
+          componentID: 'test-component-id',
+        },
+      } as any;
+
+      const response = await listComponentVersions(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response).toHaveProperty('isError', true);
+      expect(response.content[0].text).toContain('Failed to list component versions:');
+      expect(response.content[0].text).toContain(errorMessage);
+    });
+  });
+
+  describe('Missing componentID scenarios', () => {
+    it('should list components when componentID is not provided', async () => {
+      const mockComponents = {
+        items: [
+          { id: 'comp-1', name: 'frontend' },
+          { id: 'comp-2', name: 'backend' },
+        ],
+        next_page_token: null,
+      };
+
+      mockCircleCIClient.projects.getProject.mockResolvedValue({
+        id: 'test-project-id',
+        organization_id: 'test-org-id',
+      });
+
+      mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue(mockComponents);
+
+      const args = {
+        params: {
+          projectSlug: 'gh/test-org/test-repo',
+          environmentID: 'test-environment-id',
+        },
+      } as any;
+
+      const response = await listComponentVersions(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toContain('Please provide a componentID. Available components:');
+      expect(response.content[0].text).toContain('1. frontend (ID: comp-1)');
+      expect(response.content[0].text).toContain('2. backend (ID: comp-2)');
+      
+      expect(mockCircleCIClient.deploys.fetchProjectComponents).toHaveBeenCalledWith({
+        projectID: 'test-project-id',
+        orgID: 'test-org-id',
+      });
+    });
+
+    it('should handle empty components list', async () => {
+      mockCircleCIClient.projects.getProject.mockResolvedValue({
+        id: 'test-project-id',
+        organization_id: 'test-org-id',
+      });
+
+      mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
+        items: [],
+        next_page_token: null,
+      });
+
+      const args = {
+        params: {
+          projectSlug: 'gh/test-org/test-repo',
+          environmentID: 'test-environment-id',
+        },
+      } as any;
+
+      const response = await listComponentVersions(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toBe('No components found');
+    });
+
+    it('should handle fetchProjectComponents API errors', async () => {
+      const errorMessage = 'Failed to fetch components';
+
+      mockCircleCIClient.projects.getProject.mockResolvedValue({
+        id: 'test-project-id',
+        organization_id: 'test-org-id',
+      });
+
+      mockCircleCIClient.deploys.fetchProjectComponents.mockRejectedValue(
+        new Error(errorMessage),
+      );
+
+      const args = {
+        params: {
+          projectSlug: 'gh/test-org/test-repo',
+          environmentID: 'test-environment-id',
+        },
+      } as any;
+
+      const response = await listComponentVersions(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response).toHaveProperty('isError', true);
+      expect(response.content[0].text).toContain('Failed to list component versions:');
+      expect(response.content[0].text).toContain(errorMessage);
+    });
+  });
+});

--- a/src/tools/listComponentVersions/handler.ts
+++ b/src/tools/listComponentVersions/handler.ts
@@ -1,0 +1,221 @@
+import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { listComponentVersionsInputSchema } from './inputSchema.js';
+import { getCircleCIClient } from '../../clients/client.js';
+import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
+
+type ProjectInfo = {
+  projectID: string;
+  orgID: string;
+};
+
+
+export const listComponentVersions: ToolCallback<{
+  params: typeof listComponentVersionsInputSchema;
+}> = async (args) => {
+  const {
+    projectSlug,
+    projectID: providedProjectID,
+    orgID: providedOrgID,
+    componentID,
+    environmentID,
+  } = args.params;
+
+  try {
+    // Resolve project and organization information
+    const projectInfoResult = await resolveProjectInfo(projectSlug, providedProjectID, providedOrgID);
+    
+    if (!projectInfoResult.success) {
+      return projectInfoResult.error;
+    }
+
+    const { projectID, orgID } = projectInfoResult.data;
+
+    // If environmentID is not provided, list environments
+    if (!environmentID) {
+      return await listEnvironments(orgID);
+    }
+
+    // If componentID is not provided, list components
+    if (!componentID) {
+      return await listComponents(projectID, orgID);
+    }
+
+    // If both componentID and environmentID are provided, list component versions
+    return await fetchComponentVersions(componentID, environmentID);
+
+  } catch (error) {
+    return mcpErrorOutput(
+      `Failed to list component versions: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    );
+  }
+};
+
+
+/**
+ * Resolves project and organization information from the provided parameters
+ */
+async function resolveProjectInfo(
+  projectSlug?: string,
+  providedProjectID?: string,
+  providedOrgID?: string,
+): Promise<{ success: true; data: ProjectInfo } | { success: false; error: any }> {
+  const circleci = getCircleCIClient();
+
+  try {
+    if (providedProjectID && providedOrgID) {
+      // Both IDs provided, use them directly
+      return {
+        success: true,
+        data: {
+          projectID: providedProjectID,
+          orgID: providedOrgID,
+        },
+      };
+    }
+
+    if (projectSlug) {
+      // Use projectSlug to get projectID and orgID
+      const { id: resolvedProjectId, organization_id: resolvedOrgId } = await circleci.projects.getProject({
+        projectSlug,
+      });
+      return {
+        success: true,
+        data: {
+          projectID: resolvedProjectId,
+          orgID: resolvedOrgId,
+        },
+      };
+    }
+
+    if (providedProjectID) {
+      // Use projectID to get orgID
+      const { id: resolvedProjectId, organization_id: resolvedOrgId } = await circleci.projects.getProjectByID({
+        projectID: providedProjectID,
+      });
+      return {
+        success: true,
+        data: {
+          projectID: resolvedProjectId,
+          orgID: resolvedOrgId,
+        },
+      };
+    }
+
+    return {
+      success: false,
+      error: mcpErrorOutput(`Invalid request. Please specify either a project slug or a project ID.`),
+    };
+  } catch (error) {
+    const errorMessage = projectSlug
+      ? `Failed to resolve project information for ${projectSlug}. Please verify the project slug is correct.`
+      : `Failed to resolve project information for project ID ${providedProjectID}. Please verify the project ID is correct.`;
+
+    return {
+      success: false,
+      error: mcpErrorOutput(`${errorMessage} ${error instanceof Error ? error.message : 'Unknown error'}`),
+    };
+  }
+}
+
+/**
+ * Lists available environments for the organization
+ */
+async function listEnvironments(orgID: string) {
+  const circleci = getCircleCIClient();
+
+  const environments = await circleci.deploys.fetchEnvironments({
+    orgID,
+  });
+
+  if (environments.items.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `No environments found`,
+        },
+      ],
+    };
+  }
+
+  const environmentsList = environments.items
+    .map((env: any, index: number) => `${index + 1}. ${env.name} (ID: ${env.id})`)
+    .join('\n');
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Please provide an environmentID. Available environments:\n\n${environmentsList}\n\n`,
+      },
+    ],
+  };
+}
+
+/**
+ * Lists available components for the project
+ */
+async function listComponents(projectID: string, orgID: string) {
+  const circleci = getCircleCIClient();
+
+  const components = await circleci.deploys.fetchProjectComponents({
+    projectID,
+    orgID,
+  });
+
+  if (components.items.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `No components found`,
+        },
+      ],
+    };
+  }
+
+  const componentsList = components.items
+    .map((component: any, index: number) => `${index + 1}. ${component.name} (ID: ${component.id})`)
+    .join('\n');
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Please provide a componentID. Available components:\n\n${componentsList}\n\n`,
+      },
+    ],
+  };
+}
+
+/**
+ * Lists component versions for the specified component and environment
+ */
+async function fetchComponentVersions(componentID: string, environmentID: string) {
+  const circleci = getCircleCIClient();
+
+  const componentVersions = await circleci.deploys.fetchComponentVersions({
+    componentID,
+    environmentID,
+  });
+
+  if (componentVersions.items.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `No component versions found`,
+        },
+      ],
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Versions for the component: ${JSON.stringify(componentVersions)}`,
+      },
+    ],
+  };
+}

--- a/src/tools/listComponentVersions/inputSchema.ts
+++ b/src/tools/listComponentVersions/inputSchema.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import { projectSlugDescriptionNoBranch } from '../shared/constants.js';
+
+export const listComponentVersionsInputSchema = z.object({
+  projectSlug: z
+    .string()
+    .describe(projectSlugDescriptionNoBranch)
+    .optional(),
+  projectID: z
+    .string()
+    .uuid()
+    .describe('The ID of the CircleCI project (UUID)')
+    .optional(),
+  orgID: z
+    .string()
+    .describe(
+      'The ID of the organization. This is the ID of the organization that the components and environments belong to. If not provided, it will be resolved from projectSlug or projectID.',
+    )
+    .optional(),
+  componentID: z
+    .string()
+    .optional()
+    .describe('The ID of the component to list versions for. If not provided, available components will be listed.'),
+  environmentID: z
+    .string()
+    .optional()
+    .describe('The ID of the environment to list versions for. If not provided, available environments will be listed.'),
+}).refine(
+  (data) => data.projectSlug || data.projectID,
+  {
+    message: "Either projectSlug or projectID must be provided",
+    path: ["projectSlug", "projectID"],
+  }
+);

--- a/src/tools/listComponentVersions/tool.ts
+++ b/src/tools/listComponentVersions/tool.ts
@@ -1,0 +1,58 @@
+import { listComponentVersionsInputSchema } from './inputSchema.js';
+
+export const listComponentVersionsTool = {
+   name: 'list_component_versions' as const,
+   description: `
+     This tool lists all versions for a CircleCI component. It guides you through a multi-step process to gather the required information and provides lists of available options when parameters are missing.
+
+     **Initial Requirements:**
+     - You need either a \`projectSlug\` (from \`listFollowedProjects\`) or a \`projectID\`. The tool will automatically resolve the \`orgID\` from either of these.
+
+     **Typical Flow:**
+     1. **Start:** User requests component versions or deployment information.
+     2. **Project Information:** Provide either \`projectSlug\` or \`projectID\`. The tool will automatically resolve the \`orgID\` and \`projectID\` as needed.
+     3. **Environment Selection:** If \`environmentID\` is not provided, the tool will list all available environments for the organization and prompt the user to select one. Always return all available values without categorizing them.
+     4. **Component Selection:** If \`componentID\` is not provided, the tool will list all available components for the project and prompt the user to select one. Always return all available values without categorizing them.
+     5. **Version Listing:** Once both \`environmentID\` and \`componentID\` are provided, the tool will list all versions for that component in the specified environment.
+     6. **Selection:** User selects a version from the list for subsequent operations.
+
+     **Parameters:**
+     - \`projectSlug\` (optional): The project slug from \`listFollowedProjects\` (e.g., "gh/organization/project"). Either this or \`projectID\` must be provided.
+     - \`projectID\` (optional): The CircleCI project ID (UUID). Either this or \`projectSlug\` must be provided.
+     - \`orgID\` (optional): The organization ID. If not provided, it will be automatically resolved from \`projectSlug\` or \`projectID\`.
+     - \`environmentID\` (optional): The environment ID. If not provided, available environments will be listed.
+     - \`componentID\` (optional): The component ID. If not provided, available components will be listed.
+
+     **Behavior:**
+     - The tool will guide you through the selection process step by step.
+     - Automatically resolves \`orgID\` from \`projectSlug\` or \`projectID\` when needed.
+     - When \`environmentID\` is missing, it lists environments and waits for user selection.
+     - When \`componentID\` is missing (but \`environmentID\` is provided), it lists components and waits for user selection.
+     - Only when both \`environmentID\` and \`componentID\` are provided will it list the actual component versions.
+     - Make multiple calls to this tool as you gather the required parameters.
+
+     **Common Use Cases:**
+     - Identify which versions were deployed for a component
+     - Identify which versions are live for a component
+     - Identify which versions were deployed to an environment for a component
+     - Identify which versions are not live for a component in an environment
+     - Select a version for rollback or deployment operations
+     - Obtain version name, namespace, and environment details for other CircleCI tools
+
+     **Returns:**
+     - When missing \`environmentID\`: A list of available environments with their IDs
+     - When missing \`componentID\`: A list of available components with their IDs  
+     - When both \`environmentID\` and \`componentID\` provided: A list of component versions with version name, namespace, environment ID, and is_live status
+
+     **Important Notes:**
+     - This tool requires multiple calls to gather all necessary information.
+     - Either \`projectSlug\` or \`projectID\` must be provided; the tool will resolve the missing project information automatically.
+     - The tool will prompt for missing \`environmentID\` and \`componentID\` by providing selection lists.
+     - Always use the exact IDs returned by the tool in subsequent calls.
+     - If pagination limits are reached, the tool will indicate that not all items could be displayed.
+
+     **IMPORTANT:** Do not automatically run additional tools after this tool is called. Wait for explicit user instruction before executing further tool calls. The LLM MUST NOT invoke other CircleCI tools until receiving clear instruction from the user about what to do next, even if the user selects an option. It is acceptable to list out tool call options for the user to choose from, but do not execute them until instructed.
+     `,
+   inputSchema: listComponentVersionsInputSchema,
+ };
+ 

--- a/src/tools/runRollbackPipeline/handler.test.ts
+++ b/src/tools/runRollbackPipeline/handler.test.ts
@@ -6,18 +6,12 @@ vi.mock('../../clients/client.js');
 
 describe('runRollbackPipeline handler', () => {
   const mockCircleCIClient = {
+    deploys: {
+      runRollbackPipeline: vi.fn(),
+      fetchProjectDeploySettings: vi.fn(),
+    },
     projects: {
       getProject: vi.fn(),
-    },
-    workflows: {
-      rerunWorkflow: vi.fn(),
-    },
-    deploys: {
-      fetchProjectDeploySettings: vi.fn(),
-      runRollbackPipeline: vi.fn(),
-      fetchProjectComponents: vi.fn(),
-      fetchEnvironments: vi.fn(),
-      fetchComponentVersions: vi.fn(),
     },
   };
 
@@ -35,603 +29,300 @@ describe('runRollbackPipeline handler', () => {
     );
   });
 
-  it('should return a valid MCP error response when no inputs are provided', async () => {
-    const args = {
-      params: {},
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(Array.isArray(response.content)).toBe(true);
-    expect(response.content[0]).toHaveProperty('type', 'text');
-    expect(typeof response.content[0].text).toBe('string');
-    expect(response.content[0].text).toContain('For rollback requests, projectSlug or projectID is required.');
-  });
-
-  it('should return error when rollback request is missing both projectSlug and projectID', async () => {
-    const args = {
-      params: {
-        environment_name: 'production',
-        component_name: 'my-app',
-        current_version: '1.2.0',
-        target_version: '1.1.0',
-      },
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(Array.isArray(response.content)).toBe(true);
-    expect(response.content[0]).toHaveProperty('type', 'text');
-    expect(typeof response.content[0].text).toBe('string');
-    expect(response.content[0].text).toContain('For rollback requests, projectSlug or projectID is required.');
-  });  
-
-  it('should return a valid MCP error response when project slug is not found', async () => {
-    mockCircleCIClient.projects.getProject.mockRejectedValue(new Error('Project not found'));
-
-    const args = {
-      params: {
-        projectSlug: 'gh/org/nonexistent-repo',
-        environment_name: 'prod',
-        component_name: 'api',
-        current_version: '1.0.0',
-        target_version: '0.9.0',
-      },
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(Array.isArray(response.content)).toBe(true);
-    expect(response.content[0]).toHaveProperty('type', 'text');
-    expect(response.content[0].text).toContain('Failed to get project information');
-  });
-
-  it('should return a valid MCP error response when project ID is not found', async () => {
-    const args = {
-      params: {
-        projectID: 'project-id',
-        environment_name: 'prod',
-        component_name: 'api',
-        current_version: '1.0.0',
-        target_version: '0.9.0',
-      },
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(Array.isArray(response.content)).toBe(true);
-    expect(response.content[0]).toHaveProperty('type', 'text');
-    expect(response.content[0].text).toContain('Failed to get project information');
-  });
-
-  it('should fetch and return component versions when there is only one component and one environment', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [{ id: 'component-1', name: 'backend' }],
-    });
-    mockCircleCIClient.deploys.fetchEnvironments.mockResolvedValue({
-      items: [{ id: 'env-1', name: 'production' }],
-    });
-    mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
-      rollback_pipeline_definition_id: 'rollback-pipeline-id',
-    });
-    mockCircleCIClient.deploys.fetchComponentVersions.mockResolvedValue({
-      items: [
-        {
-          name: '1.0.0',
-          namespace: 'prod',
-          environment_id: 'env-1',
-          is_live: true,
-          pipeline_id: 'pipeline-1',
-          workflow_id: 'workflow-1',
-          job_id: 'job-1',
-          job_number: 1,
-          last_deployed_at: '2025-01-01T00:00:00Z',
-        },
-        {
-          name: '0.9.0',
-          namespace: 'prod',
-          environment_id: 'env-1',
-          is_live: false,
-          pipeline_id: 'pipeline-2',
-          workflow_id: 'workflow-2',
-          job_id: 'job-2',
-          job_number: 2,
-          last_deployed_at: '2024-12-31T00:00:00Z',
-        },
-      ],
-      next_page_token: null,
-    });
-
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
-      },
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(Array.isArray(response.content)).toBe(true);
-    expect(response.content[0]).toHaveProperty('type', 'text');
-    expect(typeof response.content[0].text).toBe('string');
-    expect(response.content[0].text).toContain('Select a component version from:');
-    expect(mockCircleCIClient.deploys.fetchComponentVersions).toHaveBeenCalledWith({
-      componentID: 'component-1',
-      environmentID: 'env-1',
-    });
-  });
-
-  it('should return error when no components are found', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
-      rollback_pipeline_definition_id: 'rollback-pipeline-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [],
-    });
-
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
-      },
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(response.content[0].text).toContain('No components found for this project');
-  });
-
-  it('should prompt for component selection when multiple components exist', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
-      rollback_pipeline_definition_id: 'rollback-pipeline-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [
-        { id: 'component-1', name: 'backend' },
-        { id: 'component-2', name: 'frontend' },
-      ],
-    });
-
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
-      },
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(response.content[0].text).toContain('Multiple components found for this project');
-    expect(response.content[0].text).toContain('component-1');
-    expect(response.content[0].text).toContain('component-2');
-  });
-
-  it('should return error for invalid component name', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
-      rollback_pipeline_definition_id: 'rollback-pipeline-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [
-        { id: 'component-1', name: 'backend' },
-        { id: 'component-2', name: 'frontend' },
-      ],
-    });
-
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
-        component_name: 'nonexistent',
-      },
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(response.content[0].text).toContain('Component "nonexistent" not found');
-  });
-
-  it('should return error when no environments are found', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
-      rollback_pipeline_definition_id: 'rollback-pipeline-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [{ id: 'component-1', name: 'backend' }],
-    });
-    mockCircleCIClient.deploys.fetchEnvironments.mockResolvedValue({
-      items: [],
-    });
-
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
-      },
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');  
-    expect(response).toHaveProperty('isError', true);
-    expect(response.content[0].text).toContain('No environments found for this project');
-  });
-
-  it('should prompt for environment selection when multiple environments exist', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
-      rollback_pipeline_definition_id: 'rollback-pipeline-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [{ id: 'component-1', name: 'backend' }],
-    });
-    mockCircleCIClient.deploys.fetchEnvironments.mockResolvedValue({
-      items: [
-        { id: 'env-1', name: 'production' },
-        { id: 'env-2', name: 'staging' },
-      ],
-    });
-
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
-      },
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(response.content[0].text).toContain('Multiple environments found for this project');
-    expect(response.content[0].text).toContain('production');
-    expect(response.content[0].text).toContain('staging');
-  });
-
-  it('should return error for invalid environment name', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
-      rollback_pipeline_definition_id: 'rollback-pipeline-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [{ id: 'component-1', name: 'backend' }],
-    });
-    mockCircleCIClient.deploys.fetchEnvironments.mockResolvedValue({
-      items: [
-        { id: 'env-1', name: 'production' },
-        { id: 'env-2', name: 'staging' },
-      ],
-    });
-
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
-        environment_name: 'nonexistent',
-      },
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(response.content[0].text).toContain('Environment "nonexistent" not found');
-  });
-
-  it('should suggest workflow rerun when no rollback pipeline is configured', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
-      // No rollback_pipeline_id
-    });
-
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
+  describe('successful rollback pipeline execution', () => {
+    it('should initiate rollback pipeline with all required parameters', async () => {
+      const mockRollbackResponse = {
+        id: 'rollback-123',
         rollback_type: 'PIPELINE',
-      },
-    } as any;
+      };
 
-    const response = await runRollbackPipeline(args, mockExtra);
+      mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
+        rollback_pipeline_definition_id: 'rollback-def-123',
+      });
+      mockCircleCIClient.deploys.runRollbackPipeline.mockResolvedValue(mockRollbackResponse);
 
-    expect(response).toHaveProperty('content');
-    expect(response.content[0].text).toContain('No rollback pipeline defined for this project');
-    expect(response.content[0].text).toContain('WORKFLOW_RERUN');
-  });
-
-  it('should successfully execute pipeline rollback', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
-      rollback_pipeline_definition_id: 'rollback-pipeline-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [{ id: 'component-1', name: 'backend' }],
-    });
-    mockCircleCIClient.deploys.fetchEnvironments.mockResolvedValue({
-      items: [{ id: 'env-1', name: 'production' }],
-    });
-    mockCircleCIClient.deploys.fetchComponentVersions.mockResolvedValue({
-      items: [
-        {
-          name: '1.0.0',
-          namespace: 'prod',
-          environment_id: 'env-1',
-          is_live: true,
-          pipeline_id: 'pipeline-1',
-          workflow_id: 'workflow-1',
-          job_id: 'job-1',
-          job_number: 1,
-          last_deployed_at: '2025-01-01T00:00:00Z',
+      const args = {
+        params: {
+          projectID: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+          environmentName: 'production',
+          componentName: 'frontend',
+          currentVersion: 'v1.2.0',
+          targetVersion: 'v1.1.0',
+          namespace: 'web-app',
         },
-      ],
-    });
-    mockCircleCIClient.deploys.runRollbackPipeline.mockResolvedValue({
-      id: 'rollback-123',
-      rollback_type: 'PIPELINE',
+      } as any;
+
+      const response = await runRollbackPipeline(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(Array.isArray(response.content)).toBe(true);
+      expect(response.content[0]).toHaveProperty('type', 'text');
+      expect(response.content[0].text).toBe('Rollback initiated successfully. ID: rollback-123, Type: PIPELINE');
+      
+      expect(mockCircleCIClient.deploys.runRollbackPipeline).toHaveBeenCalledTimes(1);
+      expect(mockCircleCIClient.deploys.runRollbackPipeline).toHaveBeenCalledWith({
+        projectID: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        rollbackRequest: {
+          environment_name: 'production',
+          component_name: 'frontend',
+          current_version: 'v1.2.0',
+          target_version: 'v1.1.0',
+          namespace: 'web-app',
+        },
+      });
     });
 
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
+    it('should initiate rollback pipeline with optional reason parameter', async () => {
+      const mockRollbackResponse = {
+        id: 'rollback-456',
         rollback_type: 'PIPELINE',
-        environment_name: 'production',
-        component_name: 'backend',
-        current_version: '1.0.0',
-        target_version: '0.9.0',
-        reason: 'Critical bug fix',
-      },
-    } as any;
+      };
 
-    const response = await runRollbackPipeline(args, mockExtra);
+      mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
+        rollback_pipeline_definition_id: 'rollback-def-456',
+      });
+      mockCircleCIClient.deploys.runRollbackPipeline.mockResolvedValue(mockRollbackResponse);
 
-    expect(response).toHaveProperty('content');
-    expect(response.content[0].text).toContain('Rollback initiated successfully');
-    expect(response.content[0].text).toContain('rollback-123');
-    expect(mockCircleCIClient.deploys.runRollbackPipeline).toHaveBeenCalledWith({
-      projectID: 'project-id',
-      rollbackRequest: {
-        environment_name: 'production',
-        component_name: 'backend',
-        current_version: '1.0.0',
-        target_version: '0.9.0',
-        namespace: 'prod',
-        reason: 'Critical bug fix',
-      },
-    });
-  });
-
-  it('should successfully execute workflow rerun', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [{ id: 'component-1', name: 'backend' }],
-    });
-    mockCircleCIClient.deploys.fetchEnvironments.mockResolvedValue({
-      items: [{ id: 'env-1', name: 'production' }],
-    });
-    mockCircleCIClient.deploys.fetchComponentVersions.mockResolvedValue({
-      items: [
-        {
-          name: '1.0.0',
-          namespace: 'prod',
-          environment_id: 'env-1',
-          is_live: true,
-          pipeline_id: 'pipeline-1',
-          workflow_id: 'workflow-1',
-          job_id: 'job-1',
-          job_number: 1,
-          last_deployed_at: '2025-01-01T00:00:00Z',
+      const args = {
+        params: {
+          projectID: 'b2c3d4e5-f6g7-8901-bcde-fg2345678901',
+          environmentName: 'staging',
+          componentName: 'backend',
+          currentVersion: 'v2.1.0',
+          targetVersion: 'v2.0.0',
+          namespace: 'api-service',
+          reason: 'Critical bug fix required',
         },
-      ],
-    });
-    mockCircleCIClient.workflows.rerunWorkflow.mockResolvedValue({
-      workflow_id: 'workflow-1',
-    });
+      } as any;
 
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
-        rollback_type: 'WORKFLOW_RERUN',
-        environment_name: 'production',
-        component_name: 'backend',
-        current_version: '1.0.0',
-        target_version: '0.9.0',
-        workflow_id: 'workflow-1',
-      },
-    } as any;
+      const response = await runRollbackPipeline(args, mockExtra);
 
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(response.content[0].text).toContain('Workflow rerun initiated successfully');
-    expect(mockCircleCIClient.workflows.rerunWorkflow).toHaveBeenCalledWith({
-      workflowId: 'workflow-1',
-      fromFailed: false,
-    });
-  });
-
-  it('should return error when workflow_id is missing for workflow rerun', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [{ id: 'component-1', name: 'backend' }],
-    });
-    mockCircleCIClient.deploys.fetchEnvironments.mockResolvedValue({
-      items: [{ id: 'env-1', name: 'production' }],
-    });
-    mockCircleCIClient.deploys.fetchComponentVersions.mockResolvedValue({
-      items: [
-        {
-          name: '1.0.0',
-          namespace: 'prod',
-          environment_id: 'env-1',
-          is_live: true,
-          pipeline_id: 'pipeline-1',
-          workflow_id: 'workflow-1',
-          job_id: 'job-1',
-          job_number: 1,
-          last_deployed_at: '2025-01-01T00:00:00Z',
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toBe('Rollback initiated successfully. ID: rollback-456, Type: PIPELINE');
+      
+      expect(mockCircleCIClient.deploys.runRollbackPipeline).toHaveBeenCalledWith({
+        projectID: 'b2c3d4e5-f6g7-8901-bcde-fg2345678901',
+        rollbackRequest: {
+          environment_name: 'staging',
+          component_name: 'backend',
+          current_version: 'v2.1.0',
+          target_version: 'v2.0.0',
+          namespace: 'api-service',
+          reason: 'Critical bug fix required',
         },
-      ],
+      });
     });
 
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
-        rollback_type: 'WORKFLOW_RERUN',
-        environment_name: 'production',
-        component_name: 'backend', 
-        current_version: '1.0.0',
-        target_version: '0.9.0',
-        // workflow_id is missing
-      },
-    } as any;
-
-    const response = await runRollbackPipeline(args, mockExtra);
-
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(response.content[0].text).toContain('The selected version has no associated workflow');
-  });
-
-  it('should handle rollback pipeline execution error', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
-      rollback_pipeline_definition_id: 'rollback-pipeline-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [{ id: 'component-1', name: 'backend' }],
-    });
-    mockCircleCIClient.deploys.fetchEnvironments.mockResolvedValue({
-      items: [{ id: 'env-1', name: 'production' }],
-    });
-    mockCircleCIClient.deploys.fetchComponentVersions.mockResolvedValue({
-      items: [
-        {
-          name: '1.0.0',
-          namespace: 'prod',
-          environment_id: 'env-1',
-          is_live: true,  
-          pipeline_id: 'pipeline-1',
-          workflow_id: 'workflow-1',
-          job_id: 'job-1',
-          job_number: 1,
-          last_deployed_at: '2025-01-01T00:00:00Z',
-        },
-      ],
-    });
-    mockCircleCIClient.deploys.runRollbackPipeline.mockRejectedValue(
-      new Error('Rollback failed'),
-    );
-
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
+    it('should initiate rollback pipeline with optional parameters object', async () => {
+      const mockRollbackResponse = {
+        id: 'rollback-789',
         rollback_type: 'PIPELINE',
-        environment_name: 'production',
-        component_name: 'backend',
-        current_version: '1.0.0',
-        target_version: '0.9.0',
-      },
-    } as any;
+      };
 
-    const response = await runRollbackPipeline(args, mockExtra);
+      mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
+        rollback_pipeline_definition_id: 'rollback-def-789',
+      });
+      mockCircleCIClient.deploys.runRollbackPipeline.mockResolvedValue(mockRollbackResponse);
 
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(response.content[0].text).toContain('Failed to initiate rollback');
-    expect(response.content[0].text).toContain('Rollback failed');
+      const args = {
+        params: {
+          projectID: 'c3d4e5f6-g7h8-9012-cdef-gh3456789012',
+          environmentName: 'production',
+          componentName: 'database',
+          currentVersion: 'v3.2.0',
+          targetVersion: 'v3.1.0',
+          namespace: 'db-cluster',
+          reason: 'Performance regression',
+          parameters: {
+            skip_migration: true,
+            notify_team: 'devops',
+          },
+        },
+      } as any;
+
+      const response = await runRollbackPipeline(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toBe('Rollback initiated successfully. ID: rollback-789, Type: PIPELINE');
+      
+      expect(mockCircleCIClient.deploys.runRollbackPipeline).toHaveBeenCalledWith({
+        projectID: 'c3d4e5f6-g7h8-9012-cdef-gh3456789012',
+        rollbackRequest: {
+          environment_name: 'production',
+          component_name: 'database',
+          current_version: 'v3.2.0',
+          target_version: 'v3.1.0',
+          namespace: 'db-cluster',
+          reason: 'Performance regression',
+          parameters: {
+            skip_migration: true,
+            notify_team: 'devops',
+          },
+        },
+      });
+    });
+
+    it('should initiate rollback pipeline using projectSlug', async () => {
+      const mockRollbackResponse = {
+        id: 'rollback-slug-123',
+        rollback_type: 'PIPELINE',
+      };
+
+      mockCircleCIClient.projects.getProject.mockResolvedValue({
+        id: 'resolved-project-id-123',
+        organization_id: 'org-id-123',
+      });
+      mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
+        rollback_pipeline_definition_id: 'rollback-def-slug-123',
+      });
+      mockCircleCIClient.deploys.runRollbackPipeline.mockResolvedValue(mockRollbackResponse);
+
+      const args = {
+        params: {
+          projectSlug: 'gh/organization/project',
+          environmentName: 'production',
+          componentName: 'frontend',
+          currentVersion: 'v1.2.0',
+          targetVersion: 'v1.1.0',
+          namespace: 'web-app',
+        },
+      } as any;
+
+      const response = await runRollbackPipeline(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(Array.isArray(response.content)).toBe(true);
+      expect(response.content[0]).toHaveProperty('type', 'text');
+      expect(response.content[0].text).toBe('Rollback initiated successfully. ID: rollback-slug-123, Type: PIPELINE');
+      
+      expect(mockCircleCIClient.projects.getProject).toHaveBeenCalledWith({
+        projectSlug: 'gh/organization/project',
+      });
+      expect(mockCircleCIClient.deploys.runRollbackPipeline).toHaveBeenCalledWith({
+        projectID: 'resolved-project-id-123',
+        rollbackRequest: {
+          environment_name: 'production',
+          component_name: 'frontend',
+          current_version: 'v1.2.0',
+          target_version: 'v1.1.0',
+          namespace: 'web-app',
+        },
+      });
+    });
   });
 
-  it('should handle workflow rerun execution error', async () => {
-    mockCircleCIClient.projects.getProject.mockResolvedValue({
-      id: 'project-id',
-      organization_id: 'org-id',
-    });
-    mockCircleCIClient.deploys.fetchProjectComponents.mockResolvedValue({
-      items: [{ id: 'component-1', name: 'backend' }],
-    });
-    mockCircleCIClient.deploys.fetchEnvironments.mockResolvedValue({
-      items: [{ id: 'env-1', name: 'production' }],
-    });
-    mockCircleCIClient.deploys.fetchComponentVersions.mockResolvedValue({
-      items: [
-        {
-          name: '1.0.0',
-          namespace: 'prod',
-          environment_id: 'env-1',
-          is_live: true,
-          pipeline_id: 'pipeline-1',
-          workflow_id: 'workflow-1',
-          job_id: 'job-1',
-          job_number: 1,
-          last_deployed_at: '2025-01-01T00:00:00Z',
+  describe('error handling', () => {
+    it('should return error when API call fails with Error object', async () => {
+      const errorMessage = 'Rollback pipeline not configured for this project';
+      mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
+        rollback_pipeline_definition_id: 'rollback-def-error',
+      });
+      mockCircleCIClient.deploys.runRollbackPipeline.mockRejectedValue(new Error(errorMessage));
+
+      const args = {
+        params: {
+          projectID: 'e5f6g7h8-i9j0-1234-efgh-ij5678901234',
+          environment_name: 'production',
+          componentName: 'frontend',
+          currentVersion: 'v2.0.0',
+          targetVersion: 'v1.9.0',
+          namespace: 'app',
         },
-      ],
+      } as any;
+
+      const response = await runRollbackPipeline(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(Array.isArray(response.content)).toBe(true);
+      expect(response.content[0]).toHaveProperty('type', 'text');
+      expect(response.content[0].text).toContain('Failed to initiate rollback:');
+      expect(response.content[0].text).toContain('Rollback pipeline not configured for this project');
     });
-    mockCircleCIClient.workflows.rerunWorkflow.mockRejectedValue(
-      new Error('Workflow rerun failed'),
-    );
 
-    const args = {
-      params: {
-        projectSlug: 'gh/org/repo',
-        rollback_type: 'WORKFLOW_RERUN',
-        environment_name: 'production',
-        component_name: 'backend',
-        current_version: '1.0.0',
-        target_version: '0.9.0',
-        workflow_id: 'workflow-1',
-      },
-    } as any;
+    it('should return error when API call fails with non-Error object', async () => {
+      mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
+        rollback_pipeline_definition_id: 'rollback-def-error2',
+      });
+      mockCircleCIClient.deploys.runRollbackPipeline.mockRejectedValue('String error');
 
-    const response = await runRollbackPipeline(args, mockExtra);
+      const args = {
+        params: {
+          projectID: 'f6g7h8i9-j0k1-2345-fghi-jk6789012345',
+          environment_name: 'staging',
+          component_name: 'backend',
+          current_version: 'v3.0.0',
+          target_version: 'v2.9.0',
+          namespace: 'api',
+        },
+      } as any;
 
-    expect(response).toHaveProperty('content');
-    expect(response).toHaveProperty('isError', true);
-    expect(response.content[0].text).toContain('Failed to initiate rollback');
-    expect(response.content[0].text).toContain('Workflow rerun failed');
+      const response = await runRollbackPipeline(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toContain('Failed to initiate rollback:');
+      expect(response.content[0].text).toContain('Unknown error');
+    });
+
+    it('should return error when projectSlug resolution fails', async () => {
+      const errorMessage = 'Project not found';
+      mockCircleCIClient.projects.getProject.mockRejectedValue(new Error(errorMessage));
+
+      const args = {
+        params: {
+          projectSlug: 'gh/invalid/project',
+          environmentName: 'production',
+          componentName: 'frontend',
+          currentVersion: 'v1.2.0',
+          targetVersion: 'v1.1.0',
+          namespace: 'web-app',
+        },
+      } as any;
+
+      const response = await runRollbackPipeline(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toContain('Failed to resolve project information for gh/invalid/project');
+      expect(response.content[0].text).toContain('Project not found');
+    });
+
+    it('should return error when neither projectSlug nor projectID provided', async () => {
+      const args = {
+        params: {
+          environmentName: 'production',
+          componentName: 'frontend',
+          currentVersion: 'v1.2.0',
+          targetVersion: 'v1.1.0',
+          namespace: 'web-app',
+        },
+      } as any;
+
+      const response = await runRollbackPipeline(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toContain('Either projectSlug or projectID must be provided');
+    });
+
+    it('should return the appropriate message when no rollback pipeline definition is configured', async () => {
+      mockCircleCIClient.deploys.fetchProjectDeploySettings.mockResolvedValue({
+        rollback_pipeline_definition_id: null,
+      });
+
+      const args = {
+        params: {
+          projectID: 'test-project-id',
+          environmentName: 'production',
+          componentName: 'frontend',
+          currentVersion: 'v1.2.0',
+          targetVersion: 'v1.1.0',
+          namespace: 'web-app',
+        },
+      } as any;
+
+      const response = await runRollbackPipeline(args, mockExtra);
+
+      expect(response).toHaveProperty('content');
+      expect(response.content[0].text).toContain('No rollback pipeline definition found for this project');
+      expect(response.content[0].text).toContain('https://circleci.com/docs/deploy/rollback-a-project-using-the-rollback-pipeline/');
+    });
   });
 });

--- a/src/tools/runRollbackPipeline/handler.ts
+++ b/src/tools/runRollbackPipeline/handler.ts
@@ -7,299 +7,93 @@ export const runRollbackPipeline: ToolCallback<{
   params: typeof runRollbackPipelineInputSchema;
 }> = async (args: any) => {
   const {
-    projectSlug: inputProjectSlug,
-    environment_name,
-    component_name,
-    current_version,
-    target_version,
-    workflow_id,
+    projectSlug,
+    projectID: providedProjectID,
+    environmentName,
+    componentName,
+    currentVersion,
+    targetVersion,
+    namespace,
     reason,
     parameters,
-    projectID,
-    rollback_type,
   } = args.params;
-  // They need to provide the projectID or projectSlug
-  const hasProjectIDOrSlug = inputProjectSlug || projectID;
-  if (!hasProjectIDOrSlug) {
-    return mcpErrorOutput(
-      'For rollback requests, projectSlug or projectID is required.',
-    );
-  }
 
-  let updatedProjectID = projectID;
-  let orgID = undefined;
+
   // Init the client and get the base URL
   const circleci = getCircleCIClient();
-
-  // Get project information - we need both projectID and orgID
-  if (inputProjectSlug) {
-    // Use projectSlug to get projectID and orgID
-    try {
-      const { id: projectId, organization_id: orgId } = await circleci.projects.getProject({
-        projectSlug: inputProjectSlug,
+  
+  // Resolve project ID from projectSlug or use provided projectID
+  let projectID: string;
+  try {
+    if (providedProjectID) {
+      projectID = providedProjectID;
+    } else if (projectSlug) {
+      const { id: resolvedProjectId } = await circleci.projects.getProject({
+        projectSlug,
       });
-      updatedProjectID = projectId;
-      orgID = orgId;
-    } catch (error) {
-      return mcpErrorOutput(
-        `Failed to get project information for ${inputProjectSlug}. Please verify the project slug is correct. ${error instanceof Error ? error.message : 'Unknown error'}`,
-      );
+      projectID = resolvedProjectId;
+    } else {
+      return mcpErrorOutput('Either projectSlug or projectID must be provided');
     }
-  } else if (projectID) {
-    // Use projectID directly - we need to get orgID somehow
-    updatedProjectID = projectID;
-    try {
-      // Try to get project info using projectID to get orgID
-      const { organization_id: orgId } = await circleci.projects.getProjectByID({
-        projectID: projectID,
-      });
-      orgID = orgId;
-    } catch (error) {
-      return mcpErrorOutput(
-        `Failed to get project information for project ID ${projectID}. Please verify the project ID is correct. ${error instanceof Error ? error.message : 'Unknown error'}`,
-      );
-    }
-  }
-
-  if (!updatedProjectID || !orgID) {
-    return mcpErrorOutput(
-      'Could not get project information. Please verify the projectID or slug is correct.',
-    );
-  }
-
-  if (rollback_type === 'PIPELINE') {
-    // // Check if the project has a rollback pipeline defined (only needed for actual rollback)
-    try {
-      const deploySettings = await circleci.deploys.fetchProjectDeploySettings({
-        projectID: updatedProjectID,
-      });
-
-      if (!deploySettings.rollback_pipeline_definition_id) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `No rollback pipeline defined for this project. Would you like to rerun a workflow instead? Call this tool again with rollback_type set to "WORKFLOW_RERUN".
-                Otherwise, you can set up a rollback pipeline using https://circleci.com/docs/deploy/rollback-a-project-using-the-rollback-pipeline/
-                `
-              }
-            ]
-          };
-      }
-    } catch {
-      return mcpErrorOutput(
-        'Failed to fetch rollback pipeline definition. Please try again later.',
-      );
-    }
+  } catch (error) {
+    const errorMessage = projectSlug
+      ? `Failed to resolve project information for ${projectSlug}. Please verify the project slug is correct.`
+      : `Failed to resolve project information for project ID ${providedProjectID}. Please verify the project ID is correct.`;
+    
+    return mcpErrorOutput(`${errorMessage} ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
   
-  // Get the components for this project, if there is only one we can use the information
-  // If there is a component, we are sure there is a deploy marker
-  const components = await circleci.deploys.fetchProjectComponents({
-    projectID: updatedProjectID,
-    orgID: orgID,
-  });
+  // First, check if the project has a rollback pipeline definition configured
+  try {
+    const deploySettings = await circleci.deploys.fetchProjectDeploySettings({
+      projectID,
+    });
 
-  if (components?.items.length === 0) {
-    // If there is no components, we can't rollback since there are no deploy markers
+    if (!deploySettings.rollback_pipeline_definition_id) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: 'No rollback pipeline definition found for this project. You may need to configure a rollback pipeline first using https://circleci.com/docs/deploy/rollback-a-project-using-the-rollback-pipeline/ or you can trigger a rollback by workflow rerun.',
+          },
+        ],
+      };
+    }
+  } catch (error) {
     return mcpErrorOutput(
-      'No components found for this project. Set up deploy markers to use this tool. See https://circleci.com/docs/deploy/configure-deploy-markers/ for more information.',
+      `Failed to fetch rollback pipeline definition: ${error instanceof Error ? error.message : 'Unknown error'}`,
     );
   }
-
-  if (components.items.length > 1 && !component_name) {
-    const componentList = components.items
-      .map((env: any, index: number) => `${index + 1}. ${env.name} (ID: ${env.id})`)
-      .join('\n');
-    
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Multiple components found for this project. Please specify component_name parameter with one of the following:\n\n${componentList}\n\nExample: Call the rollback tool again with component_name set to "${components.items[0].name}"`,
-        },
-      ],
-    };
-  }
-
-  let selectedComponent = components.items[0];
-
-  if (component_name) {
-    const matchingComponent = components.items.find((component: any) => component.name === component_name);
-    if (!matchingComponent) {
-      const componentList = components.items
-        .map((component: any, index: number) => `${index + 1}. ${component.name}`)
-        .join('\n');
-      
-      return mcpErrorOutput(
-        `Component "${component_name}" not found. Available components:\n\n${componentList}`
-      );
-    }
-    selectedComponent = matchingComponent;
-  }
-
-
-
-  // Fetch the environments for this project
-  const environments = await circleci.deploys.fetchEnvironments({
-    orgID: orgID,
-  });
-
-  if (environments.items.length === 0) {
-    // If there is no components, we can't rollback since there are no deploy markers
-    return mcpErrorOutput(
-      'No environments found for this project. Set up one using https://circleci.com/docs/deploy/configure-deploy-markers/#manage-environments',
-    );
-  }
-  // If multiple environments, we need to ask the user to select one
-  if (environments.items.length > 1 && !environment_name) {
-    const environmentList = environments.items
-      .map((env: any, index: number) => `${index + 1}. ${env.name} (ID: ${env.id})`)
-      .join('\n');
-    
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Multiple environments found for this project. Please specify environment_name parameter with one of the following:\n\n${environmentList}\n\nExample: Call the rollback tool again with environment_name set to "${environments.items[0].name}"`,
-        },
-      ],
-    };
-  }
-
-  let selectedEnvironment = environments.items[0];
-
-  // If user provided environment_name, find the matching environment
-  if (environment_name) {
-    const matchingEnvironment = environments.items.find((env: any) => env.name === environment_name);
-    if (!matchingEnvironment) {
-      const environmentList = environments.items
-        .map((env: any, index: number) => `${index + 1}. ${env.name}`)
-        .join('\n');
-      
-      return mcpErrorOutput(
-        `Environment "${environment_name}" not found. Available environments:\n\n${environmentList}`
-      );
-    }
-    selectedEnvironment = matchingEnvironment;
-  }
-
+  
   // Check if this is a new rollback request with required fields
-  const isRollbackRequestComplete = environment_name && component_name && current_version && target_version;
-  
-  // If only projectSlug is provided, fetch and show component versions for selection
-  if (!isRollbackRequestComplete) {
-    // Show which environment and component we're working with
-    let message = '';
-    // Environment selection message
-    if (environments.items.length === 1) {
-      message += `Found 1 environment: "${selectedEnvironment.name}". Using this environment for rollback.\n`;
-    } else {
-      message += `Using environment: "${selectedEnvironment.name}".\n`;
-    }
-    // Component selection message
-    if (components.items.length === 1) {
-      message += `Found 1 component: "${selectedComponent.name}". Using this component for rollback.\n\n`;
-    } else {
-      message += `Found ${components.items.length} components. Using component: "${selectedComponent.name}".\n\n`;
-    }
 
-    // Fetch the versions
-    const componentVersions = await circleci.deploys.fetchComponentVersions({
-      componentID: selectedComponent.id,
-      environmentID: selectedEnvironment.id,
-      workflowID: workflow_id,
+  const rollbackRequest = {
+    environment_name: environmentName,
+    component_name: componentName,
+    current_version: currentVersion,
+    target_version: targetVersion,
+    ...(namespace && { namespace }),
+    ...(reason && { reason }),
+    ...(parameters && { parameters }),
+  };
+
+  try {
+    const rollbackResponse = await circleci.deploys.runRollbackPipeline({
+      projectID,
+      rollbackRequest,
     });
 
     return {
       content: [
         {
           type: 'text',
-          text: `${message}Select a component version from: ${JSON.stringify(componentVersions)}`,
+          text: `Rollback initiated successfully. ID: ${rollbackResponse.id}, Type: ${rollbackResponse.rollback_type}`,
         },
       ],
     };
+  } catch (error) {
+    return mcpErrorOutput(
+      `Failed to initiate rollback: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    );
   }
-
-  // Fetch component versions for actual rollback execution
-  const componentVersions = await circleci.deploys.fetchComponentVersions({
-    componentID: components.items[0].id,
-    environmentID: selectedEnvironment.id,
-  });
-
-  const currentVersion = componentVersions.items.find(
-    (component: any) => component.is_live
-  )?.name;
-
-  const namespace = componentVersions.items.find(
-    (component: any) => component.is_live
-  )?.namespace;
-  
-  if (isRollbackRequestComplete && rollback_type === 'PIPELINE') {
-    // Handle new rollback API
-    const rollbackRequest = {
-      environment_name: selectedEnvironment.name!,
-      component_name: selectedComponent.name!,
-      current_version: currentVersion!,
-      target_version: target_version!,
-      ...(namespace && { namespace }),
-      ...(reason && { reason }),
-      ...(parameters && { parameters }),
-    };
-
-    try {
-      const rollbackResponse = await circleci.deploys.runRollbackPipeline({
-        projectID: updatedProjectID,
-        rollbackRequest,
-      });
-
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Rollback initiated successfully. ID: ${rollbackResponse.id}, Type: ${rollbackResponse.rollback_type}`,
-          },
-        ],
-      };
-    } catch (error) {
-      return mcpErrorOutput(
-        `Failed to initiate rollback: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      );
-    }
-  }
-
-  if (isRollbackRequestComplete && rollback_type === 'WORKFLOW_RERUN') {
-
-    if (!workflow_id) {
-      return mcpErrorOutput(
-        'The selected version has no associated workflow. Please select a different version.',
-      );
-    }
-
-    try {
-      // Handle workflow rerun
-      await circleci.workflows.rerunWorkflow({
-        workflowId: workflow_id!,
-        fromFailed: false,
-      });
-
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Workflow rerun initiated successfully.`,
-          },
-        ],
-      };
-
-    } catch (error) {
-      return mcpErrorOutput(
-        `Failed to initiate rollback: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      );
-    }
-  }
-
-  return mcpErrorOutput(
-    'Incomplete rollback request. Please provide environment_name, component_name, current_version, and target_version.',
-  );
 };

--- a/src/tools/runRollbackPipeline/inputSchema.ts
+++ b/src/tools/runRollbackPipeline/inputSchema.ts
@@ -1,35 +1,31 @@
 import { z } from 'zod';
-import {
-  projectSlugDescription,
-} from '../shared/constants.js';
+import { projectSlugDescriptionNoBranch } from '../shared/constants.js';
 
 export const runRollbackPipelineInputSchema = z.object({
-  projectSlug: z.string().describe(projectSlugDescription).optional(),
-  projectID: z.string().uuid().describe('The ID of the CircleCI project (UUID)').optional(),
-  rollback_type: z
-    .enum(['PIPELINE', 'WORKFLOW_RERUN'])
-    .describe('The type of rollback operation to perform')
-    .default('PIPELINE'),
-  workflow_id: z
+  projectSlug: z
     .string()
-    .describe('The ID of the workflow to rerun')
+    .describe(projectSlugDescriptionNoBranch)
     .optional(),
-  environment_name: z
+  projectID: z
     .string()
-    .describe('The environment name')
+    .uuid()
+    .describe('The ID of the CircleCI project (UUID)')
     .optional(),
-  component_name: z
+  environmentName: z
     .string()
-    .describe('The component name')
-    .optional(),
-  current_version: z
+    .describe('The environment name'),
+  componentName: z
     .string()
-    .describe('The current version')
-    .optional(),
-  target_version: z
+    .describe('The component name'),
+  currentVersion: z
     .string()
-    .describe('The target version')
-    .optional(),
+    .describe('The current version'),
+  targetVersion: z
+    .string()
+    .describe('The target version'),
+  namespace: z
+    .string()
+    .describe('The namespace of the component'),
   reason: z
     .string()
     .describe('The reason for the rollback')
@@ -38,4 +34,10 @@ export const runRollbackPipelineInputSchema = z.object({
     .record(z.any())
     .describe('The extra parameters for the rollback pipeline')
     .optional(),
-});
+}).refine(
+  (data) => data.projectSlug || data.projectID,
+  {
+    message: "Either projectSlug or projectID must be provided",
+    path: ["projectSlug", "projectID"],
+  }
+);


### PR DESCRIPTION
The purpiose of these changes is to simplify the logic in the rollback tool and make the interactions with it more flexible.