### PR TITLE
feat: add get_artifact_content tool

### DIFF
--- a/src/circleci-tools.ts
+++ b/src/circleci-tools.ts
@@ -35,6 +35,8 @@ import { listComponentVersions } from './tools/listComponentVersions/handler.js'
 
 import { listArtifactsTool } from './tools/listArtifacts/tool.js';
 import { listArtifacts } from './tools/listArtifacts/handler.js';
+import { getArtifactContentTool } from './tools/getArtifactContent/tool.js';
+import { getArtifactContent } from './tools/getArtifactContent/handler.js';
 
 // Define the tools with their configurations
 export const CCI_TOOLS = [
@@ -55,6 +57,7 @@ export const CCI_TOOLS = [
   runRollbackPipelineTool,
   listComponentVersionsTool,
   listArtifactsTool,
+  getArtifactContentTool,
 ];
 
 // Extract the tool names as a union type
@@ -87,4 +90,5 @@ export const CCI_HANDLERS = {
   run_rollback_pipeline: runRollbackPipeline,
   list_component_versions: listComponentVersions,
   list_artifacts: listArtifacts,
+  get_artifact_content: getArtifactContent,
 } satisfies ToolHandlers;

--- a/src/tools/getArtifactContent/handler.ts
+++ b/src/tools/getArtifactContent/handler.ts
@@ -1,0 +1,56 @@
+import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getArtifactContentInputSchema } from './inputSchema.js';
+import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
+import outputTextTruncated from '../../lib/outputTextTruncated.js';
+
+export const getArtifactContent: ToolCallback<{
+  params: typeof getArtifactContentInputSchema;
+}> = async (args) => {
+  const { artifactURL } = args.params ?? {};
+
+  if (!artifactURL) {
+    return mcpErrorOutput('artifactURL is required.');
+  }
+
+  const token = process.env.CIRCLECI_TOKEN;
+  if (!token) {
+    return mcpErrorOutput('CIRCLECI_TOKEN is not set.');
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(artifactURL, {
+      headers: {
+        'Circle-Token': token,
+      },
+    });
+  } catch (error) {
+    return mcpErrorOutput(
+      `Failed to fetch artifact: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!response.ok) {
+    return mcpErrorOutput(
+      `Failed to fetch artifact: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  const isBinary =
+    !contentType.startsWith('text/') &&
+    !contentType.includes('json') &&
+    !contentType.includes('xml') &&
+    !contentType.includes('javascript') &&
+    !contentType.includes('yaml') &&
+    !contentType.includes('html');
+
+  if (isBinary) {
+    return mcpErrorOutput(
+      `Artifact is a binary file (content-type: ${contentType}). Only text artifacts can be read directly.`,
+    );
+  }
+
+  const content = await response.text();
+  return outputTextTruncated(content);
+};

--- a/src/tools/getArtifactContent/inputSchema.ts
+++ b/src/tools/getArtifactContent/inputSchema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const getArtifactContentInputSchema = z.object({
+  artifactURL: z
+    .string()
+    .describe(
+      'The URL of the CircleCI artifact to fetch. Obtain this from the list_artifacts tool.',
+    ),
+});

--- a/src/tools/getArtifactContent/tool.ts
+++ b/src/tools/getArtifactContent/tool.ts
@@ -1,0 +1,15 @@
+import { getArtifactContentInputSchema } from './inputSchema.js';
+
+export const getArtifactContentTool = {
+  name: 'get_artifact_content' as const,
+  description: `
+    Fetches the content of a CircleCI artifact by URL.
+
+    Use this after list_artifacts to read the actual content of an artifact
+    (e.g., test reports, logs, binaries, coverage reports).
+
+    The artifact URL must be obtained from the list_artifacts tool output.
+    Authentication is handled automatically using the configured CIRCLECI_TOKEN.
+    `,
+  inputSchema: getArtifactContentInputSchema,
+};


### PR DESCRIPTION
## Summary

- Adds a new `get_artifact_content` MCP tool that fetches the content of a CircleCI artifact by URL
- Authentication is handled automatically using the configured `CIRCLECI_TOKEN` (`Circle-Token` header)
- Binary files are rejected with a helpful error; text content is returned truncated if large
- Addresses feedback that agents had to resort to manual authenticated curl commands to read artifact content

## Test plan

- [ ] Call `list_artifacts` to get artifact URLs for a job
- [ ] Call `get_artifact_content` with one of the returned URLs and verify content is returned
- [ ] Verify binary artifacts return a clear error message
- [ ] Verify large text artifacts are truncated with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)