### PR TITLE
fix: download all usage export CSV parts instead of only the first

### DIFF
--- a/src/lib/usage-api/findUnderusedResourceClasses.test.ts
+++ b/src/lib/usage-api/findUnderusedResourceClasses.test.ts
@@ -74,6 +74,14 @@ describe('findUnderusedResourceClasses library functions', () => {
       expect(grouped.size).toBe(2);
       expect(grouped.has('proj|||flow|||build|||medium')).toBe(true);
     });
+
+    it('should accumulate into an existing groupMap', () => {
+      const groupMap = new Map<string, any[]>();
+      groupRecordsByJob([mockRecords[0]], groupMap);
+      groupRecordsByJob([mockRecords[0]], groupMap);
+      const group = groupMap.get('proj|||flow|||build|||medium');
+      expect(group).toHaveLength(2);
+    });
   });
 
   describe('analyzeJobGroups', () => {

--- a/src/lib/usage-api/findUnderusedResourceClasses.ts
+++ b/src/lib/usage-api/findUnderusedResourceClasses.ts
@@ -45,16 +45,16 @@ export function validateCSVColumns(records: any[]): void {
   }
 }
 
-export function groupRecordsByJob(records: any[]): Map<string, any[]> {
-  const groupMap = new Map<string, any[]>();
+export function groupRecordsByJob(records: any[], groupMap?: Map<string, any[]>): Map<string, any[]> {
+  const map = groupMap ?? new Map<string, any[]>();
   for (const row of records) {
     const key = [row.project_name, row.workflow_name, row.job_name, row.resource_class].join('|||');
-    if (!groupMap.has(key)) {
-      groupMap.set(key, []);
+    if (!map.has(key)) {
+      map.set(key, []);
     }
-    groupMap.get(key)?.push(row);
+    map.get(key)?.push(row);
   }
-  return groupMap;
+  return map;
 }
 
 const avg = (arr: number[]) => arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
@@ -144,11 +144,20 @@ export function generateReport(underusedJobs: any[], threshold: number): string 
   return report;
 }
 
-export async function findUnderusedResourceClassesFromCSV({ csvFilePath, threshold = 40 }: { csvFilePath: string, threshold?: number }) {
-  const records = readAndParseCSV(csvFilePath);
-  validateCSVColumns(records);
-  const groupedRecords = groupRecordsByJob(records);
-  const underusedJobs = analyzeJobGroups(groupedRecords, threshold);
+export async function findUnderusedResourceClassesFromCSV({ csvFilePath, threshold = 40 }: { csvFilePath: string | string[], threshold?: number }) {
+  const paths = Array.isArray(csvFilePath) ? csvFilePath : [csvFilePath];
+  // Processing files one at a time to avoid holding all CSVs in memory simultaneously and usage exports can produce 8 part files at ~350Mb each,
+  // which caused a stack overflow when loaded all at once.
+  // As a result this groupMap is used to accumulate grouped records across files, so only one file's worth of rows is in memory at a time.
+  const groupMap = new Map<string, any[]>();
+
+  for (const p of paths) {
+    const records = readAndParseCSV(p);
+    validateCSVColumns(records);
+    groupRecordsByJob(records, groupMap);
+  }
+
+  const underusedJobs = analyzeJobGroups(groupMap, threshold);
   const report = generateReport(underusedJobs, threshold);
   
   return { report, underused: underusedJobs };

--- a/src/lib/usage-api/getUsageApiData.test.ts
+++ b/src/lib/usage-api/getUsageApiData.test.ts
@@ -20,9 +20,15 @@ describe('Usage API Data Fetching', () => {
   const END_DATE = '2024-08-31T23:59:59Z';
   const JOB_ID = 'test-job-id';
   const DOWNLOAD_URL = 'https://fake-url.com/usage.csv.gz';
+  const DOWNLOAD_URL_2 = 'https://fake-url.com/usage-part2.csv.gz';
+  const DOWNLOAD_URL_3 = 'https://fake-url.com/usage-part3.csv.gz';
   const OUTPUT_DIR = '/tmp/usage-data';
   const MOCK_CSV_CONTENT = 'col1,col2\nval1,val2';
+  const MOCK_CSV_CONTENT_2 = 'col1,col2\nval3,val4';
+  const MOCK_CSV_CONTENT_3 = 'col1,col2\nval5,val6';
   const MOCK_GZIPPED_CSV = gzipSync(Buffer.from(MOCK_CSV_CONTENT));
+  const MOCK_GZIPPED_CSV_2 = gzipSync(Buffer.from(MOCK_CSV_CONTENT_2));
+  const MOCK_GZIPPED_CSV_3 = gzipSync(Buffer.from(MOCK_CSV_CONTENT_3));
 
   let mockCircleCIClient: any;
   let startUsageExportJobMock: any;
@@ -53,7 +59,7 @@ describe('Usage API Data Fetching', () => {
         arrayBuffer: () => Promise.resolve(MOCK_GZIPPED_CSV),
       });
 
-      const result = await downloadAndSaveUsageData(DOWNLOAD_URL, OUTPUT_DIR, { startDate: START_DATE, endDate: END_DATE });
+      const result = await downloadAndSaveUsageData([DOWNLOAD_URL], OUTPUT_DIR, { startDate: START_DATE, endDate: END_DATE });
 
       expect(fetch).toHaveBeenCalledWith(DOWNLOAD_URL);
       expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -70,7 +76,7 @@ describe('Usage API Data Fetching', () => {
         arrayBuffer: () => Promise.resolve(MOCK_GZIPPED_CSV),
       });
 
-      await downloadAndSaveUsageData(DOWNLOAD_URL, OUTPUT_DIR, { startDate: START_DATE, endDate: END_DATE });
+      await downloadAndSaveUsageData([DOWNLOAD_URL], OUTPUT_DIR, { startDate: START_DATE, endDate: END_DATE });
 
       expect(fs.mkdirSync).toHaveBeenCalledWith(OUTPUT_DIR, { recursive: true });
     });
@@ -83,8 +89,52 @@ describe('Usage API Data Fetching', () => {
             text: async () => 'Internal Server Error'
         });
         
-        const result = await downloadAndSaveUsageData(DOWNLOAD_URL, OUTPUT_DIR, { startDate: START_DATE, endDate: END_DATE });
-        expect(result.content[0].text).toContain('ERROR: Failed to download CSV');
+        const result = await downloadAndSaveUsageData([DOWNLOAD_URL], OUTPUT_DIR, { startDate: START_DATE, endDate: END_DATE });
+        expect(result.content[0].text).toContain('ERROR: Failed to download or save usage data');
+    });
+
+    it('should download all parts and save as separate files for multiple URLs', async () => {
+      (fetch as any)
+        .mockResolvedValueOnce({ ok: true, arrayBuffer: () => Promise.resolve(MOCK_GZIPPED_CSV) })
+        .mockResolvedValueOnce({ ok: true, arrayBuffer: () => Promise.resolve(MOCK_GZIPPED_CSV_2) })
+        .mockResolvedValueOnce({ ok: true, arrayBuffer: () => Promise.resolve(MOCK_GZIPPED_CSV_3) });
+
+      const result = await downloadAndSaveUsageData(
+        [DOWNLOAD_URL, DOWNLOAD_URL_2, DOWNLOAD_URL_3],
+        OUTPUT_DIR,
+        { startDate: START_DATE, endDate: END_DATE }
+      );
+
+      expect(fetch).toHaveBeenCalledTimes(3);
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        `${OUTPUT_DIR}/usage-data-2024-08-01_2024-08-31_part1.csv`,
+        Buffer.from(MOCK_CSV_CONTENT)
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        `${OUTPUT_DIR}/usage-data-2024-08-01_2024-08-31_part2.csv`,
+        Buffer.from(MOCK_CSV_CONTENT_2)
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        `${OUTPUT_DIR}/usage-data-2024-08-01_2024-08-31_part3.csv`,
+        Buffer.from(MOCK_CSV_CONTENT_3)
+      );
+      expect(result.content[0].text).toContain('3 files');
+    });
+
+    it('should stop and return error if any part fails to download', async () => {
+      (fetch as any)
+        .mockResolvedValueOnce({ ok: true, arrayBuffer: () => Promise.resolve(MOCK_GZIPPED_CSV) })
+        .mockResolvedValueOnce({ ok: false, status: 403, statusText: 'Forbidden', text: async () => 'Access Denied' });
+
+      const result = await downloadAndSaveUsageData(
+        [DOWNLOAD_URL, DOWNLOAD_URL_2],
+        OUTPUT_DIR,
+        { startDate: START_DATE, endDate: END_DATE }
+      );
+
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+      expect(result.content[0].text).toContain('ERROR: Failed to download or save usage data');
     });
   });
 

