### PR TITLE
chore: release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-03-25
+
+### Added
+
+- Added `listArtifacts` tool to list artifacts for a CircleCI job
+
+### Fixed
+
+- Removed non-spec `tools.list` capability advertisement that caused compatibility issues with some MCP clients
+
 ## [0.14.2] - 2026-02-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `listArtifacts` tool to list artifacts for a CircleCI job
+- Added `listArtifacts` tool to list artifacts for a CircleCI job (thank you @nadav-dav)
 
 ### Fixed
 
-- Removed non-spec `tools.list` capability advertisement that caused compatibility issues with some MCP clients
+- Removed non-spec `tools.list` capability advertisement that caused compatibility issues with some MCP clients (thank you @stig)
 
 ## [0.14.2] - 2026-02-20
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,21 @@ After the issue has been created, follow these steps to create a Pull Request.
 
 Thank you for your contribution!
 
+### <a name="release"></a>Release Process
+
+Releases are published automatically by CI when changes are merged to `main`. The pipeline builds, tests, lints, and then publishes both an npm package and a multi-architecture Docker image. The published version is determined by the `version` field in `package.json`.
+
+To prepare a release:
+
+1. Create a release branch from `main`: `git checkout -b release/x.y.z main`
+2. Bump the `version` in `package.json` following [Semantic Versioning](https://semver.org/)
+3. Update `CHANGELOG.md` with all changes since the last release, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
+4. Commit the version bump and changelog update
+5. Open a Pull Request targeting `main`
+6. After review and merge, CI will automatically:
+   - Publish the package to npm (skipped if the version is already published)
+   - Build and push a multi-architecture Docker image (`linux/amd64`, `linux/arm64`) tagged with `latest`, the package version, and the commit SHA
+
 ### <a name="creating-tools"></a>Creating New Tools
 
 This project provides a tool generator script to help you quickly create new tools with the correct structure and boilerplate code.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",


### PR DESCRIPTION
## Summary

- Bump version from `0.14.2` to `0.15.0`
- Add changelog entry for new `listArtifacts` tool and `tools.list` capability fix
- Add missing Release Process section to CONTRIBUTING.md documenting the CI-driven publish workflow

## Changelog (0.15.0)

### Added
- `listArtifacts` tool to list artifacts for a CircleCI job

### Fixed
- Removed non-spec `tools.list` capability advertisement

## Test plan
- [ ] CI passes (build, test, lint)
- [ ] Verify npm publish triggers on merge
- [ ] Verify Docker image publish triggers on merge