### PR TITLE
fix: use pipeline ID from trigger to eliminate status-check race condition (NOT-867)

### DIFF
--- a/src/clients/schemas.ts
+++ b/src/clients/schemas.ts
@@ -159,6 +159,7 @@ const ConfigValidateSchema = z.object({
 });
 
 const RunPipelineResponseSchema = z.object({
+  id: z.string(),
   number: z.number(),
 });
 

--- a/src/lib/latest-pipeline/getLatestPipelineWorkflows.test.ts
+++ b/src/lib/latest-pipeline/getLatestPipelineWorkflows.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getLatestPipelineWorkflows } from './getLatestPipelineWorkflows.js';
+import * as clientModule from '../../clients/client.js';
+
+vi.mock('../../clients/client.js');
+
+describe('getLatestPipelineWorkflows', () => {
+  const mockWorkflows = [
+    {
+      id: 'wf-1',
+      name: 'build',
+      status: 'success',
+      created_at: '2026-04-21T00:00:00Z',
+      pipeline_number: 42,
+      project_slug: 'gh/org/repo',
+      pipeline_id: 'pipeline-abc',
+    },
+  ];
+
+  const mockCircleCIClient = {
+    pipelines: {
+      getPipelines: vi.fn(),
+    },
+    workflows: {
+      getPipelineWorkflows: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(clientModule, 'getCircleCIClient').mockReturnValue(
+      mockCircleCIClient as any,
+    );
+    mockCircleCIClient.workflows.getPipelineWorkflows.mockResolvedValue(
+      mockWorkflows,
+    );
+  });
+
+  it('uses pipelineId directly and skips branch search when pipelineId is provided', async () => {
+    const result = await getLatestPipelineWorkflows({
+      projectSlug: 'gh/org/repo',
+      branch: 'main',
+      pipelineId: 'pipeline-abc',
+    });
+
+    expect(mockCircleCIClient.pipelines.getPipelines).not.toHaveBeenCalled();
+    expect(
+      mockCircleCIClient.workflows.getPipelineWorkflows,
+    ).toHaveBeenCalledWith({ pipelineId: 'pipeline-abc' });
+    expect(result).toEqual(mockWorkflows);
+  });
+
+  it('falls back to branch search when pipelineId is not provided', async () => {
+    mockCircleCIClient.pipelines.getPipelines.mockResolvedValue([
+      { id: 'pipeline-xyz', project_slug: 'gh/org/repo', number: 10 },
+    ]);
+
+    const result = await getLatestPipelineWorkflows({
+      projectSlug: 'gh/org/repo',
+      branch: 'main',
+    });
+
+    expect(mockCircleCIClient.pipelines.getPipelines).toHaveBeenCalledWith({
+      projectSlug: 'gh/org/repo',
+      branch: 'main',
+    });
+    expect(
+      mockCircleCIClient.workflows.getPipelineWorkflows,
+    ).toHaveBeenCalledWith({ pipelineId: 'pipeline-xyz' });
+    expect(result).toEqual(mockWorkflows);
+  });
+
+  it('throws when no pipelines found and pipelineId is absent', async () => {
+    mockCircleCIClient.pipelines.getPipelines.mockResolvedValue([]);
+
+    await expect(
+      getLatestPipelineWorkflows({ projectSlug: 'gh/org/repo', branch: 'main' }),
+    ).rejects.toThrow('Latest pipeline not found');
+
+    expect(
+      mockCircleCIClient.workflows.getPipelineWorkflows,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('ignores a second pipeline on the same branch when pipelineId pins the first', async () => {
+    // Simulate race: a second pipeline "def-456" was pushed to same branch.
+    // Agent captured "abc-123" at trigger time and passes it via pipelineId.
+    mockCircleCIClient.pipelines.getPipelines.mockResolvedValue([
+      { id: 'def-456', project_slug: 'gh/org/repo', number: 11 },
+      { id: 'abc-123', project_slug: 'gh/org/repo', number: 10 },
+    ]);
+
+    await getLatestPipelineWorkflows({
+      projectSlug: 'gh/org/repo',
+      branch: 'main',
+      pipelineId: 'abc-123',
+    });
+
+    // Must use the pinned ID, not def-456 (the most recent)
+    expect(
+      mockCircleCIClient.workflows.getPipelineWorkflows,
+    ).toHaveBeenCalledWith({ pipelineId: 'abc-123' });
+    expect(mockCircleCIClient.pipelines.getPipelines).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/latest-pipeline/getLatestPipelineWorkflows.ts
+++ b/src/lib/latest-pipeline/getLatestPipelineWorkflows.ts
@@ -3,13 +3,19 @@ import { getCircleCIClient } from '../../clients/client.js';
 export type GetLatestPipelineWorkflowsParams = {
   projectSlug: string;
   branch?: string;
+  pipelineId?: string;
 };
 
 export const getLatestPipelineWorkflows = async ({
   projectSlug,
   branch,
+  pipelineId,
 }: GetLatestPipelineWorkflowsParams) => {
   const circleci = getCircleCIClient();
+
+  if (pipelineId) {
+    return circleci.workflows.getPipelineWorkflows({ pipelineId });
+  }
 
   const pipelines = await circleci.pipelines.getPipelines({
     projectSlug,
@@ -22,9 +28,7 @@ export const getLatestPipelineWorkflows = async ({
     throw new Error('Latest pipeline not found');
   }
 
-  const workflows = await circleci.workflows.getPipelineWorkflows({
+  return circleci.workflows.getPipelineWorkflows({
     pipelineId: latestPipeline.id,
   });
-
-  return workflows;
 };

--- a/src/tools/getLatestPipelineStatus/handler.test.ts
+++ b/src/tools/getLatestPipelineStatus/handler.test.ts
@@ -221,6 +221,30 @@ describe('getLatestPipelineStatus handler', () => {
     expect(response).toEqual(mockFormattedResponse);
   });
 
+  it('should use pipelineId directly when provided, bypassing branch search', async () => {
+    const args = {
+      params: {
+        projectURL:
+          'https://app.circleci.com/pipelines/github/circleci/project',
+        pipelineId: 'abc-123',
+      },
+    };
+
+    const controller = new AbortController();
+    const response = await getLatestPipelineStatus(args as any, {
+      signal: controller.signal,
+    });
+
+    expect(
+      getLatestPipelineWorkflowsModule.getLatestPipelineWorkflows,
+    ).toHaveBeenCalledWith({
+      projectSlug: 'gh/circleci/project',
+      branch: 'main',
+      pipelineId: 'abc-123',
+    });
+    expect(response).toEqual(mockFormattedResponse);
+  });
+
   it('should handle errors from getLatestPipelineWorkflows', async () => {
     vi.mocked(
       getLatestPipelineWorkflowsModule.getLatestPipelineWorkflows,

--- a/src/tools/getLatestPipelineStatus/handler.ts
+++ b/src/tools/getLatestPipelineStatus/handler.ts
@@ -18,6 +18,7 @@ export const getLatestPipelineStatus: ToolCallback<{
     branch,
     projectURL,
     projectSlug: inputProjectSlug,
+    pipelineId,
   } = args.params ?? {};
 
   let projectSlug: string | null | undefined;
@@ -56,6 +57,7 @@ export const getLatestPipelineStatus: ToolCallback<{
   const latestPipelineWorkflows = await getLatestPipelineWorkflows({
     projectSlug,
     branch: branchFromURL ?? branch,
+    pipelineId,
   });
 
   return formatLatestPipelineStatus(latestPipelineWorkflows);

--- a/src/tools/getLatestPipelineStatus/inputSchema.ts
+++ b/src/tools/getLatestPipelineStatus/inputSchema.ts
@@ -34,4 +34,10 @@ export const getLatestPipelineStatusInputSchema = z.object({
         'For example: "https://github.com/user/my-project.git"',
     )
     .optional(),
+  pipelineId: z
+    .string()
+    .describe(
+      'The pipeline ID returned by the run_pipeline tool. When provided, fetches status for this specific pipeline directly, avoiding any race condition from branch-based lookup.',
+    )
+    .optional(),
 });

--- a/src/tools/getLatestPipelineStatus/tool.ts
+++ b/src/tools/getLatestPipelineStatus/tool.ts
@@ -13,7 +13,7 @@ export const getLatestPipelineStatusTool = {
     - Check build progress
     - Get pipeline information
 
-    Input options (EXACTLY ONE of these THREE options must be used):
+    Input options (EXACTLY ONE of these FOUR options must be used):
 
     ${option1DescriptionBranchRequired}
 
@@ -29,6 +29,9 @@ export const getLatestPipelineStatusTool = {
     - workspaceRoot: The absolute path to the workspace root
     - gitRemoteURL: The URL of the git remote repository
     - branch: The name of the current branch
+
+    Option 4 - Pipeline ID (use when pipeline ID is known from run_pipeline):
+    - pipelineId: The pipeline ID returned by the run_pipeline tool. Fetches status for this specific pipeline directly, bypassing branch-based lookup and eliminating any race condition from concurrent pushes to the same branch. Combine with projectURL or projectSlug for context.
     
     Recommended Workflow:
     1. Use listFollowedProjects tool to get a list of projects

--- a/src/tools/runPipeline/handler.test.ts
+++ b/src/tools/runPipeline/handler.test.ts
@@ -256,6 +256,7 @@ describe('runPipeline handler', () => {
     expect(response.content[0]).toHaveProperty('type', 'text');
     expect(typeof response.content[0].text).toBe('string');
     expect(response.content[0].text).toContain('Pipeline run successfully');
+    expect(response.content[0].text).toContain('pipeline-id');
     expect(mockCircleCIClient.pipelines.runPipeline).toHaveBeenCalledWith({
       projectSlug: 'gh/org/repo',
       branch: 'main',
@@ -297,6 +298,7 @@ describe('runPipeline handler', () => {
     expect(response.content[0]).toHaveProperty('type', 'text');
     expect(typeof response.content[0].text).toBe('string');
     expect(response.content[0].text).toContain('Pipeline run successfully');
+    expect(response.content[0].text).toContain('pipeline-id');
     expect(mockCircleCIClient.pipelines.runPipeline).toHaveBeenCalledWith({
       projectSlug: 'gh/org/repo',
       branch: 'main',
@@ -339,6 +341,7 @@ describe('runPipeline handler', () => {
     expect(response.content[0]).toHaveProperty('type', 'text');
     expect(typeof response.content[0].text).toBe('string');
     expect(response.content[0].text).toContain('Pipeline run successfully');
+    expect(response.content[0].text).toContain('pipeline-id');
     expect(mockCircleCIClient.pipelines.runPipeline).toHaveBeenCalledWith({
       projectSlug: 'gh/org/repo',
       branch: 'feature-branch',
@@ -386,5 +389,6 @@ describe('runPipeline handler', () => {
     expect(response.content[0]).toHaveProperty('type', 'text');
     expect(typeof response.content[0].text).toBe('string');
     expect(response.content[0].text).toContain('Pipeline run successfully');
+    expect(response.content[0].text).toContain('pipeline-id');
   });
 });

--- a/src/tools/runPipeline/handler.ts
+++ b/src/tools/runPipeline/handler.ts
@@ -124,7 +124,7 @@ export const runPipeline: ToolCallback<{
     content: [
       {
         type: 'text',
-        text: `Pipeline run successfully. View it at: ${baseURL}/pipelines/${projectSlug}/${runPipelineResponse.number}`,
+        text: `Pipeline run successfully. Pipeline ID: ${runPipelineResponse.id}. View it at: ${baseURL}/pipelines/${projectSlug}/${runPipelineResponse.number}`,
       },
     ],
   };


### PR DESCRIPTION
## Summary

- `run_pipeline` now includes the pipeline UUID in its output text (`Pipeline ID: <uuid>`) so agents can capture it without parsing the URL
- `get_latest_pipeline_status` accepts a new optional `pipelineId` parameter
- `getLatestPipelineWorkflows` short-circuits to `getPipelineWorkflows(pipelineId)` when an ID is provided, skipping the branch search entirely
- `RunPipelineResponseSchema` updated to parse `id` from the API response (field was already returned, just not captured)

## Why

The previous flow had a race condition:

1. Agent calls `run_pipeline` → pipeline `abc-123` triggered on branch `main`
2. Another push lands on `main` → pipeline `def-456` created
3. Agent calls `get_latest_pipeline_status` → branch search returns `def-456` (the newest) → agent monitors the wrong pipeline, silently

With this change the agent captures `abc-123` from the `run_pipeline` output and passes it as `pipelineId` to `get_latest_pipeline_status`. The branch search is bypassed entirely — `def-456` is never seen.

## Test plan

- [ ] New test file `getLatestPipelineWorkflows.test.ts` with 4 cases:
  - pipelineId provided → `getPipelines` never called, correct ID used
  - pipelineId absent → falls back to branch search as before
  - no pipelines found → throws `Latest pipeline not found`
  - race scenario: two pipelines on same branch, pinned ID wins
- [ ] `get_latest_pipeline_status` handler test: `pipelineId` threaded through correctly
- [ ] `run_pipeline` handler tests: output text contains pipeline UUID
- [ ] Full suite passes: `npx vitest run` (261 tests)
- [ ] TypeScript compiles cleanly: `tsc --noEmit`

## Depends on

`circleci/public-api-service` PR adding `url` to the trigger response — the `id` field was already returned by the API, so the MCP fix works independently, but both should ship together per NOT-867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)