### PR TITLE
fix: prevent non-MCP output on stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2025-09-17
+
+### Fixed
+
+- Output log messages to stderr instead of stdout, following MCP server specification. This avoids MCP server startup issues in some agents, such as Warp. Fixes #125
+
 ## [0.14.0] - 2025-08-11
 
 ### Added

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,8 @@ export default tseslint.config(
       },
     },
     rules: {
-      'no-console': 'off',
+      // No output to stdout that isn't MCP, allow stderr
+      'no-console': ['error', { allow: ['error'] }],
       '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ if (process.env.debug === 'true') {
     srv.notification = async (...args: any[]) => {
       try {
         const [{ method, params }] = args;
-        console.log(
+        console.error(
           '[DEBUG] outgoing notification:',
           method,
           JSON.stringify(params),
@@ -37,7 +37,7 @@ if (process.env.debug === 'true') {
     srv.request = async (...args: any[]) => {
       const [payload] = args;
       const result = await origRequest(...args);
-      console.log(
+      console.error(
         '[DEBUG] response to',
         payload?.method,
         JSON.stringify(result).slice(0, 200),
@@ -49,7 +49,7 @@ if (process.env.debug === 'true') {
 
 // Register all CircleCI tools once
 if (process.env.debug === 'true') {
-  console.log('[DEBUG] [Startup] Registering CircleCI MCP tools...');
+  console.error('[DEBUG] [Startup] Registering CircleCI MCP tools...');
 }
 // Ensure we advertise support for tools/list in capabilities (SDK only sets listChanged)
 (server as any).server.registerCapabilities({ tools: { list: true } });
@@ -58,7 +58,7 @@ CCI_TOOLS.forEach((tool) => {
   const handler = CCI_HANDLERS[tool.name];
   if (!handler) throw new Error(`Handler for tool ${tool.name} not found`);
   if (process.env.debug === 'true') {
-    console.log(`[DEBUG] [Startup] Registering tool: ${tool.name}`);
+    console.error(`[DEBUG] [Startup] Registering tool: ${tool.name}`);
   }
   server.tool(
     tool.name,
@@ -70,10 +70,10 @@ CCI_TOOLS.forEach((tool) => {
 
 async function main() {
   if (process.env.start === 'remote') {
-    console.log('Starting CircleCI MCP unified HTTP+SSE server...');
+    console.error('Starting CircleCI MCP unified HTTP+SSE server...');
     createUnifiedTransport(server);
   } else {
-    console.log('Starting CircleCI MCP server in stdio mode...');
+    console.error('Starting CircleCI MCP server in stdio mode...');
     createStdioTransport(server);
   }
 }

--- a/src/transports/unified.ts
+++ b/src/transports/unified.ts
@@ -11,7 +11,7 @@ class DebugSSETransport extends SSEServerTransport {
   }
   override async send(payload: any) {
     if (process.env.debug === 'true') {
-      console.log('[DEBUG] SSE out ->', JSON.stringify(payload));
+      console.error('[DEBUG] SSE out ->', JSON.stringify(payload));
     }
     return super.send(payload);
   }
@@ -42,12 +42,12 @@ export const createUnifiedTransport = (server: McpServer) => {
           req.header('Mcp-Session-Id') ||
           req.header('mcp-session-id') ||
           (req.query.sessionId as string);
-        console.log(`[DEBUG] [GET /mcp] Incoming session:`, sessionId);
+        console.error(`[DEBUG] [GET /mcp] Incoming session:`, sessionId);
       }
       // Create SSE transport (stateless)
       const transport = new DebugSSETransport('/mcp', res);
       if (process.env.debug === 'true') {
-        console.log(`[DEBUG] [GET /mcp] Created SSE transport.`);
+        console.error(`[DEBUG] [GET /mcp] Created SSE transport.`);
       }
       await server.connect(transport);
       // Notify newly connected client of current tool catalogue
@@ -65,8 +65,8 @@ export const createUnifiedTransport = (server: McpServer) => {
       try {
         if (process.env.debug === 'true') {
           const names = Object.keys((server as any)._registeredTools ?? {});
-          console.log(`[DEBUG] visible tools:`, names);
-          console.log(
+          console.error(`[DEBUG] visible tools:`, names);
+          console.error(
             `[DEBUG] incoming request body:`,
             JSON.stringify(req.body),
           );
@@ -91,7 +91,7 @@ export const createUnifiedTransport = (server: McpServer) => {
         // started listening on the SSE stream).
         if (req.body?.method === 'initialize') {
           if (process.env.debug === 'true') {
-            console.log(
+            console.error(
               '[DEBUG] initialize handled -> sending tools/list_changed again',
             );
           }
@@ -124,14 +124,14 @@ export const createUnifiedTransport = (server: McpServer) => {
       req.header('mcp-session-id') ||
       (req.query.sessionId as string);
     if (process.env.debug === 'true') {
-      console.log(`[DEBUG] [DELETE /mcp] Incoming sessionId:`, sessionId);
+      console.error(`[DEBUG] [DELETE /mcp] Incoming sessionId:`, sessionId);
     }
     res.status(204).end();
   });
 
   const port = process.env.port || 8000;
   app.listen(port, () => {
-    console.log(
+    console.error(
       `CircleCI MCP unified HTTP+SSE server listening on http://0.0.0.0:${port}`,
     );
   });


### PR DESCRIPTION
Fixes #125 

This PR removes all occurences of `console.log` in the MCP server. As per the [MCP docs](https://modelcontextprotocol.io/docs/develop/build-server#logging-in-mcp-servers):

> For *STDIO-based servers:* Never write to standard output (stdout). This includes:
>
> * `print()` statements in Python
> * `console.log()` in JavaScript
> * `fmt.Println()` in Go
> * Similar stdout functions in other languages
>
> Writing to stdout will corrupt the JSON-RPC messages and break your server.

This PR also extends the ESLint configuration to prevent future usage of `console.log`.
