### PR TITLE
Add get_orb_details and search_orbs orb registry tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Use Cursor, Windsurf, Copilot, Claude, or any MCP-compatible client to interact 
 | [`get_build_failure_logs`](#get_build_failure_logs) | Retrieve detailed failure logs from CircleCI builds |
 | [`get_job_test_results`](#get_job_test_results) | Retrieve test metadata and results for CircleCI jobs |
 | [`get_latest_pipeline_status`](#get_latest_pipeline_status) | Get the status of the latest pipeline for a branch |
+| [`get_orb_details`](#get_orb_details) | Get the full schema of a CircleCI orb (commands, jobs, executors, parameters) |
 | [`list_artifacts`](#list_artifacts) | List artifacts produced by a CircleCI job |
 | [`list_component_versions`](#list_component_versions) | List all versions for a CircleCI component |
 | [`list_followed_projects`](#list_followed_projects) | List all CircleCI projects you're following |
@@ -29,6 +30,7 @@ Use Cursor, Windsurf, Copilot, Claude, or any MCP-compatible client to interact 
 | [`run_evaluation_tests`](#run_evaluation_tests) | Run evaluation tests on a CircleCI pipeline |
 | [`run_pipeline`](#run_pipeline) | Trigger a pipeline to run |
 | [`run_rollback_pipeline`](#run_rollback_pipeline) | Trigger a rollback for a project |
+| [`search_orbs`](#search_orbs) | Search the CircleCI certified orb registry by keyword |
 
 ## Installation
 
@@ -747,6 +749,21 @@ Stopped: in progress
 </details>
 
 <details>
+<summary id="get_orb_details"><strong><code>get_orb_details</code></strong></summary>
+
+Retrieves the full schema of a CircleCI orb — every command, job, and executor it exposes, along with each parameter's name, type, default value, and required/optional status — plus the version pin. Use this when authoring or modifying `.circleci/config.yml`: the schema lets you write correct YAML on the first try instead of guessing from training data.
+
+Accepts:
+- `circleci/slack` — returns the latest version's schema.
+- `circleci/slack@4.12.6` — returns the schema for a specific version.
+
+Returns sections (in order): description, examples, executors, jobs, commands, and a final "use this version: `namespace/name@version`" pin. The pin and commands list sit at the tail so they survive truncation if the output is very large.
+
+Example: "Show me the parameters for circleci/aws-cli"
+
+</details>
+
+<details>
 <summary id="list_artifacts"><strong><code>list_artifacts</code></strong></summary>
 
 Retrieves the list of artifacts produced by a CircleCI job. This tool can be used in three ways:
@@ -882,6 +899,19 @@ Triggers a rollback for a CircleCI project. The tool interactively guides you th
    - **Pipeline Rollback:** triggers the rollback pipeline
    - **Workflow Rerun:** reruns a previous workflow using its workflow ID
 7. **Confirmation** — summarizes and confirms before execution
+
+</details>
+
+<details>
+<summary id="search_orbs"><strong><code>search_orbs</code></strong></summary>
+
+Searches the CircleCI orb registry by keyword. Use this when you need an orb for a task but don't already know which one — for example, a less common deployment target or a specific kind of scan. For well-known orbs like `circleci/slack` or `circleci/aws-cli`, skip this and call [`get_orb_details`](#get_orb_details) directly with the slug.
+
+**Limitation:** only the certified orb set (~77 orbs published by CircleCI and partners) is text-searchable through CircleCI's GraphQL API. The thousands of community orbs are not indexed for search — if you know a community orb's exact name (e.g., `datadog/agent`), call `get_orb_details` directly with that slug.
+
+Returns matching orbs sorted by recent build popularity, with each result's latest version pin.
+
+Example: "Find me a CircleCI orb for AWS ECS deployments"
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "date-fns": "4.1.0",
     "express": "^4.19.2",
     "parse-github-url": "^1.0.3",
+    "yaml": "2.9.0",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       parse-github-url:
         specifier: ^1.0.3
         version: 1.0.3
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -80,7 +83,7 @@ importers:
         version: 8.29.0(eslint@9.23.0)(typescript@5.8.2)
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/node@22.13.13)(tsx@4.19.3)
+        version: 3.1.1(@types/node@22.13.13)(tsx@4.19.3)(yaml@2.9.0)
 
 packages:
 
@@ -1686,6 +1689,11 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2066,13 +2074,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.1(vite@6.2.4(@types/node@22.13.13)(tsx@4.19.3))':
+  '@vitest/mocker@3.1.1(vite@6.2.4(@types/node@22.13.13)(tsx@4.19.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.4(@types/node@22.13.13)(tsx@4.19.3)
+      vite: 6.2.4(@types/node@22.13.13)(tsx@4.19.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.1.1':
     dependencies:
@@ -3223,13 +3231,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.1.1(@types/node@22.13.13)(tsx@4.19.3):
+  vite-node@3.1.1(@types/node@22.13.13)(tsx@4.19.3)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@5.5.0)
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.4(@types/node@22.13.13)(tsx@4.19.3)
+      vite: 6.2.4(@types/node@22.13.13)(tsx@4.19.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3244,7 +3252,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.4(@types/node@22.13.13)(tsx@4.19.3):
+  vite@6.2.4(@types/node@22.13.13)(tsx@4.19.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.3
@@ -3253,11 +3261,12 @@ snapshots:
       '@types/node': 22.13.13
       fsevents: 2.3.3
       tsx: 4.19.3
+      yaml: 2.9.0
 
-  vitest@3.1.1(@types/node@22.13.13)(tsx@4.19.3):
+  vitest@3.1.1(@types/node@22.13.13)(tsx@4.19.3)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(vite@6.2.4(@types/node@22.13.13)(tsx@4.19.3))
+      '@vitest/mocker': 3.1.1(vite@6.2.4(@types/node@22.13.13)(tsx@4.19.3)(yaml@2.9.0))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1
@@ -3273,8 +3282,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.4(@types/node@22.13.13)(tsx@4.19.3)
-      vite-node: 3.1.1(@types/node@22.13.13)(tsx@4.19.3)
+      vite: 6.2.4(@types/node@22.13.13)(tsx@4.19.3)(yaml@2.9.0)
+      vite-node: 3.1.1(@types/node@22.13.13)(tsx@4.19.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.13
@@ -3308,6 +3317,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/circleci-tools.ts
+++ b/src/circleci-tools.ts
@@ -36,6 +36,12 @@ import { listComponentVersions } from './tools/listComponentVersions/handler.js'
 import { listArtifactsTool } from './tools/listArtifacts/tool.js';
 import { listArtifacts } from './tools/listArtifacts/handler.js';
 
+import { getOrbDetailsTool } from './tools/getOrbDetails/tool.js';
+import { getOrbDetails } from './tools/getOrbDetails/handler.js';
+
+import { searchOrbsTool } from './tools/searchOrbs/tool.js';
+import { searchOrbs } from './tools/searchOrbs/handler.js';
+
 // Define the tools with their configurations
 export const CCI_TOOLS = [
   getBuildFailureLogsTool,
@@ -55,6 +61,8 @@ export const CCI_TOOLS = [
   runRollbackPipelineTool,
   listComponentVersionsTool,
   listArtifactsTool,
+  getOrbDetailsTool,
+  searchOrbsTool,
 ];
 
 // Extract the tool names as a union type
@@ -87,4 +95,6 @@ export const CCI_HANDLERS = {
   run_rollback_pipeline: runRollbackPipeline,
   list_component_versions: listComponentVersions,
   list_artifacts: listArtifacts,
+  get_orb_details: getOrbDetails,
+  search_orbs: searchOrbs,
 } satisfies ToolHandlers;

--- a/src/clients/circleci/graphqlClient.ts
+++ b/src/clients/circleci/graphqlClient.ts
@@ -1,0 +1,32 @@
+import { HTTPClient } from './httpClient.js';
+
+type GraphQLResponse<T> = {
+  data?: T;
+  errors?: { message: string }[];
+};
+
+export class GraphQLClient {
+  protected client: HTTPClient;
+
+  constructor(httpClient: HTTPClient) {
+    this.client = httpClient;
+  }
+
+  async query<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+    const body: Record<string, unknown> = { query };
+    if (variables) body.variables = variables;
+
+    const response = await this.client.post<GraphQLResponse<T>>('', body);
+
+    if (response.errors && response.errors.length > 0) {
+      const messages = response.errors.map((e) => e.message).join('; ');
+      throw new Error(`CircleCI GraphQL error: ${messages}`);
+    }
+
+    if (!response.data) {
+      throw new Error('CircleCI GraphQL error: no data returned');
+    }
+
+    return response.data;
+  }
+}

--- a/src/clients/circleci/index.ts
+++ b/src/clients/circleci/index.ts
@@ -9,6 +9,8 @@ import { ConfigValidateAPI } from './configValidate.js';
 import { ProjectsAPI } from './projects.js';
 import { UsageAPI } from './usage.js';
 import { DeploysAPI } from './deploys.js';
+import { GraphQLClient } from './graphqlClient.js';
+import { OrbsAPI } from './orbs.js';
 export type TCircleCIClient = InstanceType<typeof CircleCIClients>;
 
 export const getBaseURL = (useAPISubdomain = false) => {
@@ -100,6 +102,24 @@ const defaultV1HTTPClient = (options: {
 };
 
 /**
+ * Creates a default HTTP client for the CircleCI GraphQL API
+ * @param options Configuration parameters
+ * @param options.token CircleCI API token
+ * @returns HTTP client for the CircleCI GraphQL endpoint
+ */
+const defaultGraphQLHTTPClient = (options: { token: string }) => {
+  if (!options.token) {
+    throw new Error('Token is required');
+  }
+
+  const baseURL = getBaseURL();
+  const headers = createCircleCIHeaders({ token: options.token });
+  return new HTTPClient(baseURL, '/graphql-unstable', {
+    headers,
+  });
+};
+
+/**
  * Creates a default HTTP client for the CircleCI API v2
  * @param options Configuration parameters
  * @param options.token CircleCI API token
@@ -118,6 +138,7 @@ export class CircleCIClients {
   public projects: ProjectsAPI;
   public usage: UsageAPI;
   public deploys: DeploysAPI;
+  public orbs: OrbsAPI;
 
   constructor({
     token,
@@ -131,11 +152,15 @@ export class CircleCIClients {
       token,
       useAPISubdomain: true,
     }),
+    graphqlHttpClient = defaultGraphQLHTTPClient({
+      token,
+    }),
   }: {
     token: string;
     v2httpClient?: HTTPClient;
     v1httpClient?: HTTPClient;
     apiSubdomainV2httpClient?: HTTPClient;
+    graphqlHttpClient?: HTTPClient;
   }) {
     this.jobs = new JobsAPI(v2httpClient);
     this.pipelines = new PipelinesAPI(v2httpClient);
@@ -147,5 +172,6 @@ export class CircleCIClients {
     this.projects = new ProjectsAPI(v2httpClient);
     this.usage = new UsageAPI(v2httpClient);
     this.deploys = new DeploysAPI(v2httpClient);
+    this.orbs = new OrbsAPI(new GraphQLClient(graphqlHttpClient));
   }
 }

--- a/src/clients/circleci/orbs.ts
+++ b/src/clients/circleci/orbs.ts
@@ -1,0 +1,170 @@
+import { GraphQLClient } from './graphqlClient.js';
+
+export type OrbVersionDetails = {
+  orbName: string;
+  version: string;
+  createdAt: string;
+  source: string;
+};
+
+export type OrbSearchResult = {
+  name: string;
+  version: string | null;
+  popularity: number;
+};
+
+type GetOrbVersionResponse = {
+  orbVersion: {
+    version: string;
+    createdAt: string;
+    source: string;
+  } | null;
+};
+
+type GetOrbLatestResponse = {
+  orb: {
+    name: string;
+    versions: { version: string; createdAt: string; source: string }[];
+  } | null;
+};
+
+type ListVersionsResponse = {
+  orb: {
+    versions: { version: string }[];
+  } | null;
+};
+
+type SearchOrbsResponse = {
+  orbs: {
+    edges: {
+      node: {
+        name: string;
+        versions: { version: string }[];
+        statistics: { last30DaysBuildCount: number | null } | null;
+      };
+    }[];
+  };
+};
+
+export class OrbsAPI {
+  protected client: GraphQLClient;
+
+  constructor(graphqlClient: GraphQLClient) {
+    this.client = graphqlClient;
+  }
+
+  async getOrb({
+    orbSlug,
+  }: {
+    orbSlug: string;
+  }): Promise<OrbVersionDetails> {
+    const slashCount = (orbSlug.match(/\//g) ?? []).length;
+    if (slashCount !== 1) {
+      throw new Error(
+        `Invalid orb slug '${orbSlug}': expected format 'namespace/name' or 'namespace/name@version'.`,
+      );
+    }
+
+    const [nameWithoutVersion, requestedVersion] = orbSlug.split('@');
+
+    if (requestedVersion) {
+      const result = await this.client.query<GetOrbVersionResponse>(
+        `query GetOrbVersion($ref: String!) {
+          orbVersion(orbVersionRef: $ref) {
+            version
+            createdAt
+            source
+          }
+        }`,
+        { ref: orbSlug },
+      );
+
+      if (result.orbVersion) {
+        return {
+          orbName: nameWithoutVersion,
+          version: result.orbVersion.version,
+          createdAt: result.orbVersion.createdAt,
+          source: result.orbVersion.source,
+        };
+      }
+
+      const versions = await this.client.query<ListVersionsResponse>(
+        `query ListVersions($name: String!) {
+          orb(name: $name) {
+            versions(count: 20) { version }
+          }
+        }`,
+        { name: nameWithoutVersion },
+      );
+
+      if (!versions.orb) {
+        throw new Error(`Orb '${nameWithoutVersion}' not found.`);
+      }
+
+      const available = versions.orb.versions.map((v) => v.version);
+      throw new Error(
+        `Version '${requestedVersion}' not found for orb '${nameWithoutVersion}'. ` +
+          `Recent available versions: ${available.slice(0, 10).join(', ') || '(none)'}.`,
+      );
+    }
+
+    const latest = await this.client.query<GetOrbLatestResponse>(
+      `query GetOrbLatest($name: String!) {
+        orb(name: $name) {
+          name
+          versions(count: 1) {
+            version
+            createdAt
+            source
+          }
+        }
+      }`,
+      { name: nameWithoutVersion },
+    );
+
+    if (!latest.orb) {
+      throw new Error(`Orb '${nameWithoutVersion}' not found.`);
+    }
+
+    if (latest.orb.versions.length === 0) {
+      throw new Error(`Orb '${nameWithoutVersion}' has no published versions.`);
+    }
+
+    const v = latest.orb.versions[0];
+    return {
+      orbName: latest.orb.name,
+      version: v.version,
+      createdAt: v.createdAt,
+      source: v.source,
+    };
+  }
+
+  async searchOrbs({ query }: { query: string }): Promise<OrbSearchResult[]> {
+    const result = await this.client.query<SearchOrbsResponse>(
+      `query SearchCertifiedOrbs {
+        orbs(first: 100, certifiedOnly: true) {
+          edges {
+            node {
+              name
+              versions(count: 1) { version }
+              statistics { last30DaysBuildCount }
+            }
+          }
+        }
+      }`,
+    );
+
+    const needle = query.toLowerCase();
+    const matches = result.orbs.edges
+      .map((e) => e.node)
+      .filter((n) => n.name.toLowerCase().includes(needle))
+      .map((n) => ({
+        name: n.name,
+        version: n.versions[0]?.version ?? null,
+        popularity: n.statistics?.last30DaysBuildCount ?? 0,
+      }));
+
+    matches.sort((a, b) => b.popularity - a.popularity);
+    return matches;
+  }
+}

--- a/src/lib/orb-schema/formatOrbDetails.ts
+++ b/src/lib/orb-schema/formatOrbDetails.ts
@@ -1,0 +1,89 @@
+// Output is wrapped with `outputTextTruncated`, which keeps the TAIL on
+// overflow. Sections are written least-to-most-critical so that, if the
+// response is truncated, the commands list and version pin (what the agent
+// most needs) survive at the end.
+import type {
+  OrbDefinition,
+  OrbExample,
+  OrbParameter,
+  OrbSchema,
+} from './parseOrbSource.js';
+
+const ORDER_NOTE = '';
+
+function formatParameter(param: OrbParameter): string {
+  const required = param.required ? 'required' : 'optional';
+  const defaultPart = param.required
+    ? ''
+    : `, default: ${JSON.stringify(param.default ?? null)}`;
+  const desc = param.description
+    ? `\n    ${param.description.replace(/\n+/g, ' ').trim()}`
+    : '';
+  return `  - \`${param.name}\` (${param.type}, ${required}${defaultPart})${desc}`;
+}
+
+function formatDefinition(def: OrbDefinition): string {
+  const lines: string[] = [`- \`${def.name}\``];
+  if (def.description) {
+    lines.push(`  ${def.description.replace(/\n+/g, ' ').trim()}`);
+  }
+  if (def.parameters.length > 0) {
+    lines.push('  Parameters:');
+    for (const p of def.parameters) lines.push(formatParameter(p));
+  } else {
+    lines.push('  (no parameters)');
+  }
+  return lines.join('\n');
+}
+
+function formatExample(ex: OrbExample): string {
+  return ex.description
+    ? `- \`${ex.name}\` — ${ex.description.replace(/\n+/g, ' ').trim()}`
+    : `- \`${ex.name}\``;
+}
+
+function section(title: string, body: string): string {
+  return `## ${title}\n\n${body}\n`;
+}
+
+export function formatOrbDetails({
+  orbName,
+  version,
+  schema,
+}: {
+  orbName: string;
+  version: string;
+  schema: OrbSchema;
+}): string {
+  const parts: string[] = [];
+
+  // Least critical first — survives tail-truncation least.
+  if (schema.description) {
+    parts.push(section('Orb Description', schema.description.trim()));
+  }
+
+  if (schema.examples.length > 0) {
+    parts.push(section('Examples', schema.examples.map(formatExample).join('\n')));
+  }
+
+  if (schema.executors.length > 0) {
+    parts.push(
+      section('Executors', schema.executors.map(formatDefinition).join('\n\n')),
+    );
+  }
+
+  if (schema.jobs.length > 0) {
+    parts.push(section('Jobs', schema.jobs.map(formatDefinition).join('\n\n')));
+  }
+
+  if (schema.commands.length > 0) {
+    parts.push(
+      section('Commands', schema.commands.map(formatDefinition).join('\n\n')),
+    );
+  }
+
+  // Most critical last — survives tail-truncation.
+  parts.push(`## Use in config\n\nPin this version: \`${orbName}@${version}\``);
+
+  return ORDER_NOTE + parts.join('\n');
+}

--- a/src/lib/orb-schema/parseOrbSource.test.ts
+++ b/src/lib/orb-schema/parseOrbSource.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { parseOrbSource, OrbSourceParseError } from './parseOrbSource.js';
+
+const SAMPLE_ORB = `version: 2.1
+description: A sample orb for testing.
+commands:
+  notify:
+    description: Send a notification.
+    parameters:
+      channel:
+        type: string
+        default: "#general"
+        description: The channel to post to.
+      message:
+        type: string
+        description: The message body.
+      mentions:
+        type: string
+        default: ""
+jobs:
+  send:
+    parameters:
+      event:
+        type: enum
+        enum: ["pass", "fail"]
+        default: "pass"
+    steps:
+      - notify:
+          channel: $CHANNEL
+executors:
+  default:
+    docker:
+      - image: cimg/base:stable
+examples:
+  basic_usage:
+    description: A minimal example.
+    usage:
+      version: 2.1
+`;
+
+describe('parseOrbSource', () => {
+  it('extracts commands, jobs, executors, and examples', () => {
+    const schema = parseOrbSource(SAMPLE_ORB);
+
+    expect(schema.description).toBe('A sample orb for testing.');
+    expect(schema.commands).toHaveLength(1);
+    expect(schema.jobs).toHaveLength(1);
+    expect(schema.executors).toHaveLength(1);
+    expect(schema.examples).toHaveLength(1);
+  });
+
+  it('flags parameters without a default as required', () => {
+    const schema = parseOrbSource(SAMPLE_ORB);
+    const notify = schema.commands.find((c) => c.name === 'notify');
+    expect(notify).toBeDefined();
+    const channel = notify!.parameters.find((p) => p.name === 'channel');
+    const message = notify!.parameters.find((p) => p.name === 'message');
+    expect(channel?.required).toBe(false);
+    expect(channel?.default).toBe('#general');
+    expect(message?.required).toBe(true);
+    expect(message?.default).toBeUndefined();
+  });
+
+  it('treats empty string default as a real default (still optional)', () => {
+    const schema = parseOrbSource(SAMPLE_ORB);
+    const mentions = schema.commands[0].parameters.find(
+      (p) => p.name === 'mentions',
+    );
+    expect(mentions?.required).toBe(false);
+    expect(mentions?.default).toBe('');
+  });
+
+  it('handles missing sections without throwing', () => {
+    const schema = parseOrbSource('version: 2.1\n');
+    expect(schema.commands).toEqual([]);
+    expect(schema.jobs).toEqual([]);
+    expect(schema.executors).toEqual([]);
+    expect(schema.examples).toEqual([]);
+  });
+
+  it('skips non-object entries in command sections instead of throwing', () => {
+    const weird = `version: 2.1
+commands:
+  good:
+    parameters:
+      x:
+        type: string
+  bad: "this is a string not an object"
+  alsoBad: 42
+`;
+    const schema = parseOrbSource(weird);
+    expect(schema.commands.map((c) => c.name)).toEqual(['good']);
+  });
+
+  it('throws OrbSourceParseError on malformed YAML', () => {
+    const malformed = 'version: 2.1\ncommands:\n  notify:\n    - parameters: [unclosed';
+    expect(() => parseOrbSource(malformed)).toThrow(OrbSourceParseError);
+  });
+
+  it('throws OrbSourceParseError when top-level is not an object', () => {
+    expect(() => parseOrbSource('just a string')).toThrow(OrbSourceParseError);
+    expect(() => parseOrbSource('')).toThrow(OrbSourceParseError);
+  });
+
+  it('coerces non-standard parameter type values to string', () => {
+    const yamlText = `version: 2.1
+commands:
+  weird:
+    parameters:
+      missingType:
+        default: foo
+      numericType:
+        type: 42
+        default: foo
+`;
+    const schema = parseOrbSource(yamlText);
+    const params = schema.commands[0].parameters;
+    expect(params.find((p) => p.name === 'missingType')?.type).toBe('unknown');
+    expect(params.find((p) => p.name === 'numericType')?.type).toBe('42');
+  });
+});

--- a/src/lib/orb-schema/parseOrbSource.ts
+++ b/src/lib/orb-schema/parseOrbSource.ts
@@ -1,0 +1,111 @@
+import { parse as parseYaml } from 'yaml';
+
+export type OrbParameter = {
+  name: string;
+  type: string;
+  default?: unknown;
+  description?: string;
+  required: boolean;
+};
+
+export type OrbDefinition = {
+  name: string;
+  description?: string;
+  parameters: OrbParameter[];
+};
+
+export type OrbExample = {
+  name: string;
+  description?: string;
+};
+
+export type OrbSchema = {
+  description?: string;
+  commands: OrbDefinition[];
+  jobs: OrbDefinition[];
+  executors: OrbDefinition[];
+  examples: OrbExample[];
+};
+
+export class OrbSourceParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OrbSourceParseError';
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function extractParameters(node: unknown): OrbParameter[] {
+  if (!isPlainObject(node)) return [];
+  return Object.entries(node).flatMap(([name, raw]) => {
+    if (!isPlainObject(raw)) return [];
+    const type =
+      typeof raw.type === 'string' || typeof raw.type === 'number'
+        ? String(raw.type)
+        : 'unknown';
+    const description =
+      typeof raw.description === 'string' ? raw.description : undefined;
+    const hasDefault = 'default' in raw;
+    const param: OrbParameter = {
+      name,
+      type,
+      description,
+      required: !hasDefault,
+    };
+    if (hasDefault) param.default = raw.default;
+    return [param];
+  });
+}
+
+function extractDefinitions(node: unknown): OrbDefinition[] {
+  if (!isPlainObject(node)) return [];
+  return Object.entries(node).flatMap(([name, raw]) => {
+    if (!isPlainObject(raw)) return [];
+    const description =
+      typeof raw.description === 'string' ? raw.description : undefined;
+    return [
+      {
+        name,
+        description,
+        parameters: extractParameters(raw.parameters),
+      },
+    ];
+  });
+}
+
+function extractExamples(node: unknown): OrbExample[] {
+  if (!isPlainObject(node)) return [];
+  return Object.entries(node).flatMap(([name, raw]) => {
+    if (!isPlainObject(raw)) return [];
+    const description =
+      typeof raw.description === 'string' ? raw.description : undefined;
+    return [{ name, description }];
+  });
+}
+
+export function parseOrbSource(yamlText: string): OrbSchema {
+  let doc: unknown;
+  try {
+    doc = parseYaml(yamlText);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new OrbSourceParseError(`Malformed orb YAML: ${msg}`);
+  }
+
+  if (!isPlainObject(doc)) {
+    throw new OrbSourceParseError(
+      'Orb source is not a valid YAML object at the top level',
+    );
+  }
+
+  return {
+    description: typeof doc.description === 'string' ? doc.description : undefined,
+    commands: extractDefinitions(doc.commands),
+    jobs: extractDefinitions(doc.jobs),
+    executors: extractDefinitions(doc.executors),
+    examples: extractExamples(doc.examples),
+  };
+}

--- a/src/tools/getOrbDetails/handler.test.ts
+++ b/src/tools/getOrbDetails/handler.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getOrbDetails } from './handler.js';
+import * as client from '../../clients/client.js';
+
+vi.mock('../../clients/client.js');
+
+const VALID_SOURCE = `version: 2.1
+description: Demo
+commands:
+  notify:
+    description: Notify a channel.
+    parameters:
+      channel:
+        type: string
+        default: "#general"
+      message:
+        type: string
+jobs: {}
+executors:
+  default:
+    docker:
+      - image: cimg/base:stable
+`;
+
+const callHandler = async (params: { orbSlug?: string }) => {
+  const controller = new AbortController();
+  return getOrbDetails(
+    { params } as Parameters<typeof getOrbDetails>[0],
+    { signal: controller.signal } as Parameters<typeof getOrbDetails>[1],
+  );
+};
+
+describe('getOrbDetails handler', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns formatted schema for a valid orb', async () => {
+    vi.spyOn(client, 'getCircleCIClient').mockReturnValue({
+      orbs: {
+        getOrb: vi.fn().mockResolvedValue({
+          orbName: 'circleci/demo',
+          version: '1.0.0',
+          createdAt: '2025-01-01T00:00:00Z',
+          source: VALID_SOURCE,
+        }),
+      },
+    } as unknown as ReturnType<typeof client.getCircleCIClient>);
+
+    const response = await callHandler({ orbSlug: 'circleci/demo' });
+
+    expect(response.content[0].type).toBe('text');
+    const text = response.content[0].text;
+    expect(text).toContain('circleci/demo@1.0.0');
+    expect(text).toContain('notify');
+    expect(text).toContain('channel');
+    expect(text).toContain('message');
+    // The pin line is at the end so it survives tail-truncation.
+    expect(text.trimEnd().endsWith('`circleci/demo@1.0.0`')).toBe(true);
+  });
+
+  it('returns mcp error when orbSlug is missing', async () => {
+    const response = await callHandler({});
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('orbSlug');
+  });
+
+  it('returns mcp error when OrbsAPI throws (orb not found)', async () => {
+    vi.spyOn(client, 'getCircleCIClient').mockReturnValue({
+      orbs: {
+        getOrb: vi.fn().mockRejectedValue(new Error("Orb 'foo/bar' not found.")),
+      },
+    } as unknown as ReturnType<typeof client.getCircleCIClient>);
+
+    const response = await callHandler({ orbSlug: 'foo/bar' });
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain("Orb 'foo/bar' not found");
+  });
+
+  it('returns friendly error when orb source YAML is malformed', async () => {
+    vi.spyOn(client, 'getCircleCIClient').mockReturnValue({
+      orbs: {
+        getOrb: vi.fn().mockResolvedValue({
+          orbName: 'circleci/demo',
+          version: '1.0.0',
+          createdAt: '2025-01-01T00:00:00Z',
+          source: 'version: 2.1\ncommands:\n  bad: [unclosed',
+        }),
+      },
+    } as unknown as ReturnType<typeof client.getCircleCIClient>);
+
+    const response = await callHandler({ orbSlug: 'circleci/demo' });
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('could not be parsed');
+    expect(response.content[0].text).toContain('circleci/demo@1.0.0');
+  });
+});

--- a/src/tools/getOrbDetails/handler.ts
+++ b/src/tools/getOrbDetails/handler.ts
@@ -1,0 +1,52 @@
+import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getOrbDetailsInputSchema } from './inputSchema.js';
+import { getCircleCIClient } from '../../clients/client.js';
+import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
+import outputTextTruncated from '../../lib/outputTextTruncated.js';
+import {
+  parseOrbSource,
+  OrbSourceParseError,
+} from '../../lib/orb-schema/parseOrbSource.js';
+import { formatOrbDetails } from '../../lib/orb-schema/formatOrbDetails.js';
+
+export const getOrbDetails: ToolCallback<{
+  params: typeof getOrbDetailsInputSchema;
+}> = async (args) => {
+  const { orbSlug } = args.params ?? {};
+
+  if (!orbSlug || typeof orbSlug !== 'string') {
+    return mcpErrorOutput(
+      'Missing required input: orbSlug. Provide a slug like "circleci/slack" or "circleci/slack@4.12.6".',
+    );
+  }
+
+  const circleci = getCircleCIClient();
+
+  let orb;
+  try {
+    orb = await circleci.orbs.getOrb({ orbSlug });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return mcpErrorOutput(msg);
+  }
+
+  let schema;
+  try {
+    schema = parseOrbSource(orb.source);
+  } catch (e) {
+    if (e instanceof OrbSourceParseError) {
+      return mcpErrorOutput(
+        `Orb '${orb.orbName}' was found (version ${orb.version}) but its source YAML could not be parsed: ${e.message}. You can still pin this version in config (\`${orb.orbName}@${orb.version}\`), but parameter details are unavailable.`,
+      );
+    }
+    throw e;
+  }
+
+  const formatted = formatOrbDetails({
+    orbName: orb.orbName,
+    version: orb.version,
+    schema,
+  });
+
+  return outputTextTruncated(formatted);
+};

--- a/src/tools/getOrbDetails/inputSchema.ts
+++ b/src/tools/getOrbDetails/inputSchema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const getOrbDetailsInputSchema = z.object({
+  orbSlug: z
+    .string()
+    .describe(
+      'The orb identifier. Accepts either "namespace/name" (e.g., "circleci/slack") to get the latest version, or "namespace/name@version" (e.g., "circleci/slack@4.12.6") for a specific version.',
+    ),
+});

--- a/src/tools/getOrbDetails/tool.ts
+++ b/src/tools/getOrbDetails/tool.ts
@@ -1,0 +1,23 @@
+import { getOrbDetailsInputSchema } from './inputSchema.js';
+
+export const getOrbDetailsTool = {
+  name: 'get_orb_details' as const,
+  description: `
+  This tool retrieves the complete schema for a specific CircleCI orb, including all commands, jobs, executors, and their parameters (names, types, defaults, whether required), plus the current latest version. Use this tool whenever you need to write or modify CircleCI config that uses an orb — it gives you the exact parameter names and types so you can generate correct YAML instead of guessing from training data. Accepts an orb slug like "circleci/slack@4.12.6" for a specific version, or "circleci/slack" to get the latest version's schema.
+
+  Parameters:
+  - params: An object containing:
+    - orbSlug: string - The orb identifier in the form "namespace/name" or "namespace/name@version".
+
+  Example usage:
+  {
+    "params": {
+      "orbSlug": "circleci/slack"
+    }
+  }
+
+  Returns:
+  - The orb's latest (or requested) version number and its full schema: commands, jobs, executors, and parameters with types, defaults, and required/optional status.
+  `,
+  inputSchema: getOrbDetailsInputSchema,
+};

--- a/src/tools/searchOrbs/handler.test.ts
+++ b/src/tools/searchOrbs/handler.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { searchOrbs } from './handler.js';
+import * as client from '../../clients/client.js';
+
+vi.mock('../../clients/client.js');
+
+const callHandler = async (params: { query?: string }) => {
+  const controller = new AbortController();
+  return searchOrbs(
+    { params } as Parameters<typeof searchOrbs>[0],
+    { signal: controller.signal } as Parameters<typeof searchOrbs>[1],
+  );
+};
+
+describe('searchOrbs handler', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('formats matching orbs sorted by popularity', async () => {
+    vi.spyOn(client, 'getCircleCIClient').mockReturnValue({
+      orbs: {
+        searchOrbs: vi.fn().mockResolvedValue([
+          { name: 'circleci/slack', version: '6.1.3', popularity: 7533848 },
+          { name: 'circleci/slack-orb-tools', version: '1.0.0', popularity: 12 },
+        ]),
+      },
+    } as unknown as ReturnType<typeof client.getCircleCIClient>);
+
+    const response = await callHandler({ query: 'slack' });
+    const text = response.content[0].text;
+    expect(text).toContain('Found 2 matching certified orbs for "slack"');
+    expect(text).toContain('`circleci/slack@6.1.3`');
+    expect(text).toContain('7,533,848 builds');
+    expect(text).toContain('`circleci/slack-orb-tools@1.0.0`');
+  });
+
+  it('returns helpful no-results message when nothing matches', async () => {
+    vi.spyOn(client, 'getCircleCIClient').mockReturnValue({
+      orbs: {
+        searchOrbs: vi.fn().mockResolvedValue([]),
+      },
+    } as unknown as ReturnType<typeof client.getCircleCIClient>);
+
+    const response = await callHandler({ query: 'asdfghjkl' });
+    expect(response.content[0].text).toContain('No certified orbs match');
+    expect(response.content[0].text).toContain('get_orb_details');
+  });
+
+  it('returns mcp error when query is missing', async () => {
+    const response = await callHandler({});
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('query');
+  });
+
+  it('returns mcp error when OrbsAPI throws', async () => {
+    vi.spyOn(client, 'getCircleCIClient').mockReturnValue({
+      orbs: {
+        searchOrbs: vi.fn().mockRejectedValue(new Error('GraphQL error: boom')),
+      },
+    } as unknown as ReturnType<typeof client.getCircleCIClient>);
+
+    const response = await callHandler({ query: 'slack' });
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('boom');
+  });
+});

--- a/src/tools/searchOrbs/handler.ts
+++ b/src/tools/searchOrbs/handler.ts
@@ -1,0 +1,48 @@
+import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { searchOrbsInputSchema } from './inputSchema.js';
+import { getCircleCIClient } from '../../clients/client.js';
+import mcpErrorOutput from '../../lib/mcpErrorOutput.js';
+
+const NO_RESULTS = (q: string) =>
+  `No certified orbs match "${q}". The CircleCI registry has thousands of community orbs that are not indexed for text search — if you know the exact name of a community orb (e.g., "datadog/agent"), call get_orb_details directly with that slug.`;
+
+export const searchOrbs: ToolCallback<{
+  params: typeof searchOrbsInputSchema;
+}> = async (args) => {
+  const { query } = args.params ?? {};
+
+  if (!query || typeof query !== 'string') {
+    return mcpErrorOutput(
+      'Missing required input: query. Provide a keyword to search for (e.g., "slack").',
+    );
+  }
+
+  const circleci = getCircleCIClient();
+
+  let results;
+  try {
+    results = await circleci.orbs.searchOrbs({ query });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return mcpErrorOutput(msg);
+  }
+
+  if (results.length === 0) {
+    return {
+      content: [{ type: 'text', text: NO_RESULTS(query) }],
+    };
+  }
+
+  const lines = results.map((r) => {
+    const versionPart = r.version ? `@${r.version}` : ' (no published versions)';
+    const popularityPart =
+      r.popularity > 0
+        ? ` — ${r.popularity.toLocaleString()} builds in last 30 days`
+        : '';
+    return `- \`${r.name}${versionPart}\` (certified)${popularityPart}`;
+  });
+
+  const text = `Found ${results.length} matching certified orb${results.length === 1 ? '' : 's'} for "${query}":\n\n${lines.join('\n')}\n\nUse get_orb_details with one of these slugs to retrieve the full schema (commands, jobs, executors, parameters).`;
+
+  return { content: [{ type: 'text', text }] };
+};

--- a/src/tools/searchOrbs/inputSchema.ts
+++ b/src/tools/searchOrbs/inputSchema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const searchOrbsInputSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .describe(
+      'A keyword to search for in orb names (e.g., "slack", "aws", "kubernetes", "terraform"). Matches by substring on the orb name.',
+    ),
+});

--- a/src/tools/searchOrbs/tool.ts
+++ b/src/tools/searchOrbs/tool.ts
@@ -1,0 +1,25 @@
+import { searchOrbsInputSchema } from './inputSchema.js';
+
+export const searchOrbsTool = {
+  name: 'search_orbs' as const,
+  description: `
+  This tool searches the CircleCI orb registry to find reusable configuration packages (orbs) that provide pre-built commands, jobs, and executors for common CI/CD tasks. Use this when you need to find an orb for a task but don't already know which orb to use — for example, if the user wants to deploy to a less common platform or run a specific type of scan. For well-known orbs (circleci/slack, circleci/aws-cli, circleci/node, etc.), skip this and call get_orb_details directly.
+
+  Limitation: only the CircleCI certified orb set (~77 orbs) is text-searchable. Community orbs are not indexed for search — if you know a community orb's exact name, call get_orb_details directly.
+
+  Parameters:
+  - params: An object containing:
+    - query: string - A keyword to match against orb names.
+
+  Example usage:
+  {
+    "params": {
+      "query": "slack"
+    }
+  }
+
+  Returns:
+  - A list of matching certified orbs with their latest version, sorted by recent build popularity.
+  `,
+  inputSchema: searchOrbsInputSchema,
+};


### PR DESCRIPTION
Adds get_orb_details and search_orbs tools for orb registry lookups via GraphQL API. These tools let agents look up orb schemas (commands, jobs, executors, parameters, versions) directly.