### PR TITLE
fix(schemas): fix labels field schema to use object format (DR-413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2026-04-21
+
+### Fixed
+
+- Fixed `labels` schema parsing in deploy environments and components responses. Labels are now correctly parsed as `{ key, value }` objects instead of strings, which restores `list_component_versions` when resolving environments or components that carry labels.
+
 ## [0.15.0] - 2026-03-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/clients/__tests__/schemas.test.ts
+++ b/src/clients/__tests__/schemas.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DeployComponentsResponse,
+  DeployEnvironmentResponse,
+} from '../schemas.js';
+
+describe('DeployEnvironmentResponseSchema', () => {
+  it('should parse a valid environment response with object labels', () => {
+    const input = {
+      items: [
+        {
+          id: 'env-1',
+          name: 'production',
+          description: 'Production environment',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          labels: [{ key: 'env', value: 'prod' }],
+        },
+      ],
+      next_page_token: null,
+    };
+
+    const result = DeployEnvironmentResponse.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.items[0].labels).toEqual([{ key: 'env', value: 'prod' }]);
+      expect(result.data.items[0].description).toBe('Production environment');
+    }
+  });
+
+  it('should parse an environment with empty labels array', () => {
+    const input = {
+      items: [
+        {
+          id: 'env-1',
+          name: 'staging',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          labels: [],
+        },
+      ],
+      next_page_token: null,
+    };
+
+    const result = DeployEnvironmentResponse.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it('should parse an environment response without optional description', () => {
+    const input = {
+      items: [
+        {
+          id: 'env-1',
+          name: 'staging',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          labels: [],
+        },
+      ],
+      next_page_token: null,
+    };
+
+    const result = DeployEnvironmentResponse.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.items[0].description).toBeUndefined();
+    }
+  });
+
+  it('should fail to parse if labels is an array of strings (old format)', () => {
+    const input = {
+      items: [
+        {
+          id: 'env-1',
+          name: 'production',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          labels: ['env:prod'],
+        },
+      ],
+      next_page_token: null,
+    };
+
+    const result = DeployEnvironmentResponse.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('DeployComponentsResponseSchema', () => {
+  it('should parse a valid components response with object labels', () => {
+    const input = {
+      items: [
+        {
+          id: 'comp-1',
+          project_id: 'project-1',
+          name: 'frontend',
+          release_count: 5,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          labels: [{ key: 'tier', value: 'web' }],
+        },
+      ],
+      next_page_token: null,
+    };
+
+    const result = DeployComponentsResponse.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.items[0].labels).toEqual([{ key: 'tier', value: 'web' }]);
+    }
+  });
+
+  it('should parse a component with empty labels array', () => {
+    const input = {
+      items: [
+        {
+          id: 'comp-1',
+          project_id: 'project-1',
+          name: 'backend',
+          release_count: 3,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          labels: [],
+        },
+      ],
+      next_page_token: null,
+    };
+
+    const result = DeployComponentsResponse.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it('should parse a component with multiple labels', () => {
+    const input = {
+      items: [
+        {
+          id: 'comp-1',
+          project_id: 'project-1',
+          name: 'api',
+          release_count: 10,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          labels: [
+            { key: 'tier', value: 'api' },
+            { key: 'team', value: 'platform' },
+          ],
+        },
+      ],
+      next_page_token: null,
+    };
+
+    const result = DeployComponentsResponse.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.items[0].labels).toHaveLength(2);
+    }
+  });
+
+  it('should fail to parse if labels is an array of strings (old format)', () => {
+    const input = {
+      items: [
+        {
+          id: 'comp-1',
+          project_id: 'project-1',
+          name: 'frontend',
+          release_count: 5,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          labels: ['tier:web'],
+        },
+      ],
+      next_page_token: null,
+    };
+
+    const result = DeployComponentsResponse.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/clients/schemas.ts
+++ b/src/clients/schemas.ts
@@ -182,13 +182,15 @@ const DeploySettingsResponseSchema = z.object({
   rollback_pipeline_definition_id: z.string().optional().describe('The rollback pipeline definition ID, if configured for this project'),
 }).passthrough(); // Allow additional properties we might not know about
 
+const LabelSchema = z.object({ key: z.string(), value: z.string() });
+
 const DeployComponentsResponseSchema = z.object({
   items: z.array(z.object({
     id: z.string(),
     project_id: z.string(),
     name: z.string(),
     release_count: z.number(),
-    labels: z.array(z.string()),
+    labels: z.array(LabelSchema),
     created_at: z.string(),
     updated_at: z.string(),
   })),
@@ -212,11 +214,12 @@ const DeployComponentVersionsResponseSchema = z.object({
 
 export const DeployEnvironmentResponseSchema = z.object({
   items: z.array(z.object({
-  id: z.string(),
-  name: z.string(),
-  created_at: z.string(),
-  updated_at: z.string(),
-  labels: z.array(z.string()),
+    id: z.string(),
+    name: z.string(),
+    description: z.string().optional(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    labels: z.array(LabelSchema),
   })),
   next_page_token: z.string().nullable(),
 });

--- a/src/tools/listComponentVersions/handler.test.ts
+++ b/src/tools/listComponentVersions/handler.test.ts
@@ -337,8 +337,8 @@ describe('listComponentVersions handler', () => {
     it('should list environments when environmentID is not provided', async () => {
       const mockEnvironments = {
         items: [
-          { id: 'env-1', name: 'production' },
-          { id: 'env-2', name: 'staging' },
+          { id: 'env-1', name: 'production', created_at: '2023-01-01T00:00:00Z', updated_at: '2023-01-02T00:00:00Z', labels: [{ key: 'env', value: 'prod' }] },
+          { id: 'env-2', name: 'staging', created_at: '2023-01-01T00:00:00Z', updated_at: '2023-01-02T00:00:00Z', labels: [] },
         ],
         next_page_token: null,
       };
@@ -425,8 +425,8 @@ describe('listComponentVersions handler', () => {
     it('should list components when componentID is not provided', async () => {
       const mockComponents = {
         items: [
-          { id: 'comp-1', name: 'frontend' },
-          { id: 'comp-2', name: 'backend' },
+          { id: 'comp-1', name: 'frontend', project_id: 'test-project-id', release_count: 5, created_at: '2023-01-01T00:00:00Z', updated_at: '2023-01-02T00:00:00Z', labels: [{ key: 'tier', value: 'web' }] },
+          { id: 'comp-2', name: 'backend', project_id: 'test-project-id', release_count: 3, created_at: '2023-01-01T00:00:00Z', updated_at: '2023-01-02T00:00:00Z', labels: [] },
         ],
         next_page_token: null,
       };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a schema parsing bug that caused `list_component_versions` to fail when resolving environments or components as intermediate steps.

The CircleCI API v2 returns `labels` as an array of objects (`[{"key": "env", "value": "prod"}]`), but the Zod schemas were defining `labels` as `z.array(z.string())`, causing `safeParse()` to fail and surface as `"Failed to list component versions: <zod error>"`.

## Changes

### `src/clients/schemas.ts`
- Added a reusable `LabelSchema`: `z.object({ key: z.string(), value: z.string() })`
- Replaced `z.array(z.string())` with `z.array(LabelSchema)` in both `DeployComponentsResponseSchema` and `DeployEnvironmentResponseSchema`
- Added optional `description: z.string().optional()` field to `DeployEnvironmentResponseSchema` (returned by API but previously omitted)

### `src/tools/listComponentVersions/handler.test.ts`
- Updated mock environment and component objects to use the correct object labels format `[{ key: "...", value: "..." }]`

### `src/clients/__tests__/schemas.test.ts` (new file)
- Added regression tests that validate representative API responses through `safeParse()` for both `DeployEnvironmentResponse` and `DeployComponentsResponse`, including a negative test confirming the old string-array format now correctly fails

## Testing

All 256 tests pass (`pnpm test`).

Closes DR-413
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DR-413](https://linear.app/circleci/issue/DR-413/fix-labels-schema-parsing-bug-in-mcp-server)

<div><a href="https://cursor.com/agents/bc-f542d0c2-f569-4b81-a672-2bcc90ab5f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f542d0c2-f569-4b81-a672-2bcc90ab5f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

