### PR TITLE
docs: restructure README for improved navigation and completeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,46 @@
 # CircleCI MCP Server
 
-[![GitHub](https://img.shields.io/github/license/CircleCI-Public/mcp-server-circleci)](https://github.com/CircleCI-Public/mcp-server-circleci/blob/main/LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/CircleCI-Public/mcp-server-circleci/blob/main/LICENSE)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/CircleCI-Public/mcp-server-circleci/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/CircleCI-Public/mcp-server-circleci/tree/main)
 [![npm](https://img.shields.io/npm/v/@circleci/mcp-server-circleci?logo=npm)](https://www.npmjs.com/package/@circleci/mcp-server-circleci)
 
 Model Context Protocol (MCP) is a [new, standardized protocol](https://modelcontextprotocol.io/introduction) for managing context between large language models (LLMs) and external systems. In this repository, we provide an MCP Server for [CircleCI](https://circleci.com).
 
-This lets you use Cursor IDE, Windsurf, Copilot, or any MCP supported Client, to use natural language to accomplish things with CircleCI, e.g.:
+Use Cursor, Windsurf, Copilot, Claude, or any MCP-compatible client to interact with CircleCI using natural language — without leaving your IDE.
 
-- `Find the latest failed pipeline on my branch and get logs`
-  https://github.com/CircleCI-Public/mcp-server-circleci/wiki#circleci-mcp-server-with-cursor-ide
+## Tools
 
-https://github.com/user-attachments/assets/3c765985-8827-442a-a8dc-5069e01edb74
-
-## Requirements
-
-- CircleCI Personal API Token - you can generate one through the CircleCI. [Learn more](https://circleci.com/docs/managing-api-tokens/) or [click here](https://app.circleci.com/settings/user/tokens) for quick access.
-
-For NPX installation:
-
-- pnpm package manager - [Learn more](https://pnpm.io/installation)
-- Node.js >= v18.0.0
-
-For Docker installation:
-
-- Docker - [Learn more](https://docs.docker.com/get-docker/)
+| Tool | Description |
+|------|-------------|
+| [`get_build_failure_logs`](#get_build_failure_logs) | Retrieve detailed failure logs from CircleCI builds |
+| [`find_flaky_tests`](#find_flaky_tests) | Identify flaky tests by analyzing test execution history |
+| [`get_latest_pipeline_status`](#get_latest_pipeline_status) | Get the status of the latest pipeline for a branch |
+| [`get_job_test_results`](#get_job_test_results) | Retrieve test metadata and results for CircleCI jobs |
+| [`config_helper`](#config_helper) | Validate and get guidance for your CircleCI configuration |
+| [`create_prompt_template`](#create_prompt_template) | Generate structured prompt templates for AI applications |
+| [`recommend_prompt_template_tests`](#recommend_prompt_template_tests) | Generate test cases for prompt templates |
+| [`list_followed_projects`](#list_followed_projects) | List all CircleCI projects you're following |
+| [`run_pipeline`](#run_pipeline) | Trigger a pipeline to run |
+| [`run_rollback_pipeline`](#run_rollback_pipeline) | Trigger a rollback for a project |
+| [`rerun_workflow`](#rerun_workflow) | Rerun a workflow from start or from the failed job |
+| [`analyze_diff`](#analyze_diff) | Analyze git diffs against cursor rules for violations |
+| [`list_component_versions`](#list_component_versions) | List all versions for a CircleCI component |
+| [`download_usage_api_data`](#download_usage_api_data) | Download usage data from the CircleCI Usage API |
+| [`find_underused_resource_classes`](#find_underused_resource_classes) | Find jobs with underused compute resources |
 
 ## Installation
 
-### Cursor
+<details>
+<summary><strong>Cursor</strong></summary>
+
+**Prerequisites:**
+- [CircleCI Personal API token](https://app.circleci.com/settings/user/tokens) ([learn more](https://circleci.com/docs/managing-api-tokens/))
+- NPX: [Node.js >= v18](https://nodejs.org/) and [pnpm](https://pnpm.io/installation)
+- Docker: [Docker](https://docs.docker.com/get-docker/)
 
 #### Using NPX in a local MCP Server
 
-Add the following to your cursor MCP config:
+Add the following to your Cursor MCP config:
 
 ```json
 {
@@ -42,18 +50,20 @@ Add the following to your cursor MCP config:
       "args": ["-y", "@circleci/mcp-server-circleci@latest"],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
-        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
+        "CIRCLECI_BASE_URL": "https://circleci.com",
+        "MAX_MCP_OUTPUT_LENGTH": "50000"
       }
     }
   }
 }
 ```
 
+> `CIRCLECI_BASE_URL` is optional — required for on-prem customers only.
+> `MAX_MCP_OUTPUT_LENGTH` is optional — maximum output length for MCP responses (default: 50000).
 
 #### Using Docker in a local MCP Server
 
-Add the following to your cursor MCP config:
+Add the following to your Cursor MCP config:
 
 ```json
 {
@@ -70,12 +80,12 @@ Add the following to your cursor MCP config:
         "CIRCLECI_BASE_URL",
         "-e",
         "MAX_MCP_OUTPUT_LENGTH",
-        "circleci:mcp-server-circleci"
+        "circleci/mcp-server-circleci"
       ],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
-        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
+        "CIRCLECI_BASE_URL": "https://circleci.com",
+        "MAX_MCP_OUTPUT_LENGTH": "50000"
       }
     }
   }
@@ -84,14 +94,14 @@ Add the following to your cursor MCP config:
 
 #### Using a Self-Managed Remote MCP Server
 
-Add the following to your cursor MCP config:
+Add the following to your Cursor MCP config:
 
 ```json
 {
   "inputs": [
     {
       "type": "promptString",
-      "id": "circleci-token", 
+      "id": "circleci-token",
       "description": "CircleCI API Token",
       "password": true
     }
@@ -104,15 +114,22 @@ Add the following to your cursor MCP config:
 }
 ```
 
-### VS Code
+</details>
+
+<details>
+<summary><strong>VS Code</strong></summary>
+
+**Prerequisites:**
+- [CircleCI Personal API token](https://app.circleci.com/settings/user/tokens) ([learn more](https://circleci.com/docs/managing-api-tokens/))
+- NPX: [Node.js >= v18](https://nodejs.org/) and [pnpm](https://pnpm.io/installation)
+- Docker: [Docker](https://docs.docker.com/get-docker/)
 
 #### Using NPX in a local MCP Server
 
-To install CircleCI MCP Server for VS Code in `.vscode/mcp.json`:
+Add the following to `.vscode/mcp.json` in your project:
 
 ```json
 {
-  // 💡 Inputs are prompted on first server start, then stored securely by VS Code.
   "inputs": [
     {
       "type": "promptString",
@@ -128,7 +145,6 @@ To install CircleCI MCP Server for VS Code in `.vscode/mcp.json`:
     }
   ],
   "servers": {
-    // https://github.com/ppl-ai/modelcontextprotocol/
     "circleci-mcp-server": {
       "type": "stdio",
       "command": "npx",
@@ -142,13 +158,14 @@ To install CircleCI MCP Server for VS Code in `.vscode/mcp.json`:
 }
 ```
 
+> 💡 Inputs are prompted on first server start, then stored securely by VS Code.
+
 #### Using Docker in a local MCP Server
 
-To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using Docker:
+Add the following to `.vscode/mcp.json` in your project:
 
 ```json
 {
-  // 💡 Inputs are prompted on first server start, then stored securely by VS Code.
   "inputs": [
     {
       "type": "promptString",
@@ -164,7 +181,6 @@ To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using Docker:
     }
   ],
   "servers": {
-    // https://github.com/ppl-ai/modelcontextprotocol/
     "circleci-mcp-server": {
       "type": "stdio",
       "command": "docker",
@@ -176,7 +192,7 @@ To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using Docker:
         "CIRCLECI_TOKEN",
         "-e",
         "CIRCLECI_BASE_URL",
-        "circleci:mcp-server-circleci"
+        "circleci/mcp-server-circleci"
       ],
       "env": {
         "CIRCLECI_TOKEN": "${input:circleci-token}",
@@ -189,7 +205,7 @@ To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using Docker:
 
 #### Using a Self-Managed Remote MCP Server
 
-To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using a self-managed remote MCP server:
+Add the following to `.vscode/mcp.json` in your project:
 
 ```json
 {
@@ -202,11 +218,19 @@ To install CircleCI MCP Server for VS Code in `.vscode/mcp.json` using a self-ma
 }
 ```
 
-### Claude Desktop
+</details>
+
+<details>
+<summary><strong>Claude Desktop</strong></summary>
+
+**Prerequisites:**
+- [CircleCI Personal API token](https://app.circleci.com/settings/user/tokens) ([learn more](https://circleci.com/docs/managing-api-tokens/))
+- NPX: [Node.js >= v18](https://nodejs.org/) and [pnpm](https://pnpm.io/installation)
+- Docker: [Docker](https://docs.docker.com/get-docker/)
 
 #### Using NPX in a local MCP Server
 
-Add the following to your claude_desktop_config.json:
+Add the following to your `claude_desktop_config.json`:
 
 ```json
 {
@@ -216,26 +240,17 @@ Add the following to your claude_desktop_config.json:
       "args": ["-y", "@circleci/mcp-server-circleci@latest"],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
-        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
+        "CIRCLECI_BASE_URL": "https://circleci.com",
+        "MAX_MCP_OUTPUT_LENGTH": "50000"
       }
     }
   }
 }
 ```
-To locate this file:
-
-macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-
-
-Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-
-[Claude Desktop setup](https://modelcontextprotocol.io/quickstart/user)
-
 
 #### Using Docker in a local MCP Server
 
-Add the following to your claude_desktop_config.json:
+Add the following to your `claude_desktop_config.json`:
 
 ```json
 {
@@ -252,38 +267,26 @@ Add the following to your claude_desktop_config.json:
         "CIRCLECI_BASE_URL",
         "-e",
         "MAX_MCP_OUTPUT_LENGTH",
-        "circleci:mcp-server-circleci"
+        "circleci/mcp-server-circleci"
       ],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
-        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
+        "CIRCLECI_BASE_URL": "https://circleci.com",
+        "MAX_MCP_OUTPUT_LENGTH": "50000"
       }
     }
   }
 }
 ```
 
-To find/create this file, first open your claude desktop settings. Then click on "Developer" in the left-hand bar of the Settings pane, and then click on "Edit Config"
-
-This will create a configuration file at:
-
-- macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
-- Windows: %APPDATA%\Claude\claude_desktop_config.json
-
-See the guide below for more information on using MCP servers with Claude Desktop:
-https://modelcontextprotocol.io/quickstart/user
-
 #### Using a Self-Managed Remote MCP Server
 
-Create a wrapper script first
-
-Create a script file such as 'circleci-remote-mcp.sh':
+Create a wrapper script (e.g. `circleci-remote-mcp.sh`):
 
 ```bash
 #!/bin/bash
 export CIRCLECI_TOKEN="your-circleci-token"
-npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8000/mcp --allow-http 
+npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8000/mcp --allow-http
 ```
 
 Make it executable:
@@ -292,7 +295,7 @@ Make it executable:
 chmod +x circleci-remote-mcp.sh
 ```
 
-Then add the following to your claude_desktop_config.json:
+Then add the following to your `claude_desktop_config.json`:
 
 ```json
 {
@@ -304,21 +307,24 @@ Then add the following to your claude_desktop_config.json:
 }
 ```
 
-To find/create this file, first open your Claude Desktop settings. Then click on "Developer" in the left-hand bar of the Settings pane, and then click on "Edit Config"
+To find or create your config file, open Claude Desktop settings, click **Developer** in the left sidebar, then click **Edit Config**. The config file is located at:
 
-This will create a configuration file at:
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
-- macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
-- Windows: %APPDATA%\Claude\claude_desktop_config.json
+For more information: https://modelcontextprotocol.io/quickstart/user
 
-See the guide below for more information on using MCP servers with Claude Desktop:
-https://modelcontextprotocol.io/quickstart/user
+</details>
 
-### Claude Code
+<details>
+<summary><strong>Claude Code</strong></summary>
+
+**Prerequisites:**
+- [CircleCI Personal API token](https://app.circleci.com/settings/user/tokens) ([learn more](https://circleci.com/docs/managing-api-tokens/))
+- NPX: [Node.js >= v18](https://nodejs.org/) and [pnpm](https://pnpm.io/installation)
+- Docker: [Docker](https://docs.docker.com/get-docker/)
 
 #### Using NPX in a local MCP Server
-
-After installing Claude Code, run the following command:
 
 ```bash
 claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -- npx -y @circleci/mcp-server-circleci@latest
@@ -326,31 +332,31 @@ claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -- npx 
 
 #### Using Docker in a local MCP Server
 
-After installing Claude Code, run the following command:
-
 ```bash
-claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -e CIRCLECI_BASE_URL=https://circleci.com -- docker run --rm -i -e CIRCLECI_TOKEN -e CIRCLECI_BASE_URL circleci:mcp-server-circleci
+claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -e CIRCLECI_BASE_URL=https://circleci.com -- docker run --rm -i -e CIRCLECI_TOKEN -e CIRCLECI_BASE_URL circleci/mcp-server-circleci
 ```
 
-See the guide below for more information on using MCP servers with Claude Code:
-https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp
-
-#### Using Self-Managed Remote MCP Server
-
-After installing Claude Code, run the following command:
+#### Using a Self-Managed Remote MCP Server
 
 ```bash
 claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -- npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8000/mcp --allow-http
 ```
 
-See the guide below for more information on using MCP servers with Claude Code:
-https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp
+For more information: https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp
 
-### Windsurf
+</details>
+
+<details>
+<summary><strong>Windsurf</strong></summary>
+
+**Prerequisites:**
+- [CircleCI Personal API token](https://app.circleci.com/settings/user/tokens) ([learn more](https://circleci.com/docs/managing-api-tokens/))
+- NPX: [Node.js >= v18](https://nodejs.org/) and [pnpm](https://pnpm.io/installation)
+- Docker: [Docker](https://docs.docker.com/get-docker/)
 
 #### Using NPX in a local MCP Server
 
-Add the following to your windsurf mcp_config.json:
+Add the following to your Windsurf `mcp_config.json`:
 
 ```json
 {
@@ -360,8 +366,8 @@ Add the following to your windsurf mcp_config.json:
       "args": ["-y", "@circleci/mcp-server-circleci@latest"],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
-        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
+        "CIRCLECI_BASE_URL": "https://circleci.com",
+        "MAX_MCP_OUTPUT_LENGTH": "50000"
       }
     }
   }
@@ -370,7 +376,7 @@ Add the following to your windsurf mcp_config.json:
 
 #### Using Docker in a local MCP Server
 
-Add the following to your windsurf mcp_config.json:
+Add the following to your Windsurf `mcp_config.json`:
 
 ```json
 {
@@ -387,21 +393,21 @@ Add the following to your windsurf mcp_config.json:
         "CIRCLECI_BASE_URL",
         "-e",
         "MAX_MCP_OUTPUT_LENGTH",
-        "circleci:mcp-server-circleci"
+        "circleci/mcp-server-circleci"
       ],
       "env": {
         "CIRCLECI_TOKEN": "your-circleci-token",
-        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
-        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
+        "CIRCLECI_BASE_URL": "https://circleci.com",
+        "MAX_MCP_OUTPUT_LENGTH": "50000"
       }
     }
   }
 }
 ```
 
-#### Using Self-Managed Remote MCP Server
+#### Using a Self-Managed Remote MCP Server
 
-Add the following to your windsurf mcp_config.json:
+Add the following to your Windsurf `mcp_config.json`:
 
 ```json
 {
@@ -420,32 +426,27 @@ Add the following to your windsurf mcp_config.json:
 }
 ```
 
-See the guide below for more information on using MCP servers with windsurf:
-https://docs.windsurf.com/windsurf/mcp
+For more information: https://docs.windsurf.com/windsurf/mcp
 
-### Installing via Smithery
+</details>
 
-To install CircleCI MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@CircleCI-Public/mcp-server-circleci):
+<details>
+<summary><strong>Amazon Q Developer CLI</strong></summary>
 
-```bash
-npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claude
-```
+**Prerequisites:**
+- [CircleCI Personal API token](https://app.circleci.com/settings/user/tokens) ([learn more](https://circleci.com/docs/managing-api-tokens/))
+- NPX: [Node.js >= v18](https://nodejs.org/) and [pnpm](https://pnpm.io/installation)
 
-### Amazon Q Developer CLi
+MCP client configuration in Amazon Q Developer is stored in JSON format in a file named `mcp.json`. Two levels of configuration are supported:
 
-MCP client configuration in Amazon Q Developer is stored in JSON format, in a file named mcp.json.
+- **Global:** `~/.aws/amazonq/mcp.json` — applies to all workspaces
+- **Workspace:** `.amazonq/mcp.json` — specific to the current workspace
 
-Amazon Q Developer CLI supports two levels of MCP configuration:
-
-Global Configuration: ~/.aws/amazonq/mcp.json - Applies to all workspaces
-
-Workspace Configuration: .amazonq/mcp.json - Specific to the current workspace
-
-Both files are optional; neither, one, or both can exist. If both files exist, Amazon Q Developer reads MCP configuration from both and combines them, taking the union of their contents. If there is a conflict (i.e., a server defined in the global config is also present in the workspace config), a warning is displayed and only the server entry in the workspace config is used.
+If both files exist, their contents are merged. In case of conflict, the workspace config takes precedence.
 
 #### Using NPX in a local MCP Server
 
-Edit your global configuration file ~/.aws/amazonq/mcp.json or create a new one in the current workspace .amazonq/mcp.json with the following content:
+Edit `~/.aws/amazonq/mcp.json` or create `.amazonq/mcp.json` with the following:
 
 ```json
 {
@@ -458,8 +459,8 @@ Edit your global configuration file ~/.aws/amazonq/mcp.json or create a new one 
       ],
       "env": {
         "CIRCLECI_TOKEN": "YOUR_CIRCLECI_TOKEN",
-        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
-        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
+        "CIRCLECI_BASE_URL": "https://circleci.com",
+        "MAX_MCP_OUTPUT_LENGTH": "50000"
       },
       "timeout": 60000
     }
@@ -469,9 +470,7 @@ Edit your global configuration file ~/.aws/amazonq/mcp.json or create a new one 
 
 #### Using a Self-Managed Remote MCP Server
 
-Create a wrapper script first
-
-Create a script file such as 'circleci-remote-mcp.sh':
+Create a wrapper script (e.g. `circleci-remote-mcp.sh`):
 
 ```bash
 #!/bin/bash
@@ -479,23 +478,25 @@ export CIRCLECI_TOKEN="your-circleci-token"
 npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8000/mcp --allow-http
 ```
 
-Make it executable:
+Make it executable and add it:
 
 ```bash
 chmod +x circleci-remote-mcp.sh
-```
-
-Then add it:
-
-```bash
 q mcp add --name circleci --command "/full/path/to/circleci-remote-mcp.sh"
 ```
 
-### Amazon Q Developer in the IDE
+</details>
+
+<details>
+<summary><strong>Amazon Q Developer in the IDE</strong></summary>
+
+**Prerequisites:**
+- [CircleCI Personal API token](https://app.circleci.com/settings/user/tokens) ([learn more](https://circleci.com/docs/managing-api-tokens/))
+- NPX: [Node.js >= v18](https://nodejs.org/) and [pnpm](https://pnpm.io/installation)
 
 #### Using NPX in a local MCP Server
 
-Edit your global configuration file ~/.aws/amazonq/mcp.json or create a new one in the current workspace .amazonq/mcp.json with the following content:
+Edit `~/.aws/amazonq/mcp.json` or create `.amazonq/mcp.json` with the following:
 
 ```json
 {
@@ -508,8 +509,8 @@ Edit your global configuration file ~/.aws/amazonq/mcp.json or create a new one 
       ],
       "env": {
         "CIRCLECI_TOKEN": "YOUR_CIRCLECI_TOKEN",
-        "CIRCLECI_BASE_URL": "https://circleci.com", // Optional - required for on-prem customers only
-        "MAX_MCP_OUTPUT_LENGTH": "50000" // Optional - maximum output length for MCP responses (default: 50000)
+        "CIRCLECI_BASE_URL": "https://circleci.com",
+        "MAX_MCP_OUTPUT_LENGTH": "50000"
       },
       "timeout": 60000
     }
@@ -519,542 +520,327 @@ Edit your global configuration file ~/.aws/amazonq/mcp.json or create a new one 
 
 #### Using a Self-Managed Remote MCP Server
 
-Create a wrapper script first
-
-Create a script file such as 'circleci-remote-mcp.sh':
+Create a wrapper script (e.g. `circleci-remote-mcp.sh`):
 
 ```bash
 #!/bin/bash
 npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8000/mcp --allow-http
 ```
 
-Make it executable:
+Make it executable, then add it via the MCP configuration UI:
+
+1. [Access the MCP configuration UI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/mcp-ide.html#mcp-ide-configuration-access-ui)
+2. Choose the **+** symbol
+3. Select scope: **global** or **local**
+4. Enter a name (e.g. `circleci-remote-mcp`)
+5. Select transport protocol: **stdio**
+6. Enter the command path to your script
+7. Click **Save**
+
+</details>
+
+<details>
+<summary><strong>Smithery</strong></summary>
+
+To install CircleCI MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@CircleCI-Public/mcp-server-circleci):
 
 ```bash
-chmod +x circleci-remote-mcp.sh
+npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claude
 ```
 
-Then add it to the Q Developer in your IDE:
+</details>
 
-Access the MCP configuration UI (https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/mcp-ide.html#mcp-ide-configuration-access-ui).
+## Demo
 
-Choose the plus (+) symbol.
+<details>
+<summary><strong>Watch it in action</strong></summary>
 
-Select the scope: global or local.
+Example: "Find the latest failed pipeline on my branch and get logs"
+— see the [wiki](https://github.com/CircleCI-Public/mcp-server-circleci/wiki#circleci-mcp-server-with-cursor-ide) for more examples.
 
-If you select global scope, the MCP server configuration is stored in ~/.aws/amazonq/mcp.json and available across all your projects. If you select local scope, the configuration is stored in .amazonq/mcp.json within your current project.
+https://github.com/user-attachments/assets/3c765985-8827-442a-a8dc-5069e01edb74
 
-In the Name field, enter the name of the CircleCI remote MCP server (e.g. circleci-remote-mcp).
+</details>
 
-Select the transport protocol (stdio).
+## Tool Details
 
-In the Command field, enter the shell command created previously that the MCP server will run when it initializes (e.g. /full/path/to/circleci-remote-mcp.sh).
+<details>
+<summary id="get_build_failure_logs"><strong><code>get_build_failure_logs</code></strong></summary>
 
-Click the Save button.
+Retrieves detailed failure logs from CircleCI builds. This tool can be used in three ways:
 
-# Features
+1. **Using Project Slug and Branch (Recommended):**
+   - First use `list_followed_projects` to get your projects, then:
+   - Example: "Get build failures for my-project on the main branch"
 
-## Supported Tools
+2. **Using CircleCI URLs:**
+   - Provide a failed job URL or pipeline URL directly
+   - Example: "Get logs from https://app.circleci.com/pipelines/github/org/repo/123"
 
-- `get_build_failure_logs`
+3. **Using Local Project Context:**
+   - Works from your local workspace by providing workspace root, git remote URL, and branch name
+   - Example: "Find the latest failed pipeline on my current branch"
 
-  Retrieves detailed failure logs from CircleCI builds. This tool can be used in three ways:
+The tool returns formatted logs including:
 
-  1. Using Project Slug and Branch (Recommended Workflow):
+- Job names
+- Step-by-step execution details
+- Failure messages and context
 
-     - First, list your available projects:
-       - Use the list_followed_projects tool to get your projects
-       - Example: "List my CircleCI projects"
-       - Then choose the project, which has a projectSlug associated with it
-       - Example: "Lets use my-project"
-     - Then ask to retrieve the build failure logs for a specific branch:
-       - Example: "Get build failures for my-project on the main branch"
+</details>
 
-  2. Using CircleCI URLs:
+<details>
+<summary id="find_flaky_tests"><strong><code>find_flaky_tests</code></strong></summary>
 
-     - Provide a failed job URL or pipeline URL directly
-     - Example: "Get logs from https://app.circleci.com/pipelines/github/org/repo/123"
+Identifies flaky tests in your CircleCI project by analyzing test execution history. Leverages the [flaky test detection feature](https://circleci.com/blog/introducing-test-insights-with-flaky-test-detection/#flaky-test-detection) in CircleCI.
 
-  3. Using Local Project Context:
-     - Works from your local workspace by providing:
-       - Workspace root path
-       - Git remote URL
-       - Branch name
-     - Example: "Find the latest failed pipeline on my current branch"
+This tool can be used in three ways:
 
-  The tool returns formatted logs including:
+1. **Using Project Slug (Recommended):**
+   - First use `list_followed_projects` to get your projects, then:
+   - Example: "Get flaky tests for my-project"
 
-  - Job names
-  - Step-by-step execution details
-  - Failure messages and context
+2. **Using CircleCI Project URL:**
+   - Example: "Find flaky tests in https://app.circleci.com/pipelines/github/org/repo"
 
-  This is particularly useful for:
+3. **Using Local Project Context:**
+   - Works from your local workspace by providing workspace root and git remote URL
+   - Example: "Find flaky tests in my current project"
 
-  - Debugging failed builds
-  - Analyzing test failures
-  - Investigating deployment issues
-  - Quick access to build logs without leaving your IDE
+Output modes:
 
-- `find_flaky_tests`
+- **Text (default):** Returns flaky test details in text format
+- **File** (requires `FILE_OUTPUT_DIRECTORY` env var): Creates a directory with flaky test details
 
-  Identifies flaky tests in your CircleCI project by analyzing test execution history. This leverages the flaky test detection feature described here: https://circleci.com/blog/introducing-test-insights-with-flaky-test-detection/#flaky-test-detection
+</details>
 
-  This tool can be used in three ways:
+<details>
+<summary id="get_latest_pipeline_status"><strong><code>get_latest_pipeline_status</code></strong></summary>
 
-  1. Using Project Slug (Recommended Workflow):
+Retrieves the status of the latest pipeline for a given branch. This tool can be used in three ways:
 
-     - First, list your available projects:
-       - Use the list_followed_projects tool to get your projects
-       - Example: "List my CircleCI projects"
-       - Then choose the project, which has a projectSlug associated with it
-       - Example: "Lets use my-project"
-     - Then ask to retrieve the flaky tests:
-       - Example: "Get flaky tests for my-project"
+1. **Using Project Slug and Branch (Recommended):**
+   - Example: "Get the status of the latest pipeline for my-project on the main branch"
 
-  2. Using CircleCI Project URL:
+2. **Using CircleCI Project URL:**
+   - Example: "Get the status of the latest pipeline for https://app.circleci.com/pipelines/github/org/repo"
 
-     - Provide the project URL directly from CircleCI
-     - Example: "Find flaky tests in https://app.circleci.com/pipelines/github/org/repo"
+3. **Using Local Project Context:**
+   - Works from your local workspace by providing workspace root, git remote URL, and branch name
 
-  3. Using Local Project Context:
-     - Works from your local workspace by providing:
-       - Workspace root path
-       - Git remote URL
-     - Example: "Find flaky tests in my current project"
+Example output:
 
-  The tool can be used in two ways:
-  1. Using text output mode (default):
-     - This will return the flaky tests and their details in a text format
-  2. Using file output mode: (requires the `FILE_OUTPUT_DIRECTORY` environment variable to be set)
-     - This will create a directory with the flaky tests and their details
+```
+---
+Workflow: build
+Status: success
+Duration: 5 minutes
+Created: 4/20/2025, 10:15:30 AM
+Stopped: 4/20/2025, 10:20:45 AM
+---
+Workflow: test
+Status: running
+Duration: unknown
+Created: 4/20/2025, 10:21:00 AM
+Stopped: in progress
+```
 
-  The tool returns detailed information about flaky tests, including:
+</details>
 
-  - Test names and file locations
-  - Failure messages and contexts
+<details>
+<summary id="get_job_test_results"><strong><code>get_job_test_results</code></strong></summary>
 
-  This helps you:
+Retrieves test metadata for CircleCI jobs, allowing you to analyze test results without leaving your IDE. This tool can be used in three ways:
 
-  - Identify unreliable tests in your test suite
-  - Get detailed context about test failures
-  - Make data-driven decisions about test improvements
-
-- `get_latest_pipeline_status`
-
-  Retrieves the status of the latest pipeline for a given branch. This tool can be used in three ways:
-
-  1. Using Project Slug and Branch (Recommended Workflow):
-
-     - First, list your available projects:
-       - Use the list_followed_projects tool to get your projects
-       - Example: "List my CircleCI projects"
-       - Then choose the project, which has a projectSlug associated with it
-       - Example: "Lets use my-project"
-     - Then ask to retrieve the latest pipeline status for a specific branch:
-       - Example: "Get the status of the latest pipeline for my-project on the main branch"
-
-  2. Using CircleCI Project URL:
+1. **Using Project Slug and Branch (Recommended):**
+   - Example: "Get test results for my-project on the main branch"
 
-     - Provide the project URL directly from CircleCI
-     - Example: "Get the status of the latest pipeline for https://app.circleci.com/pipelines/github/org/repo"
+2. **Using CircleCI URL:**
+   - Job URL: `https://app.circleci.com/pipelines/github/org/repo/123/workflows/abc-def/jobs/789`
+   - Workflow URL: `https://app.circleci.com/pipelines/github/org/repo/123/workflows/abc-def`
+   - Pipeline URL: `https://app.circleci.com/pipelines/github/org/repo/123`
 
-  3. Using Local Project Context:
-     - Works from your local workspace by providing:
-       - Workspace root path
-       - Git remote URL
-       - Branch name
-     - Example: "Get the status of the latest pipeline for my current project"
+3. **Using Local Project Context:**
+   - Works from your local workspace by providing workspace root, git remote URL, and branch name
 
-  The tool returns a formatted status of the latest pipeline:
+The tool returns:
 
-  - Workflow names and their current status
-  - Duration of each workflow
-  - Creation and completion timestamps
-  - Overall pipeline health
+- Summary of all tests (total, successful, failed)
+- Detailed info on failed tests: name, class, file, error message, duration
+- List of successful tests with timing
+- Filter by test result
 
-  Example output:
+> [!NOTE]
+> Test metadata must be configured in your CircleCI config. See [Collect Test Data](https://circleci.com/docs/collect-test-data/) for setup instructions.
 
-  ```
-  ---
-  Workflow: build
-  Status: success
-  Duration: 5 minutes
-  Created: 4/20/2025, 10:15:30 AM
-  Stopped: 4/20/2025, 10:20:45 AM
-  ---
-  Workflow: test
-  Status: running
-  Duration: unknown
-  Created: 4/20/2025, 10:21:00 AM
-  Stopped: in progress
-  ```
+</details>
 
-  This is particularly useful for:
+<details>
+<summary id="config_helper"><strong><code>config_helper</code></strong></summary>
 
-  - Checking the status of the latest pipeline
-  - Getting the status of the latest pipeline for a specific branch
-  - Quickly checking the status of the latest pipeline without leaving your IDE
+Assists with CircleCI configuration tasks by providing guidance and validation.
 
-- `get_job_test_results`
+- Validates your `.circleci/config.yml` for syntax and semantic errors
+- Provides detailed validation results and configuration recommendations
+- Example: "Validate my CircleCI config"
 
-  Retrieves test metadata for CircleCI jobs, allowing you to analyze test results without leaving your IDE. This tool can be used in three ways:
+</details>
 
-  1. Using Project Slug and Branch (Recommended Workflow):
+<details>
+<summary id="create_prompt_template"><strong><code>create_prompt_template</code></strong></summary>
 
-     - First, list your available projects:
-       - Use the list_followed_projects tool to get your projects
-       - Example: "List my CircleCI projects"
-       - Then choose the project, which has a projectSlug associated with it
-       - Example: "Lets use my-project"
-     - Then ask to retrieve the test results for a specific branch:
-       - Example: "Get test results for my-project on the main branch"
+Generates structured prompt templates for AI-enabled applications based on feature requirements.
 
-  2. Using CircleCI URL:
+- Transforms user requirements into optimized prompt templates
+- Returns a structured template and a context schema defining required input parameters
+- Example: "Create a prompt template for generating bedtime stories by age and topic"
 
-     - Provide a CircleCI URL in any of these formats:
-       - Job URL: "https://app.circleci.com/pipelines/github/org/repo/123/workflows/abc-def/jobs/789"
-       - Workflow URL: "https://app.circleci.com/pipelines/github/org/repo/123/workflows/abc-def"
-       - Pipeline URL: "https://app.circleci.com/pipelines/github/org/repo/123"
-     - Example: "Get test results for https://app.circleci.com/pipelines/github/org/repo/123/workflows/abc-def"
+</details>
 
-  3. Using Local Project Context:
-     - Works from your local workspace by providing:
-       - Workspace root path
-       - Git remote URL
-       - Branch name
-     - Example: "Get test results for my current project on the main branch"
+<details>
+<summary id="recommend_prompt_template_tests"><strong><code>recommend_prompt_template_tests</code></strong></summary>
 
-  The tool returns detailed test result information:
+Generates test cases for prompt templates to ensure they produce expected results.
 
-  - Summary of all tests (total, successful, failed)
-  - Detailed information about failed tests including:
-    - Test name and class
-    - File location
-    - Error messages
-    - Runtime duration
-  - List of successful tests with timing information
-  - Filter by tests result
+- Creates diverse test scenarios based on your prompt template and context schema
+- Returns an array of recommended test cases with various parameter combinations
+- Example: "Generate tests for my bedtime story prompt template"
 
-  This is particularly useful for:
+</details>
 
-  - Quickly analyzing test failures without visiting the CircleCI web UI
-  - Identifying patterns in test failures
-  - Finding slow tests that might need optimization
-  - Checking test coverage across your project
-  - Troubleshooting flaky tests
+<details>
+<summary id="list_followed_projects"><strong><code>list_followed_projects</code></strong></summary>
 
-  Note: The tool requires that test metadata is properly configured in your CircleCI config. For more information on setting up test metadata collection, see:
-  https://circleci.com/docs/collect-test-data/
+Lists all projects that the user is following on CircleCI.
 
-- `config_helper`
+- Shows all projects you have access to with their `projectSlug`
+- Example: "List my CircleCI projects"
 
-  Assists with CircleCI configuration tasks by providing guidance and validation. This tool helps you:
+Example output:
 
-  1. Validate CircleCI Config:
-     - Checks your .circleci/config.yml for syntax and semantic errors
-     - Example: "Validate my CircleCI config"
+```
+Projects followed:
+1. my-project (projectSlug: gh/organization/my-project)
+2. another-project (projectSlug: gh/organization/another-project)
+```
 
-  The tool provides:
+> [!NOTE]
+> The `projectSlug` (not the project name) is required for many other CircleCI tools.
 
-  - Detailed validation results
-  - Configuration recommendations
+</details>
 
-  This helps you:
+<details>
+<summary id="run_pipeline"><strong><code>run_pipeline</code></strong></summary>
 
-  - Catch configuration errors before pushing
-  - Learn CircleCI configuration best practices
-  - Troubleshoot configuration issues
-  - Implement CircleCI features correctly
+Triggers a pipeline to run. This tool can be used in three ways:
 
-- `create_prompt_template`
+1. **Using Project Slug and Branch (Recommended):**
+   - Example: "Run the pipeline for my-project on the main branch"
 
-  Helps generate structured prompt templates for AI-enabled applications based on feature requirements. This tool:
+2. **Using CircleCI URL:**
+   - Pipeline URL, Workflow URL, Job URL, or Project URL with branch
+   - Example: "Run the pipeline for https://app.circleci.com/pipelines/github/org/repo/123"
 
-  1. Converts Feature Requirements to Structured Prompts:
-     - Transforms user requirements into optimized prompt templates
-     - Example: "Create a prompt template for generating bedtime stories by age and topic"
+3. **Using Local Project Context:**
+   - Works from your local workspace by providing workspace root, git remote URL, and branch name
 
-  The tool provides:
+The tool returns a link to monitor the pipeline execution.
 
-  - A structured prompt template
-  - A context schema defining required input parameters
+</details>
 
-  This helps you:
+<details>
+<summary id="run_rollback_pipeline"><strong><code>run_rollback_pipeline</code></strong></summary>
 
-  - Create effective prompts for AI applications
-  - Standardize input parameters for consistent results
-  - Build robust AI-powered features
+Triggers a rollback for a CircleCI project. The tool interactively guides you through:
 
-- `recommend_prompt_template_tests`
+1. **Project Selection** — lists followed projects for you to choose from
+2. **Environment Selection** — lists available environments (auto-selects if only one)
+3. **Component Selection** — lists available components (auto-selects if only one)
+4. **Version Selection** — displays available versions; you select the target for rollback
+5. **Rollback Mode Detection** — checks if a rollback pipeline is configured
+6. **Execute Rollback** — two options:
+   - **Pipeline Rollback:** triggers the rollback pipeline
+   - **Workflow Rerun:** reruns a previous workflow using its workflow ID
+7. **Confirmation** — summarizes and confirms before execution
 
-  Generates test cases for prompt templates to ensure they produce expected results. This tool:
+</details>
 
-  1. Provides Test Cases for Prompt Templates:
-     - Creates diverse test scenarios based on your prompt template and context schema
-     - Example: "Generate tests for my bedtime story prompt template"
+<details>
+<summary id="rerun_workflow"><strong><code>rerun_workflow</code></strong></summary>
 
-  The tool provides:
+Reruns a workflow from its start or from the failed job.
 
-  - An array of recommended test cases
-  - Various parameter combinations to test template robustness
+Returns the ID of the newly-created workflow and a link to monitor it.
 
-  This helps you:
+</details>
 
-  - Validate prompt template functionality
-  - Ensure consistent AI responses across inputs
-  - Identify edge cases and potential issues
-  - Improve overall AI application quality
+<details>
+<summary id="analyze_diff"><strong><code>analyze_diff</code></strong></summary>
 
-- `list_followed_projects`
+Analyzes git diffs against cursor rules to identify rule violations.
 
-  Lists all projects that the user is following on CircleCI. This tool:
+Provide:
+- **Git diff content** (e.g. `git diff --cached`, `git diff HEAD`)
+- **Repository rules** from `.cursorrules` or `.cursor/rules`
 
-  1. Retrieves and Displays Projects:
-     - Shows all projects the user has access to and is following
-     - Provides the project name and projectSlug for each entry
-     - Example: "List my CircleCI projects"
+Returns detailed violation reports with confidence scores and explanations.
 
-  The tool returns a formatted list of projects, example output:
+Useful for:
+- Pre-commit code quality checks
+- Ensuring consistency with team coding standards
+- Catching rule violations before code review
 
-  ```
-  Projects followed:
-  1. my-project (projectSlug: gh/organization/my-project)
-  2. another-project (projectSlug: gh/organization/another-project)
-  ```
+</details>
 
-  This is particularly useful for:
+<details>
+<summary id="list_component_versions"><strong><code>list_component_versions</code></strong></summary>
 
-  - Identifying which CircleCI projects are available to you
-  - Obtaining the projectSlug needed for other CircleCI tools
-  - Selecting a project for subsequent operations
+Lists all versions for a specific CircleCI component in an environment. Includes deployment status, commit information, and timestamps.
 
-  Note: The projectSlug (not the project name) is required for many other CircleCI tools, and will be used for those tool calls after a project is selected.
+The tool will prompt you to select the component and environment if not provided.
 
-- `run_pipeline`
+Useful for:
+- Identifying which version is currently live
+- Selecting target versions for rollback operations
+- Getting deployment details (pipeline, workflow, job)
 
-  Triggers a pipeline to run. This tool can be used in three ways:
+</details>
 
-  1. Using Project Slug and Branch (Recommended Workflow):
+<details>
+<summary id="download_usage_api_data"><strong><code>download_usage_api_data</code></strong></summary>
 
-     - First, list your available projects:
-       - Use the list_followed_projects tool to get your projects
-       - Example: "List my CircleCI projects"
-       - Then choose the project, which has a projectSlug associated with it
-       - Example: "Lets use my-project"
-     - Then ask to run the pipeline for a specific branch:
-       - Example: "Run the pipeline for my-project on the main branch"
+Downloads usage data from the CircleCI Usage API for a given organization. Accepts flexible date input (e.g., "March 2025" or "last month"). Cloud-only feature.
 
-  2. Using CircleCI URL:
+**Option 1:** Start a new export job by providing:
+- `orgId`, `startDate`, `endDate` (max 32 days), `outputDir`
 
-     - Provide a CircleCI URL in any of these formats:
-       - Job URL: "https://app.circleci.com/pipelines/github/org/repo/123/workflows/abc-def/jobs/789"
-       - Workflow URL: "https://app.circleci.com/pipelines/github/org/repo/123/workflows/abc-def"
-       - Pipeline URL: "https://app.circleci.com/pipelines/github/org/repo/123"
-       - Project URL with branch: "https://app.circleci.com/projects/github/org/repo?branch=main"
-     - Example: "Run the pipeline for https://app.circleci.com/pipelines/github/org/repo/123/workflows/abc-def"
+**Option 2:** Check/download an existing export job by providing:
+- `orgId`, `jobId`, `outputDir`
 
-  3. Using Local Project Context:
-     - Works from your local workspace by providing:
-       - Workspace root path
-       - Git remote URL
-       - Branch name
-     - Example: "Run the pipeline for my current project on the main branch"
+Returns a CSV file with CircleCI usage data for the specified time frame.
 
-  The tool returns a link to monitor the pipeline execution.
+> [!NOTE]
+> Usage data can be fed into the `find_underused_resource_classes` tool for cost optimization analysis.
 
-  This is particularly useful for:
+</details>
 
-  - Quickly running pipelines without visiting the CircleCI web UI
-  - Running pipelines from a specific branch
+<details>
+<summary id="find_underused_resource_classes"><strong><code>find_underused_resource_classes</code></strong></summary>
 
-- `run_rollback_pipeline`
+Analyzes a CircleCI usage data CSV file to find jobs with average or max CPU/RAM usage below a given threshold (default: 40%).
 
-  This tool allows for triggering a rollback for a project.
-  It requires the following parameters;
+Provide a CSV file obtained from `download_usage_api_data`.
 
-  - `project_id` - The ID of the CircleCI project (UUID)
-  - `environmentName` - The environment name
-  - `componentName` - The component name
-  - `currentVersion` - The current version
-  - `targetVersion` - The target version
-  - `namespace` - The namespace of the component
-  - `reason` - The reason for the rollback (optional)
-  - `parameters` - The extra parameters for the rollback pipeline (optional)
+Returns a markdown list of underused jobs organized by project and workflow — useful for identifying cost optimization opportunities.
 
-  If not all the parameters are provided right away, the toll will make use of other tools to try and retrieve all the required info.
-  The rollback can be performed in two different way, depending on whether a rollback pipeline definition has been configured for the project:
-
-  - Pipeline Rollback: will trigger the rollback pipeline.
-  - Workflow Rerun: will trigger the rerun of a previous workflow.
-
-  A typical interaction with this tool will follow this pattern:
-
-  1. Project Selection - Retrieve list of followed projects and prompt user to select one
-  2. Environment Selection - List available environments and select target (auto-select if only one exists)
-  3. Component Selection - List available components and select target (auto-select if only one exists)
-  4. Version Selection - Display available versions, user selects non-live version for rollback
-  5. Rollback Mode Detection - Check if rollback pipeline is configured for the selected project
-  6. Execute Rollback - Two options available:
-    - Pipeline Rollback: Prompt for optional reason, execute rollback pipeline
-    - Workflow Rerun**: Rerun workflow using selected version's workflow ID
-  7. Confirmation - Summarize rollback request and confirm before execution
-
-- `rerun_workflow`
-
-  Reruns a workflow from its start or from the failed job.
-
-  The tool returns the ID of the newly-created workflow, and a link to monitor the new workflow.
-
-  This is particularly useful for:
-
-  - Quickly rerunning a workflow from its start or from the failed job without visiting the CircleCI web UI
-
-- `analyze_diff`
-
-  Analyzes git diffs against cursor rules to identify rule violations.
-
-  This tool can be used by providing:
-
-  1. Git Diff Content:
-
-     - Staged changes: `git diff --cached`
-     - Unstaged changes: `git diff`
-     - All changes: `git diff HEAD`
-     - Example: "Analyze my staged changes against the cursor rules"
-
-  2. Repository Rules:
-     - Rules from `.cursorrules` file in your repository root
-     - Rules from `.cursor/rules` directory
-     - Multiple rule files combined with `---` separator
-     - Example: "Check my diff against the TypeScript coding standards"
-
-  The tool provides:
-
-  - Detailed violation reports with confidence scores
-  - Specific explanations for each rule violation
-
-  Example usage scenarios:
-
-  - "Analyze my staged changes for any rule violations"
-  - "Check my unstaged changes against rules"
-
-  This is particularly useful for:
-
-  - Pre-commit code quality checks
-  - Ensuring consistency with team coding standards
-  - Catching rule violations before code review
-
-  The tool integrates with your existing cursor rules setup and provides immediate feedback on code quality, helping you catch issues early in the development process.
-
-- `list_component_versions`
-
-  Lists all versions for a specific CircleCI component in an environment. This tool retrieves version history including deployment status, commit information, and timestamps for a component.
-  The tool will prompt the user to select the component and environment from a list if not provided.
-
-  Example output:
-
-  ```
-  Versions for the component: {
-    "items": [
-      {
-        "name": "v1.2.0",
-        "namespace": "production",
-        "environment_id": "env-456def",
-        "is_live": true,
-        "pipeline_id": "12345678-1234-1234-1234-123456789abc",
-        "workflow_id": "87654321-4321-4321-4321-cba987654321",
-        "job_id": "11111111-1111-1111-1111-111111111111",
-        "job_number": 42,
-        "last_deployed_at": "2023-01-01T00:00:00Z"
-      },
-      {
-        "name": "v1.1.0",
-        "namespace": "production", 
-        "environment_id": "env-456def",
-        "is_live": false,
-        "pipeline_id": "22222222-2222-2222-2222-222222222222",
-        "workflow_id": "33333333-3333-3333-3333-333333333333",
-        "job_id": "44444444-4444-4444-4444-444444444444",
-        "job_number": 38,
-        "last_deployed_at": "2023-01-03T00:00:00Z"
-      }
-    ]
-  }
-  ```
-
-  This is useful for:
-
-  - Identifying which versions were deployed for a component
-  - Finding the currently live version in an environment
-  - Selecting target versions for rollback operations
-  - Getting deployment details like pipeline, workflow, and job information
-  - Listing all environments
-  - Listing all components
-
-- `download_usage_api_data`
-
-  Downloads usage data from the CircleCI Usage API for a given organization. Accepts flexible, natural language date input (e.g., "March 2025" or "last month"). Cloud-only feature.
-
-  This tool can be used in one of two ways:
-
-  1) Start a new export job for a date range (max 32 days) by providing:
-  - orgId: Organization ID
-  - startDate: Start date (YYYY-MM-DD or natural language)
-  - endDate: End date (YYYY-MM-DD or natural language)
-  - outputDir: Directory to save the CSV file
-
-  2) Check/download an existing export job by providing:
-  - orgId: Organization ID
-  - jobId: Usage export job ID
-  - outputDir: Directory to save the CSV file
-
-  The tool provides:
-  - A csv containing the CircleCI Usage API data from the specified time frame
-
-  This is useful for:
-  - Downloading detailed CircleCI usage data for reporting or analysis
-  - Feeding usage data into the `find_underused_resource_classes` tool
-
-  Example usage scenarios:
-- Scenario 1:
-  1. "Download usage data for org abc123 from June into ~/Downloads"
-  2. "Check status"
-
-- Scenario 2:
-  1. "Download usage data for org abc123 for last month to my Downloads folder"
-  2. "Check usage download status"
-  3. "Check status again"
-
-- Scenario 3:
-  1. "Check my usage export job usage-job-9f2d7c and download it if ready"
-
-- `find_underused_resource_classes`
-
-  Analyzes a CircleCI usage data CSV file to find jobs/resource classes with average or max CPU/RAM usage below a given threshold (default 40%).
-
-  This tool can be used by providing:
-  - A csv containing CircleCI Usage API data, which can be obtained by using the `download_usage_api_data` tool.
-
-  The tool provides:
-  - A markdown list of all jobs that are below the threshold, delineated by project and workflow.
-
-  This is useful for:
-  - Finding jobs that are using less than half of the compute provided to them on average
-  - Generating a list of low hanging cost optimizations
-
-  Example usage scenarios:
-  - Scenario 1:
-    1. "Find underused resource classes in the file you just downloaded"
-  - Scenario 2:
-    1. "Find underused resource classes in ~/Downloads/usage-data-2025-06-01_2025-06-30.csv"
-  - Scenario 3:
-    1. "Analyze /Users/you/Projects/acme/usage-data-job-9f2d7c.csv with threshold 30"
+</details>
 
 ## Troubleshooting
 
-### Quick Fixes
+<details>
+<summary><strong>Quick Fixes</strong></summary>
 
-**Most Common Issues:**
+**Most common issues:**
 
 1. **Clear package caches:**
    ```bash
@@ -1069,54 +855,75 @@ Click the Save button.
 
 3. **Restart your IDE completely** (not just reload window)
 
-## Authentication Issues
+</details>
 
-* **Invalid token errors:** Verify your `CIRCLECI_TOKEN` in Personal API Tokens
-* **Permission errors:** Ensure token has read access to your projects
-* **Environment variables not loading:** Test with `echo $CIRCLECI_TOKEN` (Mac/Linux) or `echo %CIRCLECI_TOKEN%` (Windows)
+<details>
+<summary><strong>Authentication Issues</strong></summary>
 
-## Connection and Network Issues
+- **Invalid token errors:** Verify your `CIRCLECI_TOKEN` in [Personal API Tokens](https://app.circleci.com/settings/user/tokens)
+- **Permission errors:** Ensure the token has read access to your projects
+- **Environment variables not loading:** Test with `echo $CIRCLECI_TOKEN` (Mac/Linux) or `echo %CIRCLECI_TOKEN%` (Windows)
 
-* **Base URL:** Confirm `CIRCLECI_BASE_URL` is `https://circleci.com`
-* **Corporate networks:** Configure npm proxy settings if behind firewall
-* **Firewall blocking:** Check if security software blocks package downloads
+</details>
 
-## System Requirements
+<details>
+<summary><strong>Connection and Network Issues</strong></summary>
 
-* **Node.js version:** Ensure ≥ 18.0.0 with `node --version`
-* **Update Node.js:** Consider latest LTS if experiencing compatibility issues
-* **Package manager:** Verify npm/pnpm is working: `npm --version`
+- **Base URL:** Confirm `CIRCLECI_BASE_URL` is `https://circleci.com`
+- **Corporate networks:** Configure npm proxy settings if behind a firewall
+- **Firewall blocking:** Check if security software blocks package downloads
 
-## IDE-Specific Issues
+</details>
 
-* **Config file location:** Double-check path for your OS
-* **Syntax errors:** Validate JSON syntax in config file
-* **Console logs:** Check IDE developer console for specific errors
-* **Try different IDE:** Test config in another supported editor to isolate issue
+<details>
+<summary><strong>System Requirements</strong></summary>
 
-## Process Issues
+- **Node.js version:** Ensure >= 18.0.0 with `node --version`
+- **Update Node.js:** Consider latest LTS if experiencing compatibility issues
+- **Package manager:** Verify npm/pnpm is working: `npm --version`
 
-* **Hanging processes:** Kill existing MCP processes:
-  ```bash
-  # Mac/Linux: 
-  pkill -f "mcp-server-circleci"
-  
-  # Windows: 
-  taskkill /f /im node.exe
+</details>
 
-* **Port conflicts:** Restart IDE if connection seems blocked
+<details>
+<summary><strong>IDE-Specific Issues</strong></summary>
 
-## Advanced Debugging
+- **Config file location:** Double-check the path for your OS
+- **Syntax errors:** Validate JSON syntax in your config file
+- **Console logs:** Check the IDE developer console for specific errors
+- **Try a different IDE:** Test in another supported editor to isolate the issue
 
-* **Test package directly:** `npx @circleci/mcp-server-circleci@latest --help`
-* **Verbose logging:** `DEBUG=* npx @circleci/mcp-server-circleci@latest`
-* **Docker fallback:** Try Docker installation if npx fails consistently
+</details>
 
-## Still Need Help?
+<details>
+<summary><strong>Process Issues</strong></summary>
 
-1. Check GitHub issues for similar problems
+**Hanging processes — kill existing MCP processes:**
+
+```bash
+# Mac/Linux:
+pkill -f "mcp-server-circleci"
+
+# Windows:
+taskkill /f /im node.exe
+```
+
+**Port conflicts:** Restart your IDE if the connection seems blocked.
+
+</details>
+
+<details>
+<summary><strong>Advanced Debugging</strong></summary>
+
+- **Test package directly:** `npx @circleci/mcp-server-circleci@latest --help`
+- **Verbose logging:** `DEBUG=* npx @circleci/mcp-server-circleci@latest`
+- **Docker fallback:** Try Docker installation if npx fails consistently
+
+**Still need help?**
+1. Check [GitHub Issues](https://github.com/CircleCI-Public/mcp-server-circleci/issues) for similar problems
 2. Include your OS, Node version, and IDE when reporting issues
-3. Share relevant error messages from IDE console
+3. Share relevant error messages from the IDE console
+
+</details>
 
 # Development
 
@@ -1156,10 +963,10 @@ To run the container locally:
 docker run --rm -i -e CIRCLECI_TOKEN=your-circleci-token -e CIRCLECI_BASE_URL=https://circleci.com circleci:mcp-server-circleci
 ```
 
-To run the container as a self-managed remote MCP server you need to add the environment variable `start=remote` to the docker run command. You can also define the port to use with the environment variable `port=<port>` or else the default port `8000` will be used:
+To run the container as a self-managed remote MCP server, add `start=remote` and optionally specify the port (default: `8000`):
 
 ```bash
-docker run --rm -i -e CIRCLECI_TOKEN=your-circleci-token -e CIRCLECI_BASE_URL=https://circleci.com circleci:mcp-server-circleci -e start=remote -e port=8000
+docker run --rm -i -e CIRCLECI_TOKEN=your-circleci-token -e CIRCLECI_BASE_URL=https://circleci.com -e start=remote -e port=8000 circleci:mcp-server-circleci
 ```
 
 ## Development with MCP Inspector
@@ -1181,7 +988,7 @@ The easiest way to iterate on the MCP Server is using the MCP inspector. You can
 3. Configure the environment:
    - Add your `CIRCLECI_TOKEN` to the Environment Variables section in the inspector UI
    - The token needs read access to your CircleCI projects
-   - Optionally you can set your CircleCI Base URL. Defaults to `https//circleci.com`
+   - Optionally set your CircleCI Base URL (defaults to `https://circleci.com`)
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Refactors the README to make it significantly easier to navigate while preserving all existing content and incorporating the Docker image name fix from #80.

- **Tools summary table** added near the top so visitors immediately see what the MCP server can do, with each tool name linking down to its full description
- **Collapsible installation sections** for every IDE/client (Cursor, VS Code, Claude Desktop, Claude Code, Windsurf, Amazon Q CLI, Amazon Q IDE, Smithery) — keeping the page manageable without removing any content
- **Prerequisites inlined** into each IDE's installation block, replacing the standalone Requirements section
- **Demo video** moved into a collapsible Demo section instead of sitting inline at the top
- **Collapsible tool detail sections** with anchor IDs for deep-linking from the tools table
- **Collapsible Troubleshooting subsections** for easier scanning
- **Fixes Docker image reference** (`circleci:mcp-server-circleci` → `circleci/mcp-server-circleci`) in all user-facing installation configs — closes #80
- **Static Apache 2.0 license badge** replaces the dynamic GitHub badge (which currently renders as "Other" due to GitHub's license detection)
- **`@latest` tag** added to all NPX installation commands
- **GitHub alert syntax** (`> [!NOTE]`) used for notes throughout

## Test plan

- [ ] View the README on GitHub and verify the tools table renders correctly with working anchor links
- [ ] Expand each installation collapsible and verify code blocks render properly
- [ ] Expand each tool detail collapsible and verify content is intact
- [ ] Verify the Apache 2.0 badge displays correctly
- [ ] Confirm Docker image references use `circleci/mcp-server-circleci` (slash) in all installation configs