--- a/src/lib/usage-api/getUsageApiData.ts
+++ b/src/lib/usage-api/getUsageApiData.ts
@@ -18,38 +18,49 @@ function resolveOutputDir(outputDir: string): string {
   return outputDir;
 }
 
+function getBaseFileName(opts: { startDate?: string; endDate?: string; jobId?: string }): string {
+  if (opts.startDate && opts.endDate) {
+    return `usage-data-${opts.startDate.slice(0, 10)}_${opts.endDate.slice(0, 10)}`;
+  }
+  if (opts.jobId) {
+    return `usage-data-job-${opts.jobId}`;
+  }
+  return `usage-data-${Date.now()}`;
+}
+
+async function fetchAndDecompress(url: string): Promise<Buffer> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`${response.status} ${response.statusText}: ${text}`);
+  }
+  return gunzipSync(Buffer.from(await response.arrayBuffer()));
+}
+
 export async function downloadAndSaveUsageData(
-  downloadUrl: string,
+  downloadUrls: string[],
   outputDir: string,
   opts: { startDate?: string; endDate?: string; jobId?: string }
 ) {
   try {
-    const gzippedCsvResponse = await fetch(downloadUrl);
-    if (!gzippedCsvResponse.ok) {
-      const csvText = await gzippedCsvResponse.text();
-      return mcpErrorOutput(`ERROR: Failed to download CSV.\nStatus: ${gzippedCsvResponse.status} ${gzippedCsvResponse.statusText}\nResponse: ${csvText}`);
-    }
-    const gzBuffer = Buffer.from(await gzippedCsvResponse.arrayBuffer());
-    const csv = gunzipSync(gzBuffer);
-
-    const fileName = (() => {
-      if (opts.startDate && opts.endDate) {
-        return `usage-data-${opts.startDate.slice(0, 10)}_${opts.endDate.slice(0, 10)}.csv`;
-      }
-      if (opts.jobId) {
-        return `usage-data-job-${opts.jobId}.csv`;
-      }
-      return `usage-data-${Date.now()}.csv`;
-    })();
     const usageDataDir = path.resolve(resolveOutputDir(outputDir));
-    const filePath = path.join(usageDataDir, fileName);
+    fs.mkdirSync(usageDataDir, { recursive: true });
 
-    if (!fs.existsSync(usageDataDir)) {
-      fs.mkdirSync(usageDataDir, { recursive: true });
+    const baseName = getBaseFileName(opts);
+    const savedPaths: string[] = [];
+
+    for (let i = 0; i < downloadUrls.length; i++) {
+      const csv = await fetchAndDecompress(downloadUrls[i]);
+      const suffix = downloadUrls.length > 1 ? `_part${i + 1}` : '';
+      const filePath = path.join(usageDataDir, `${baseName}${suffix}.csv`);
+      fs.writeFileSync(filePath, csv);
+      savedPaths.push(filePath);
     }
-    fs.writeFileSync(filePath, csv);
-    
-    return { content: [{ type: 'text' as const, text: `Usage data CSV downloaded and saved to: ${filePath}` }] };
+
+    const summary = savedPaths.length === 1
+      ? `Usage data CSV downloaded and saved to: ${savedPaths[0]}`
+      : `Usage data downloaded as ${savedPaths.length} files:\n${savedPaths.join('\n')}`;
+    return { content: [{ type: 'text' as const, text: summary }] };
   } catch (e: any) {
     return mcpErrorOutput(`ERROR: Failed to download or save usage data.\nError: ${e?.stack || e}`);
   }
@@ -63,17 +74,15 @@ export async function handleExistingJob({ client, orgId, jobId, outputDir, start
     return mcpErrorOutput(`ERROR: Could not fetch job status for jobId ${jobId}.\n${e?.stack || e}`);
   }
 
-    const state = jobStatus?.state?.toLowerCase();
+  const state = jobStatus?.state?.toLowerCase();
 
   switch (state) {
     case 'completed': {
       const downloadUrls = jobStatus?.download_urls;
-      const downloadUrl = Array.isArray(downloadUrls) && downloadUrls.length > 0 ? downloadUrls[0] : null;
-
-      if (!downloadUrl) {
-        return mcpErrorOutput(`ERROR: No download_url found in job status.\nJob status: ${JSON.stringify(jobStatus, null, 2)}`);
+      if (!Array.isArray(downloadUrls) || downloadUrls.length === 0) {
+        return mcpErrorOutput(`ERROR: No download_urls found in job status.\nJob status: ${JSON.stringify(jobStatus, null, 2)}`);
       }
-      return await downloadAndSaveUsageData(downloadUrl, outputDir, { startDate, endDate, jobId });
+      return await downloadAndSaveUsageData(downloadUrls, outputDir, { startDate, endDate, jobId });
     }
     case 'created':
     case 'pending':

--- a/src/tools/findUnderusedResourceClasses/handler.test.ts
+++ b/src/tools/findUnderusedResourceClasses/handler.test.ts
@@ -1,50 +1,43 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { findUnderusedResourceClasses } from './handler.js';
-import { promises as fs } from 'fs';
+import * as fs from 'fs';
 
-vi.mock('fs', () => ({
-  promises: {
-    readFile: vi.fn(),
-  },
-}));
+vi.mock('fs');
 
 describe('findUnderusedResourceClasses handler', () => {
-  const CSV_HEADERS = 'project_name,workflow_name,job_name,resource_class,median_cpu_utilization_pct,max_cpu_utilization_pct,median_ram_utilization_pct,max_ram_utilization_pct';
-  const CSV_ROW_UNDER = 'proj,flow,build,medium,10,20,15,18';
-  const CSV_ROW_OVER = 'proj,flow,test,large,50,60,55,58';
-  const CSV = `${CSV_HEADERS}\n${CSV_ROW_UNDER}\n${CSV_ROW_OVER}`;
-  const CSV_MISSING = 'job_name,resource_class,avg_cpu_pct,max_cpu_pct,avg_ram_pct,max_ram_pct\nfoo,medium,10,20,15,18';
+  const CSV_HEADERS = 'project_name,workflow_name,job_name,resource_class,median_cpu_utilization_pct,max_cpu_utilization_pct,median_ram_utilization_pct,max_ram_utilization_pct,compute_credits';
+  const CSV_ROW_UNDER = 'proj,flow,build,medium,10,20,15,18,100';
+  const CSV_ROW_OVER = 'proj,flow,test,large,50,60,55,58,200';
 
   beforeEach(() => {
-    (fs.readFile as any).mockReset();
+    vi.clearAllMocks();
+    (fs.existsSync as any).mockReturnValue(true);
   });
 
   it('returns an error if file read fails', async () => {
-    (fs.readFile as any).mockRejectedValue(new Error('fail'));
+    (fs.readFileSync as any).mockImplementation(() => { throw new Error('fail'); });
     const result = await findUnderusedResourceClasses({ params: { csvFilePath: '/tmp/usage.csv', threshold: 40 } }, undefined as any);
     expect(result.isError).toBeTruthy();
     expect(result.content[0].text).toContain('Could not read CSV file');
   });
 
   it('returns an error if CSV is missing required columns', async () => {
-    (fs.readFile as any).mockResolvedValue(CSV_MISSING);
+    (fs.readFileSync as any).mockReturnValue('bad_col1,bad_col2\n1,2');
     const result = await findUnderusedResourceClasses({ params: { csvFilePath: '/tmp/usage.csv', threshold: 40 } }, undefined as any);
     expect(result.isError).toBeTruthy();
-    expect(result.content[0].text).toContain('Could not read CSV file');
+    expect(result.content[0].text).toContain('missing required columns');
   });
 
-  it('returns an error if all jobs are above threshold', async () => {
-    const CSV_OVER = `${CSV_HEADERS}\nproj,flow,test,large,50,60,55,58`;
-    (fs.readFile as any).mockResolvedValue(CSV_OVER);
+  it('returns a no-underused message if all jobs are above threshold', async () => {
+    (fs.readFileSync as any).mockReturnValue(`${CSV_HEADERS}\n${CSV_ROW_OVER}`);
     const result = await findUnderusedResourceClasses({ params: { csvFilePath: '/tmp/usage.csv', threshold: 40 } }, undefined as any);
-    expect(result.isError).toBeTruthy();
-    expect(result.content[0].text).toContain('Could not read CSV file');
+    expect(result.content[0].text).toContain('No underused resource classes found');
   });
 
-  it('returns an error even if underused jobs are present', async () => {
-    (fs.readFile as any).mockResolvedValue(CSV);
+  it('returns a report when underused jobs are found', async () => {
+    (fs.readFileSync as any).mockReturnValue(`${CSV_HEADERS}\n${CSV_ROW_UNDER}\n${CSV_ROW_OVER}`);
     const result = await findUnderusedResourceClasses({ params: { csvFilePath: '/tmp/usage.csv', threshold: 40 } }, undefined as any);
-    expect(result.isError).toBeTruthy();
-    expect(result.content[0].text).toContain('Could not read CSV file');
+    expect(result.content[0].text).toContain('Underused resource classes');
+    expect(result.content[0].text).toContain('build');
   });
-}); 
+});

--- a/src/tools/findUnderusedResourceClasses/inputSchema.ts
+++ b/src/tools/findUnderusedResourceClasses/inputSchema.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const findUnderusedResourceClassesInputSchema = z.object({
   csvFilePath: z
-    .string()
-    .describe('The path to the usage data CSV file to analyze.'),
+    .union([z.string(), z.array(z.string())])
+    .describe('Path to a usage data CSV file, or an array of paths to multiple part files to analyze together.'),
   threshold: z
     .number()
     .optional()


### PR DESCRIPTION
I recently got push request to this repo, so I rebuilt the PR here so that I could run the CI checks. Old PR:
https://github.com/CircleCI-Public/mcp-server-circleci/pull/155

## Summary

- The CircleCI Usage API can return multiple `download_urls` when an export job completes, but `downloadAndSaveUsageData` was only downloading `downloadUrls[0]`, silently dropping all other parts.
- Updated the download logic to iterate over all URLs and save each as a separate `_partN.csv` file. Single-URL responses still produce a single file with no suffix.
- Extracted `fetchAndDecompress()` and `getBaseFileName()` helpers for readability.
- Modifies command `findUnderusedResourceClasses` to work with multiple file paths

## Test plan

Manually tested against the CircleCI Usage API for org `3f1523fe-b58c-443b-a393-876a7610ad1f` (2026-03-20 to 2026-03-29) — confirmed all 8 part files are downloaded.

Ran `Analyze downloaded data for underused resource classes` On this data to ensure it is using all 8 parts to analyze the underused resource classes:
<img width="758" height="645" alt="image" src="https://github.com/user-attachments/assets/e6435593-4d90-4344-a744-c23bd8c5efb9" />
