### PR TITLE
feat: make MAX_LENGTH configurable via MAX_MCP_OUTPUT_LENGTH env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Add the following to your cursor MCP config:
       "args": ["-y", "@circleci/mcp-server-circleci@latest"],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
+        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
+        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
       }
     }
   }
@@ -67,11 +68,14 @@ Add the following to your cursor MCP config:
         "CIRCLECI_TOKEN",
         "-e",
         "CIRCLECI_BASE_URL",
+        "-e",
+        "MAX_MCP_OUTPUT_LENGTH",
         "circleci:mcp-server-circleci"
       ],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
+        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
+        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
       }
     }
   }
@@ -212,7 +216,8 @@ Add the following to your claude_desktop_config.json:
       "args": ["-y", "@circleci/mcp-server-circleci@latest"],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
+        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
+        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
       }
     }
   }
@@ -245,11 +250,14 @@ Add the following to your claude_desktop_config.json:
         "CIRCLECI_TOKEN",
         "-e",
         "CIRCLECI_BASE_URL",
+        "-e",
+        "MAX_MCP_OUTPUT_LENGTH",
         "circleci:mcp-server-circleci"
       ],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
+        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
+        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
       }
     }
   }
@@ -352,7 +360,8 @@ Add the following to your windsurf mcp_config.json:
       "args": ["-y", "@circleci/mcp-server-circleci@latest"],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
+        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
+        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
       }
     }
   }
@@ -376,11 +385,14 @@ Add the following to your windsurf mcp_config.json:
         "CIRCLECI_TOKEN",
         "-e",
         "CIRCLECI_BASE_URL",
+        "-e",
+        "MAX_MCP_OUTPUT_LENGTH",
         "circleci:mcp-server-circleci"
       ],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
+        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
+        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
       }
     }
   }
@@ -446,7 +458,8 @@ Edit your global configuration file ~/.aws/amazonq/mcp.json or create a new one 
       ],
       "env": {
         "CIRCLECI_TOKEN": "YOUR_CIRCLECI_TOKEN",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
+        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
+        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
       },
       "timeout": 60000
     }
@@ -495,7 +508,8 @@ Edit your global configuration file ~/.aws/amazonq/mcp.json or create a new one 
       ],
       "env": {
         "CIRCLECI_TOKEN": "YOUR_CIRCLECI_TOKEN",
-        "CIRCLECI_BASE_URL": "https://circleci.com" // Optional - required for on-prem customers only
+        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
+        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
       },
       "timeout": 60000
     }

--- a/src/lib/outputTextTruncated.ts
+++ b/src/lib/outputTextTruncated.ts
@@ -1,6 +1,7 @@
 import { McpSuccessResponse } from './mcpResponse.js';
 
-const MAX_LENGTH = 50000;
+const MAX_LENGTH =
+  parseInt(process.env.MAX_MCP_OUTPUT_LENGTH ?? '', 10) || 50000;
 
 export const SEPARATOR = '\n<<<SEPARATOR>>>\n';
 


### PR DESCRIPTION
## Summary
- Make the `MAX_LENGTH` constant in `outputTextTruncated.ts` configurable via the `MAX_MCP_OUTPUT_LENGTH` environment variable
- Default value remains 50000 (no breaking changes)
- Add documentation to README.md for all supported MCP client configurations

## Rationale
I am using CircleCi's MCP server at work to have a coding agent work through failures. There are many, many failures, and the truncation always is fixed at 50,000 characters which is roughly 12.5k tokens, according to Claude Code's output, preventing the agent from processing all failures. I will use this feature to increase MAX_MCP_OUTPUT_LENGTH above 50000, to let the coding agent read everything.

Example from Claude Code:

```
⏺ circleci-mcp-server - get_build_failure_logs (MCP)(params: {"projectURL”:…})                           
  ⎿  ⚠ Large MCP response (~12.5k tokens), this can fill up context quickly                    
  ⎿  <MCPTruncationWarning>                                                                    
     ⚠️ TRUNCATED OUTPUT WARNING ⚠️                                                              
     - Showing only most recent entries                                                        
     … +625 lines (ctrl+o to expand)                                                           
                                                                                               
⏺ WARNING: The logs have been truncated. Only showing the most recent entries. Earlier build   
  failures may not be visible.
```

There is no MCP based solution to get the entirety of the logs today. The workaround is to copy and paste from the CircleCI GUI. After this contribution, it will be possible via MCP to get the full result.

As context windows expand and context management improves, having a fixed truncation limit will be even more of a problem. Pagination of MCP tool output would also solve this problem, but is likely be a larger contribution.

Configuring the MAX_MCP_OUTPUT_LENGTH, in the meantime, will resolve the issue. Claude Code allows [configuring MAX_MCP_OUTPUT_TOKENS](https://code.claude.com/docs/en/mcp#dynamic-tool-updates), which is analogous to this contribution, so this approach is consistent with related tools.

## Test plan
- [ ] Build passes: `pnpm build`
- [ ] Tests pass: `pnpm test`
- [ ] Manual test with MCP Inspector: set `MAX_MCP_OUTPUT_LENGTH=1000` and verify truncation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)