### PR TITLE
Remove non-spec `tools.list` capability advertisement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,9 +51,6 @@ if (process.env.debug === 'true') {
 if (process.env.debug === 'true') {
   console.error('[DEBUG] [Startup] Registering CircleCI MCP tools...');
 }
-// Ensure we advertise support for tools/list in capabilities (SDK only sets listChanged)
-(server as any).server.registerCapabilities({ tools: { list: true } });
-
 CCI_TOOLS.forEach((tool) => {
   const handler = CCI_HANDLERS[tool.name];
   if (!handler) throw new Error(`Handler for tool ${tool.name} not found`);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our contributor [guidelines](https://github.com/CircleCI-Public/mcp-server-circleci/blob/main/CONTRIBUTING.md).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added or updated where needed.

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What issues are resolved by this PR?

- #142

## Describe the new behavior.

The `initialize` response was including `"tools": { "list": true }` in `ServerCapabilities`, which is not part of the MCP spec. Strict clients---such as those using the Java `io.modelcontextprotocol` SDK---reject unknown fields and fail to initialise entirely.

Per the spec, `ServerCapabilities.tools` only defines `listChanged`. The `tools/list` method is a standard JSON-RPC method that doesn't need to be advertised as a capability flag.

The server was already constructed with `{ capabilities: { tools: {} } }`, which is the correct way to advertise basic tool support. The extra `registerCapabilities` call was redundant and harmful.

Without this fix I had to pin the MCP SDK to 0.11.2 to be able to launch the server.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Three-line deletion. The capability was added by a `registerCapabilities` call that cast through `any` to bypass type checking---a hint that it wasn't part of the expected API surface.
