### PR TITLE
fix: potential fix for #126 `= args.params || {};`

### DIFF
--- a/src/tools/analyzeDiff/handler.ts
+++ b/src/tools/analyzeDiff/handler.ts
@@ -10,7 +10,7 @@ import { CircletClient } from '../../clients/circlet/index.js';
 export const analyzeDiff: ToolCallback<{
   params: typeof analyzeDiffInputSchema;
 }> = async (args) => {
-  const { diff, rules, speedMode, filterBy } = args.params || {};
+  const { diff, rules, speedMode, filterBy } = args.params ?? {};
   const circlet = new CircletClient();
   if (!diff) {
     return {

--- a/src/tools/analyzeDiff/handler.ts
+++ b/src/tools/analyzeDiff/handler.ts
@@ -10,7 +10,7 @@ import { CircletClient } from '../../clients/circlet/index.js';
 export const analyzeDiff: ToolCallback<{
   params: typeof analyzeDiffInputSchema;
 }> = async (args) => {
-  const { diff, rules, speedMode, filterBy } = args.params;
+  const { diff, rules, speedMode, filterBy } = args.params || {};
   const circlet = new CircletClient();
   if (!diff) {
     return {

--- a/src/tools/configHelper/handler.ts
+++ b/src/tools/configHelper/handler.ts
@@ -5,7 +5,7 @@ import { getCircleCIClient } from '../../clients/client.js';
 export const configHelper: ToolCallback<{
   params: typeof configHelperInputSchema;
 }> = async (args) => {
-  const { configFile } = args.params;
+  const { configFile } = args.params || {};
 
   const circleci = getCircleCIClient();
   const configValidate = await circleci.configValidate.validateConfig({

--- a/src/tools/configHelper/handler.ts
+++ b/src/tools/configHelper/handler.ts
@@ -5,7 +5,7 @@ import { getCircleCIClient } from '../../clients/client.js';
 export const configHelper: ToolCallback<{
   params: typeof configHelperInputSchema;
 }> = async (args) => {
-  const { configFile } = args.params || {};
+  const { configFile } = args.params ?? {};
 
   const circleci = getCircleCIClient();
   const configValidate = await circleci.configValidate.validateConfig({

--- a/src/tools/createPromptTemplate/handler.ts
+++ b/src/tools/createPromptTemplate/handler.ts
@@ -12,7 +12,7 @@ export const temperatureKey = 'temperature';
 export const createPromptTemplate: ToolCallback<{
   params: typeof createPromptTemplateInputSchema;
 }> = async (args) => {
-  const { prompt, promptOrigin, model } = args.params;
+  const { prompt, promptOrigin, model } = args.params || {};
 
   const circlet = new CircletClient();
   const promptObject = await circlet.circlet.createPromptTemplate(

--- a/src/tools/createPromptTemplate/handler.ts
+++ b/src/tools/createPromptTemplate/handler.ts
@@ -12,7 +12,7 @@ export const temperatureKey = 'temperature';
 export const createPromptTemplate: ToolCallback<{
   params: typeof createPromptTemplateInputSchema;
 }> = async (args) => {
-  const { prompt, promptOrigin, model } = args.params || {};
+  const { prompt, promptOrigin, model } = args.params ?? {};
 
   const circlet = new CircletClient();
   const promptObject = await circlet.circlet.createPromptTemplate(

--- a/src/tools/downloadUsageApiData/handler.ts
+++ b/src/tools/downloadUsageApiData/handler.ts
@@ -17,7 +17,7 @@ export const downloadUsageApiData: ToolCallback<{ params: typeof downloadUsageAp
     endDate,
     outputDir,
     jobId,
-  } = args.params || {};
+  } = args.params ?? {};
 
   const hasDates = Boolean(startDate) && Boolean(endDate);
   const hasJobId = Boolean(jobId);

--- a/src/tools/downloadUsageApiData/handler.ts
+++ b/src/tools/downloadUsageApiData/handler.ts
@@ -17,7 +17,7 @@ export const downloadUsageApiData: ToolCallback<{ params: typeof downloadUsageAp
     endDate,
     outputDir,
     jobId,
-  } = args.params;
+  } = args.params || {};
 
   const hasDates = Boolean(startDate) && Boolean(endDate);
   const hasJobId = Boolean(jobId);

--- a/src/tools/findUnderusedResourceClasses/handler.ts
+++ b/src/tools/findUnderusedResourceClasses/handler.ts
@@ -7,7 +7,7 @@ export const findUnderusedResourceClasses: ToolCallback<{ params: typeof findUnd
   const { 
     csvFilePath, 
     threshold 
-  } = args.params;
+  } = args.params || {};
 
   if (!csvFilePath) {
     return mcpErrorOutput('ERROR: csvFilePath is required.');

--- a/src/tools/findUnderusedResourceClasses/handler.ts
+++ b/src/tools/findUnderusedResourceClasses/handler.ts
@@ -7,7 +7,7 @@ export const findUnderusedResourceClasses: ToolCallback<{ params: typeof findUnd
   const { 
     csvFilePath, 
     threshold 
-  } = args.params || {};
+  } = args.params ?? {};
 
   if (!csvFilePath) {
     return mcpErrorOutput('ERROR: csvFilePath is required.');

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -19,7 +19,7 @@ export const getBuildFailureLogs: ToolCallback<{
     branch,
     projectURL,
     projectSlug: inputProjectSlug,
-  } = args.params || {};
+  } = args.params ?? {};
 
   let projectSlug: string | undefined;
   let pipelineNumber: number | undefined;

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -19,7 +19,7 @@ export const getBuildFailureLogs: ToolCallback<{
     branch,
     projectURL,
     projectSlug: inputProjectSlug,
-  } = args.params;
+  } = args.params || {};
 
   let projectSlug: string | undefined;
   let pipelineNumber: number | undefined;

--- a/src/tools/getFlakyTests/handler.ts
+++ b/src/tools/getFlakyTests/handler.ts
@@ -23,7 +23,7 @@ export const getFlakyTestLogs: ToolCallback<{
     gitRemoteURL,
     projectURL,
     projectSlug: inputProjectSlug,
-  } = args.params || {};
+  } = args.params ?? {};
 
   let projectSlug: string | null | undefined;
 

--- a/src/tools/getFlakyTests/handler.ts
+++ b/src/tools/getFlakyTests/handler.ts
@@ -23,7 +23,7 @@ export const getFlakyTestLogs: ToolCallback<{
     gitRemoteURL,
     projectURL,
     projectSlug: inputProjectSlug,
-  } = args.params;
+  } = args.params || {};
 
   let projectSlug: string | null | undefined;
 

--- a/src/tools/getJobTestResults/handler.ts
+++ b/src/tools/getJobTestResults/handler.ts
@@ -21,7 +21,7 @@ export const getJobTestResults: ToolCallback<{
     projectURL,
     filterByTestsResult,
     projectSlug: inputProjectSlug,
-  } = args.params || {};
+  } = args.params ?? {};
 
   let pipelineNumber: number | undefined;
   let projectSlug: string | undefined;

--- a/src/tools/getJobTestResults/handler.ts
+++ b/src/tools/getJobTestResults/handler.ts
@@ -21,7 +21,7 @@ export const getJobTestResults: ToolCallback<{
     projectURL,
     filterByTestsResult,
     projectSlug: inputProjectSlug,
-  } = args.params;
+  } = args.params || {};
 
   let pipelineNumber: number | undefined;
   let projectSlug: string | undefined;

--- a/src/tools/getLatestPipelineStatus/handler.ts
+++ b/src/tools/getLatestPipelineStatus/handler.ts
@@ -18,7 +18,7 @@ export const getLatestPipelineStatus: ToolCallback<{
     branch,
     projectURL,
     projectSlug: inputProjectSlug,
-  } = args.params || {};
+  } = args.params ?? {};
 
   let projectSlug: string | null | undefined;
   let branchFromURL: string | null | undefined;

--- a/src/tools/getLatestPipelineStatus/handler.ts
+++ b/src/tools/getLatestPipelineStatus/handler.ts
@@ -18,7 +18,7 @@ export const getLatestPipelineStatus: ToolCallback<{
     branch,
     projectURL,
     projectSlug: inputProjectSlug,
-  } = args.params;
+  } = args.params || {};
 
   let projectSlug: string | null | undefined;
   let branchFromURL: string | null | undefined;

--- a/src/tools/listComponentVersions/handler.ts
+++ b/src/tools/listComponentVersions/handler.ts
@@ -18,7 +18,7 @@ export const listComponentVersions: ToolCallback<{
     orgID: providedOrgID,
     componentID,
     environmentID,
-  } = args.params;
+  } = args.params || {};
 
   try {
     // Resolve project and organization information

--- a/src/tools/listComponentVersions/handler.ts
+++ b/src/tools/listComponentVersions/handler.ts
@@ -18,7 +18,7 @@ export const listComponentVersions: ToolCallback<{
     orgID: providedOrgID,
     componentID,
     environmentID,
-  } = args.params || {};
+  } = args.params ?? {};
 
   try {
     // Resolve project and organization information

--- a/src/tools/recommendPromptTemplateTests/handler.ts
+++ b/src/tools/recommendPromptTemplateTests/handler.ts
@@ -21,7 +21,7 @@ const recommendedTestsKey = 'recommendedTests';
 export const recommendPromptTemplateTests: ToolCallback<{
   params: typeof recommendPromptTemplateTestsInputSchema;
 }> = async (args) => {
-  const { template, contextSchema, promptOrigin } = args.params || {};
+  const { template, contextSchema, promptOrigin } = args.params ?? {};
 
   const circlet = new CircletClient();
   const result = await circlet.circlet.recommendPromptTemplateTests({

--- a/src/tools/recommendPromptTemplateTests/handler.ts
+++ b/src/tools/recommendPromptTemplateTests/handler.ts
@@ -21,7 +21,7 @@ const recommendedTestsKey = 'recommendedTests';
 export const recommendPromptTemplateTests: ToolCallback<{
   params: typeof recommendPromptTemplateTestsInputSchema;
 }> = async (args) => {
-  const { template, contextSchema, promptOrigin } = args.params;
+  const { template, contextSchema, promptOrigin } = args.params || {};
 
   const circlet = new CircletClient();
   const result = await circlet.circlet.recommendPromptTemplateTests({

--- a/src/tools/rerunWorkflow/handler.ts
+++ b/src/tools/rerunWorkflow/handler.ts
@@ -8,8 +8,8 @@ import { getWorkflowIdFromURL } from '../../lib/getWorkflowIdFromURL.js';
 export const rerunWorkflow: ToolCallback<{
   params: typeof rerunWorkflowInputSchema;
 }> = async (args) => {
-  let { workflowId } = args.params || {};
-  const { fromFailed, workflowURL } = args.params || {};
+  let { workflowId } = args.params ?? {};
+  const { fromFailed, workflowURL } = args.params ?? {};
   const baseURL = getAppURL();
   const circleci = getCircleCIClient();
 

--- a/src/tools/rerunWorkflow/handler.ts
+++ b/src/tools/rerunWorkflow/handler.ts
@@ -8,8 +8,8 @@ import { getWorkflowIdFromURL } from '../../lib/getWorkflowIdFromURL.js';
 export const rerunWorkflow: ToolCallback<{
   params: typeof rerunWorkflowInputSchema;
 }> = async (args) => {
-  let { workflowId } = args.params;
-  const { fromFailed, workflowURL } = args.params;
+  let { workflowId } = args.params || {};
+  const { fromFailed, workflowURL } = args.params || {};
   const baseURL = getAppURL();
   const circleci = getCircleCIClient();
 

--- a/src/tools/runEvaluationTests/handler.ts
+++ b/src/tools/runEvaluationTests/handler.ts
@@ -20,7 +20,7 @@ export const runEvaluationTests: ToolCallback<{
     pipelineChoiceName,
     projectSlug: inputProjectSlug,
     promptFiles,
-  } = args.params || {};
+  } = args.params ?? {};
 
   let projectSlug: string | undefined;
   let branchFromURL: string | undefined;

--- a/src/tools/runEvaluationTests/handler.ts
+++ b/src/tools/runEvaluationTests/handler.ts
@@ -20,7 +20,7 @@ export const runEvaluationTests: ToolCallback<{
     pipelineChoiceName,
     projectSlug: inputProjectSlug,
     promptFiles,
-  } = args.params;
+  } = args.params || {};
 
   let projectSlug: string | undefined;
   let branchFromURL: string | undefined;

--- a/src/tools/runPipeline/handler.ts
+++ b/src/tools/runPipeline/handler.ts
@@ -20,7 +20,7 @@ export const runPipeline: ToolCallback<{
     projectURL,
     pipelineChoiceName,
     projectSlug: inputProjectSlug,
-  } = args.params;
+  } = args.params || {};
 
   let projectSlug: string | undefined;
   let branchFromURL: string | undefined;

--- a/src/tools/runPipeline/handler.ts
+++ b/src/tools/runPipeline/handler.ts
@@ -20,7 +20,7 @@ export const runPipeline: ToolCallback<{
     projectURL,
     pipelineChoiceName,
     projectSlug: inputProjectSlug,
-  } = args.params || {};
+  } = args.params ?? {};
 
   let projectSlug: string | undefined;
   let branchFromURL: string | undefined;

--- a/src/tools/runRollbackPipeline/handler.ts
+++ b/src/tools/runRollbackPipeline/handler.ts
@@ -16,7 +16,7 @@ export const runRollbackPipeline: ToolCallback<{
     namespace,
     reason,
     parameters,
-  } = args.params || {};
+  } = args.params ?? {};
 
 
   // Init the client and get the base URL

--- a/src/tools/runRollbackPipeline/handler.ts
+++ b/src/tools/runRollbackPipeline/handler.ts
@@ -16,7 +16,7 @@ export const runRollbackPipeline: ToolCallback<{
     namespace,
     reason,
     parameters,
-  } = args.params;
+  } = args.params || {};
 
 
   // Init the client and get the base URL


### PR DESCRIPTION
# Issue: https://github.com/CircleCI-Public/mcp-server-circleci/issues/126

The issue appears to be in how the MCP server registers tools in `/src/index.ts`:

`{ params: tool.inputSchema.optional() }`

This makes the entire `params` object optional, so when clients call tools without parameters, `args.params` becomes `undefined`.

# Proposed solution

`const { someDestructuredVal } = args.params || {};`

# Changes
- just added a little `= args.params || {};` action everywhere to assuage the need for destructuring optional and potentially `undefined` `args.params`.