### PR TITLE
feat(get_build_failure_logs): add optional outputDir to write full logs to file

### DIFF
--- a/src/lib/pipeline-job-logs/getJobLogs.test.ts
+++ b/src/lib/pipeline-job-logs/getJobLogs.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { formatJobLogs } from './getJobLogs.js';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const mockLogs = [
+  {
+    jobName: 'build',
+    steps: [
+      {
+        stepName: 'Run tests',
+        logs: { output: 'Test failed', error: 'Error: assertion failed' },
+      },
+    ],
+  },
+];
+
+describe('formatJobLogs', () => {
+  let writtenFiles: string[] = [];
+
+  afterEach(() => {
+    for (const f of writtenFiles) {
+      try {
+        fs.unlinkSync(f);
+      } catch {}
+    }
+    writtenFiles = [];
+  });
+
+  it('returns inline truncated text when no outputDir is provided', () => {
+    const result = formatJobLogs(mockLogs);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('build');
+    expect(result.content[0].text).not.toContain('saved to');
+  });
+
+  it('returns "No logs found." when logs array is empty', () => {
+    const result = formatJobLogs([]);
+    expect(result.content[0].text).toBe('No logs found.');
+  });
+
+  it('writes logs to a file and returns the path when outputDir is provided', () => {
+    const outputDir = os.tmpdir();
+    const result = formatJobLogs(mockLogs, outputDir);
+
+    expect(result.content[0].text).toMatch(/^Build logs saved to: /);
+    const filePath = result.content[0].text.replace('Build logs saved to: ', '');
+    writtenFiles.push(filePath);
+
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(path.dirname(filePath)).toBe(path.resolve(outputDir));
+    expect(path.basename(filePath)).toMatch(/^circleci-build-logs-\d+\.txt$/);
+  });
+
+  it('writes full log content to the file', () => {
+    const outputDir = os.tmpdir();
+    const result = formatJobLogs(mockLogs, outputDir);
+    const filePath = result.content[0].text.replace('Build logs saved to: ', '');
+    writtenFiles.push(filePath);
+
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect(content).toContain('build');
+    expect(content).toContain('Run tests');
+    expect(content).toContain('Test failed');
+  });
+
+  it('resolves ~ in outputDir to the home directory', () => {
+    const result = formatJobLogs(mockLogs, '~/tmp-test-circleci-logs');
+    const filePath = result.content[0].text.replace('Build logs saved to: ', '');
+    const dir = path.dirname(filePath);
+
+    try {
+      expect(filePath.startsWith(os.homedir())).toBe(true);
+      expect(fs.existsSync(filePath)).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/pipeline-job-logs/getJobLogs.ts
+++ b/src/lib/pipeline-job-logs/getJobLogs.ts
@@ -3,6 +3,9 @@ import { getCircleCIClient } from '../../clients/client.js';
 import { rateLimitedRequests } from '../rateLimitedRequests/index.js';
 import { JobDetails } from '../../clients/schemas.js';
 import outputTextTruncated, { SEPARATOR } from '../outputTextTruncated.js';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
 export type GetJobLogsParams = {
   projectSlug: string;
@@ -105,12 +108,27 @@ const getJobLogs = async ({
 
 export default getJobLogs;
 
+function resolveOutputDir(outputDir: string): string {
+  if (outputDir.startsWith('~')) {
+    return path.join(os.homedir(), outputDir.slice(1));
+  }
+  if (outputDir.includes('%USERPROFILE%')) {
+    const userProfile = process.env.USERPROFILE || os.homedir();
+    return outputDir.replace('%USERPROFILE%', userProfile);
+  }
+  return outputDir;
+}
+
 /**
- * Formats job logs into a standardized output structure
- * @param logs Array of job logs containing step information
- * @returns Formatted output object with text content
+ * Formats job logs, either writing to a file (if outputDir provided) or returning truncated inline text
+ * @param jobStepLogs Array of job logs containing step information
+ * @param outputDir Optional directory to write the full log file to
+ * @returns Formatted output object with file path or inline (possibly truncated) text
  */
-export function formatJobLogs(jobStepLogs: JobWithStepLogs[]) {
+export function formatJobLogs(
+  jobStepLogs: JobWithStepLogs[],
+  outputDir?: string,
+) {
   if (jobStepLogs.length === 0) {
     return {
       content: [
@@ -124,6 +142,23 @@ export function formatJobLogs(jobStepLogs: JobWithStepLogs[]) {
   const outputText = jobStepLogs
     .map((log) => `${SEPARATOR}Job: ${log.jobName}\n` + formatSteps(log))
     .join('\n');
+
+  if (outputDir) {
+    const resolvedDir = path.resolve(resolveOutputDir(outputDir));
+    fs.mkdirSync(resolvedDir, { recursive: true });
+    const fileName = `circleci-build-logs-${Date.now()}.txt`;
+    const filePath = path.join(resolvedDir, fileName);
+    fs.writeFileSync(filePath, outputText, 'utf8');
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Build logs saved to: ${filePath}`,
+        },
+      ],
+    };
+  }
+
   return outputTextTruncated(outputText);
 }
 

--- a/src/tools/getBuildFailureLogs/handler.test.ts
+++ b/src/tools/getBuildFailureLogs/handler.test.ts
@@ -162,7 +162,7 @@ describe('getBuildFailureLogs handler', () => {
       jobNumber: undefined,
     });
 
-    expect(formatJobLogs.formatJobLogs).toHaveBeenCalledWith(mockLogs);
+    expect(formatJobLogs.formatJobLogs).toHaveBeenCalledWith(mockLogs, undefined);
     expect(response).toHaveProperty('content');
     expect(Array.isArray(response.content)).toBe(true);
     expect(response.content[0]).toHaveProperty('type', 'text');

--- a/src/tools/getBuildFailureLogs/handler.ts
+++ b/src/tools/getBuildFailureLogs/handler.ts
@@ -19,6 +19,7 @@ export const getBuildFailureLogs: ToolCallback<{
     branch,
     projectURL,
     projectSlug: inputProjectSlug,
+    outputDir,
   } = args.params ?? {};
 
   let projectSlug: string | undefined;
@@ -65,5 +66,5 @@ export const getBuildFailureLogs: ToolCallback<{
     jobNumber,
   });
 
-  return formatJobLogs(logs);
+  return formatJobLogs(logs, outputDir);
 };

--- a/src/tools/getBuildFailureLogs/inputSchema.ts
+++ b/src/tools/getBuildFailureLogs/inputSchema.ts
@@ -32,4 +32,12 @@ export const getBuildFailureOutputInputSchema = z.object({
         'For example: "https://github.com/user/my-project.git"',
     )
     .optional(),
+  outputDir: z
+    .string()
+    .describe(
+      'Optional. When provided, the full build logs are written to a file in this directory and the file path is returned. ' +
+        'Use this for large logs to avoid truncation. ' +
+        'Use the workspace/project root when available (e.g., "/home/user/my-project"), otherwise use the Downloads folder (e.g., "~/Downloads").',
+    )
+    .optional(),
 });

--- a/src/tools/getBuildFailureLogs/tool.ts
+++ b/src/tools/getBuildFailureLogs/tool.ts
@@ -7,11 +7,10 @@ export const getBuildFailureLogsTool = {
     This tool helps debug CircleCI build failures by retrieving failure logs.
 
     CRITICAL REQUIREMENTS:
-    1. Truncation Handling (HIGHEST PRIORITY):
-       - ALWAYS check for <MCPTruncationWarning> in the output
-       - When present, you MUST start your response with:
-         "WARNING: The logs have been truncated. Only showing the most recent entries. Earlier build failures may not be visible."
-       - Only proceed with log analysis after acknowledging the truncation
+    1. Large Log Handling:
+       - If you expect large logs or want the full output, provide outputDir. The full logs will be written to a file and the path returned.
+         * Use the project/workspace root when available, otherwise use the Downloads folder (e.g., "~/Downloads").
+       - If outputDir is omitted, logs are returned inline but may be truncated. When truncated, output will contain <MCPTruncationWarning> and you MUST acknowledge: "WARNING: The logs have been truncated. Only showing the most recent entries."
 
     Input options (EXACTLY ONE of these THREE options must be used):
 


### PR DESCRIPTION
## Summary

- Adds an optional `outputDir` parameter to the `get_build_failure_logs` MCP tool
- When `outputDir` is provided, the full build logs are written to a timestamped file in that directory and the file path is returned to the caller
- When `outputDir` is omitted, the existing inline truncation behavior is preserved
- Handles `~` and `%USERPROFILE%` path expansions for cross-platform compatibility

## Files changed

- `src/tools/getBuildFailureLogs/inputSchema.ts` - added optional `outputDir` param with description
- `src/tools/getBuildFailureLogs/handler.ts` - destructures and passes `outputDir` through to `formatJobLogs`
- `src/tools/getBuildFailureLogs/tool.ts` - updated tool description to guide models on when/how to use `outputDir`
- `src/lib/pipeline-job-logs/getJobLogs.ts` - `formatJobLogs` now writes to file when `outputDir` is provided, with `resolveOutputDir` helper for path expansion
- `src/tools/getBuildFailureLogs/handler.test.ts` - updated assertion to match new `outputDir` argument
- `src/lib/pipeline-job-logs/getJobLogs.test.ts` - new test file covering file-write and inline truncation paths for `formatJobLogs`

## Test plan

- [x] Verify existing tests pass (`npm test`)
- [x] Test `get_build_failure_logs` without `outputDir` — logs returned inline with truncation warning when large
- [x] Test `get_build_failure_logs` with `outputDir` set to a writable directory — file is created and path is returned
- [x] Test with `~/Downloads` as `outputDir` to confirm tilde expansion works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)