### PR TITLE
Add per-request token auth for remote MCP deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Use Cursor, Windsurf, Copilot, Claude, or any MCP-compatible client to interact 
 
 ## Installation
 
+> **Team / centralized deployment:** To run one shared remote server for your org (Kubernetes, Docker, etc.) with per-developer or shared CircleCI tokens, see [Self-Managed Remote MCP Server](#self-managed-remote-mcp-server).
+
 <details>
 <summary><strong>Cursor</strong></summary>
 
@@ -96,25 +98,7 @@ Add the following to your Cursor MCP config:
 
 #### Using a Self-Managed Remote MCP Server
 
-Add the following to your Cursor MCP config:
-
-```json
-{
-  "inputs": [
-    {
-      "type": "promptString",
-      "id": "circleci-token",
-      "description": "CircleCI API Token",
-      "password": true
-    }
-  ],
-  "servers": {
-    "circleci-mcp-server-remote": {
-      "url": "http://your-circleci-remote-mcp-server-endpoint:8000/mcp"
-    }
-  }
-}
-```
+See [Self-Managed Remote MCP Server](#self-managed-remote-mcp-server). Use the [per-user client configuration](#client-configuration-per-user-tokens) and add it to your Cursor MCP config (`Cursor Settings → MCP`).
 
 </details>
 
@@ -207,18 +191,7 @@ Add the following to `.vscode/mcp.json` in your project:
 
 #### Using a Self-Managed Remote MCP Server
 
-Add the following to `.vscode/mcp.json` in your project:
-
-```json
-{
-  "servers": {
-    "circleci-mcp-server-remote": {
-      "type": "sse",
-      "url": "http://your-circleci-remote-mcp-server-endpoint:8000/mcp"
-    }
-  }
-}
-```
+See [Self-Managed Remote MCP Server](#self-managed-remote-mcp-server). Use the [per-user client configuration](#client-configuration-per-user-tokens) in `.vscode/mcp.json`.
 
 </details>
 
@@ -283,31 +256,7 @@ Add the following to your `claude_desktop_config.json`:
 
 #### Using a Self-Managed Remote MCP Server
 
-Create a wrapper script (e.g. `circleci-remote-mcp.sh`):
-
-```bash
-#!/bin/bash
-export CIRCLECI_TOKEN="your-circleci-token"
-npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8000/mcp --allow-http
-```
-
-Make it executable:
-
-```bash
-chmod +x circleci-remote-mcp.sh
-```
-
-Then add the following to your `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "circleci-remote-mcp-server": {
-      "command": "/full/path/to/circleci-remote-mcp.sh"
-    }
-  }
-}
-```
+See [Self-Managed Remote MCP Server](#self-managed-remote-mcp-server). Create a wrapper script as shown in [Claude Desktop and CLI clients](#claude-desktop-and-cli-clients), then point your `claude_desktop_config.json` at it.
 
 To find or create your config file, open Claude Desktop settings, click **Developer** in the left sidebar, then click **Edit Config**. The config file is located at:
 
@@ -340,11 +289,7 @@ claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -e CIRC
 
 #### Using a Self-Managed Remote MCP Server
 
-```bash
-claude mcp add circleci-mcp-server -e CIRCLECI_TOKEN=your-circleci-token -- npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8000/mcp --allow-http
-```
-
-For more information: https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/tutorials#set-up-model-context-protocol-mcp
+See [Self-Managed Remote MCP Server](#self-managed-remote-mcp-server) and the [Claude Code](#claude-code) client setup there.
 
 </details>
 
@@ -409,24 +354,7 @@ Add the following to your Windsurf `mcp_config.json`:
 
 #### Using a Self-Managed Remote MCP Server
 
-Add the following to your Windsurf `mcp_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "circleci": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "http://your-circleci-remote-mcp-server-endpoint:8000/mcp",
-        "--allow-http"
-      ],
-      "disabled": false,
-      "alwaysAllow": []
-    }
-  }
-}
-```
+See [Self-Managed Remote MCP Server](#self-managed-remote-mcp-server). Use the [per-user client configuration](#client-configuration-per-user-tokens) in your Windsurf `mcp_config.json`.
 
 For more information: https://docs.windsurf.com/windsurf/mcp
 
@@ -472,20 +400,7 @@ Edit `~/.aws/amazonq/mcp.json` or create `.amazonq/mcp.json` with the following:
 
 #### Using a Self-Managed Remote MCP Server
 
-Create a wrapper script (e.g. `circleci-remote-mcp.sh`):
-
-```bash
-#!/bin/bash
-export CIRCLECI_TOKEN="your-circleci-token"
-npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8000/mcp --allow-http
-```
-
-Make it executable and add it:
-
-```bash
-chmod +x circleci-remote-mcp.sh
-q mcp add --name circleci --command "/full/path/to/circleci-remote-mcp.sh"
-```
+See [Self-Managed Remote MCP Server](#self-managed-remote-mcp-server). Use a wrapper script as shown in [Claude Desktop and CLI clients](#claude-desktop-and-cli-clients), then register it with `q mcp add`.
 
 </details>
 
@@ -522,14 +437,7 @@ Edit `~/.aws/amazonq/mcp.json` or create `.amazonq/mcp.json` with the following:
 
 #### Using a Self-Managed Remote MCP Server
 
-Create a wrapper script (e.g. `circleci-remote-mcp.sh`):
-
-```bash
-#!/bin/bash
-npx mcp-remote http://your-circleci-remote-mcp-server-endpoint:8000/mcp --allow-http
-```
-
-Make it executable, then add it via the MCP configuration UI:
+See [Self-Managed Remote MCP Server](#self-managed-remote-mcp-server). Use a wrapper script as shown in [Claude Desktop and CLI clients](#claude-desktop-and-cli-clients), then add it via the MCP configuration UI:
 
 1. [Access the MCP configuration UI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/mcp-ide.html#mcp-ide-configuration-access-ui)
 2. Choose the **+** symbol
@@ -551,6 +459,177 @@ npx -y @smithery/cli install @CircleCI-Public/mcp-server-circleci --client claud
 ```
 
 </details>
+
+## Self-Managed Remote MCP Server
+
+Run the MCP server centrally (for example on Kubernetes or Docker) so your team shares one deployment. Choose how developers authenticate:
+
+### Choose a deployment mode
+
+| Mode | When to use | Server setup | Client setup | CircleCI audit trail |
+|------|-------------|--------------|--------------|----------------------|
+| **Per-user tokens** (recommended) | Teams with SSO-backed Personal API Tokens | `REQUIRE_REQUEST_TOKEN=true`, no server PAT | Each dev forwards their PAT | Per developer |
+| **Shared token** (interim) | Quick rollout, single service identity OK | `CIRCLECI_TOKEN` on server, no `REQUIRE_REQUEST_TOKEN` | No auth header needed | Single shared identity |
+
+### 1. Deploy the server
+
+Both modes use remote HTTP mode (`start=remote`). Publish port `8000` (or your chosen port).
+
+**Per-user tokens (recommended):**
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e start=remote \
+  -e port=8000 \
+  -e REQUIRE_REQUEST_TOKEN=true \
+  circleci/mcp-server-circleci
+```
+
+**Shared token (interim):**
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e start=remote \
+  -e port=8000 \
+  -e CIRCLECI_TOKEN=your-shared-circleci-pat \
+  circleci/mcp-server-circleci
+```
+
+**Environment variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `start=remote` | Starts the HTTP+SSE MCP server instead of stdio |
+| `port` | Listening port inside the container (default: `8000`) |
+| `REQUIRE_REQUEST_TOKEN=true` | Reject requests without `Authorization: Bearer` or `Circle-Token` header |
+| `CIRCLECI_TOKEN` | Shared fallback PAT for all requests when per-user headers are not sent |
+| `CIRCLECI_BASE_URL` | Optional — required for on-prem only (default: `https://circleci.com`) |
+| `DISABLE_TELEMETRY=true` | Opt out of usage metrics export |
+
+The server accepts per-request tokens via:
+
+- `Authorization: Bearer <circleci-pat>`
+- `Circle-Token: <circleci-pat>`
+
+If a client sends a header token, it takes precedence over `CIRCLECI_TOKEN` on the server.
+
+Telemetry metrics recorded during a request are exported using the same token as that request.
+
+### 2. Configure clients
+
+Most MCP clients only support local (stdio) processes. Use [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), a third-party stdio-to-HTTP bridge, to connect them to your remote server.
+
+> **URL scheme:** Use `http://localhost:8000/mcp` with `--allow-http` for local testing. In production, terminate TLS at your ingress/load balancer and use `https://your-host/mcp` without `--allow-http`.
+
+> **Windows:** Avoid spaces around the colon in `--header` values. Put the full `Bearer <token>` value in an environment variable.
+
+> **Security:** Examples use `npx` for convenience. For production or team rollouts, pin a specific version in your MCP config (for example `mcp-remote@0.1.38` instead of `mcp-remote`). Do not use versions below `0.1.16` ([CVE-2025-6514](https://www.npmjs.com/package/mcp-remote)).
+
+#### Client configuration: per-user tokens
+
+Each developer forwards their own CircleCI Personal API Token on every request:
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "circleci-token",
+      "description": "CircleCI API Token",
+      "password": true
+    }
+  ],
+  "mcpServers": {
+    "circleci-mcp-server-remote": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "http://localhost:8000/mcp",
+        "--allow-http",
+        "--header",
+        "Authorization:${AUTH_HEADER}"
+      ],
+      "env": {
+        "AUTH_HEADER": "Bearer ${input:circleci-token}"
+      }
+    }
+  }
+}
+```
+
+Replace `http://localhost:8000/mcp` with your team's server URL. Cursor and VS Code support `${input:...}` prompts; other clients can set `AUTH_HEADER` directly.
+
+#### Client configuration: shared token
+
+When the server has `CIRCLECI_TOKEN` set and `REQUIRE_REQUEST_TOKEN` is **not** enabled, clients do not need to send a token:
+
+```json
+{
+  "mcpServers": {
+    "circleci-mcp-server-remote": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "http://localhost:8000/mcp",
+        "--allow-http"
+      ]
+    }
+  }
+}
+```
+
+#### Claude Desktop and CLI clients
+
+Create a wrapper script (e.g. `circleci-remote-mcp.sh`):
+
+```bash
+#!/bin/bash
+export AUTH_HEADER="Bearer your-circleci-token"
+npx mcp-remote http://localhost:8000/mcp --allow-http --header "Authorization:${AUTH_HEADER}"
+```
+
+Make it executable (`chmod +x circleci-remote-mcp.sh`), then reference it from your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "circleci-remote-mcp-server": {
+      "command": "/full/path/to/circleci-remote-mcp.sh"
+    }
+  }
+}
+```
+
+#### Claude Code
+
+```bash
+claude mcp add circleci-mcp-server \
+  -e AUTH_HEADER="Bearer your-circleci-token" \
+  -- npx mcp-remote http://localhost:8000/mcp --allow-http --header "Authorization:${AUTH_HEADER}"
+```
+
+Omit `--header` and `AUTH_HEADER` when using a [shared-token server](#1-deploy-the-server).
+
+### 3. Verify the deployment
+
+```bash
+# Health check (no auth required)
+curl http://localhost:8000/ping
+
+# Should return 401 when REQUIRE_REQUEST_TOKEN=true and no token is sent
+curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+
+# Should return 200 with a valid Bearer token and MCP Accept headers
+curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer your-circleci-pat" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+```
 
 ## Demo
 
@@ -977,7 +1056,7 @@ taskkill /f /im node.exe
 
 ## Telemetry
 
-The server supports OpenTelemetry metrics for tracking tool usage. To disable telemetry, set `DISABLE_TELEMETRY=true`.
+The server supports OpenTelemetry metrics for tracking tool usage. Metrics are exported unless you set `DISABLE_TELEMETRY=true`. On remote deployments, metrics use the same token as the request (per-user PAT or shared server PAT).
 
 | Metric | Description |
 |--------|-------------|
@@ -1017,17 +1096,16 @@ docker build -t circleci:mcp-server-circleci .
 
 This will create a Docker image tagged as `circleci:mcp-server-circleci` that you can use with any MCP client.
 
-To run the container locally:
+**Local stdio mode** (single developer, token on the client):
 
 ```bash
-docker run --rm -i -e CIRCLECI_TOKEN=your-circleci-token -e CIRCLECI_BASE_URL=https://circleci.com circleci:mcp-server-circleci
+docker run --rm -i \
+  -e CIRCLECI_TOKEN=your-circleci-token \
+  -e CIRCLECI_BASE_URL=https://circleci.com \
+  circleci/mcp-server-circleci
 ```
 
-To run the container as a self-managed remote MCP server, add `start=remote` and optionally specify the port (default: `8000`):
-
-```bash
-docker run --rm -i -e CIRCLECI_TOKEN=your-circleci-token -e CIRCLECI_BASE_URL=https://circleci.com -e start=remote -e port=8000 circleci:mcp-server-circleci
-```
+**Remote mode** (centralized server for a team): see [Self-Managed Remote MCP Server](#self-managed-remote-mcp-server).
 
 ## Development with MCP Inspector
 

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -1,22 +1,15 @@
+import { requireCircleCIToken } from '../lib/auth/resolveToken.js';
 import { CircleCIPrivateClients } from './circleci-private/index.js';
 import { CircleCIClients } from './circleci/index.js';
 
 export function getCircleCIClient() {
-  if (!process.env.CIRCLECI_TOKEN) {
-    throw new Error('CIRCLECI_TOKEN is not set');
-  }
-
   return new CircleCIClients({
-    token: process.env.CIRCLECI_TOKEN,
+    token: requireCircleCIToken(),
   });
 }
 
 export function getCircleCIPrivateClient() {
-  if (!process.env.CIRCLECI_TOKEN) {
-    throw new Error('CIRCLECI_TOKEN is not set');
-  }
-
   return new CircleCIPrivateClients({
-    token: process.env.CIRCLECI_TOKEN,
+    token: requireCircleCIToken(),
   });
 }

--- a/src/lib/auth/extractToken.test.ts
+++ b/src/lib/auth/extractToken.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Request } from 'express';
+
+import {
+  extractCircleCITokenFromRequest,
+  isRequestTokenRequired,
+} from './extractToken.js';
+
+function createRequest(headers: Record<string, string | undefined>): Request {
+  return {
+    header(name: string) {
+      const normalized = name.toLowerCase();
+      for (const [key, value] of Object.entries(headers)) {
+        if (key.toLowerCase() === normalized) {
+          return value;
+        }
+      }
+      return undefined;
+    },
+  } as Request;
+}
+
+describe('extractCircleCITokenFromRequest', () => {
+  it('should extract bearer tokens from Authorization header', () => {
+    const req = createRequest({
+      authorization: 'Bearer pat-user-123',
+    });
+
+    expect(extractCircleCITokenFromRequest(req)).toBe('pat-user-123');
+  });
+
+  it('should extract tokens from Circle-Token header', () => {
+    const req = createRequest({
+      'circle-token': 'pat-user-456',
+    });
+
+    expect(extractCircleCITokenFromRequest(req)).toBe('pat-user-456');
+  });
+
+  it('should prefer Authorization header over Circle-Token', () => {
+    const req = createRequest({
+      authorization: 'Bearer pat-from-bearer',
+      'circle-token': 'pat-from-circle-token',
+    });
+
+    expect(extractCircleCITokenFromRequest(req)).toBe('pat-from-bearer');
+  });
+
+  it('should return undefined for malformed bearer headers', () => {
+    const req = createRequest({
+      authorization: 'Basic abc123',
+    });
+
+    expect(extractCircleCITokenFromRequest(req)).toBeUndefined();
+  });
+});
+
+describe('isRequestTokenRequired', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.REQUIRE_REQUEST_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should be false by default', () => {
+    expect(isRequestTokenRequired()).toBe(false);
+  });
+
+  it('should be true when REQUIRE_REQUEST_TOKEN is true', () => {
+    process.env.REQUIRE_REQUEST_TOKEN = 'true';
+    expect(isRequestTokenRequired()).toBe(true);
+  });
+});

--- a/src/lib/auth/extractToken.ts
+++ b/src/lib/auth/extractToken.ts
@@ -1,0 +1,29 @@
+import type { Request } from 'express';
+
+/**
+ * Extracts a CircleCI PAT from incoming HTTP request headers.
+ * Supports Authorization: Bearer <token> and Circle-Token: <token>.
+ */
+export function extractCircleCITokenFromRequest(
+  req: Request,
+): string | undefined {
+  const authorization = req.header('authorization');
+  if (authorization) {
+    const match = authorization.match(/^Bearer\s+(.+)$/i);
+    const bearerToken = match?.[1]?.trim();
+    if (bearerToken) {
+      return bearerToken;
+    }
+  }
+
+  const circleToken = req.header('circle-token');
+  if (circleToken?.trim()) {
+    return circleToken.trim();
+  }
+
+  return undefined;
+}
+
+export function isRequestTokenRequired(): boolean {
+  return process.env.REQUIRE_REQUEST_TOKEN === 'true';
+}

--- a/src/lib/auth/requestContext.ts
+++ b/src/lib/auth/requestContext.ts
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const requestTokenStorage = new AsyncLocalStorage<string>();
+
+/**
+ * Returns the CircleCI token from the current async request context, if set.
+ */
+export function getRequestCircleCIToken(): string | undefined {
+  return requestTokenStorage.getStore();
+}
+
+/**
+ * Runs fn with the given CircleCI token available to the current async chain.
+ */
+export function runWithCircleCIToken<T>(
+  token: string,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  return requestTokenStorage.run(token, fn);
+}

--- a/src/lib/auth/resolveToken.test.ts
+++ b/src/lib/auth/resolveToken.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runWithCircleCIToken } from './requestContext.js';
+import {
+  MISSING_TOKEN_MESSAGE,
+  requireCircleCIToken,
+  resolveCircleCIToken,
+} from './resolveToken.js';
+
+describe('resolveCircleCIToken', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.CIRCLECI_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should prefer request-scoped token over env token', () => {
+    process.env.CIRCLECI_TOKEN = 'env-token';
+
+    const token = runWithCircleCIToken('request-token', () =>
+      resolveCircleCIToken(),
+    );
+
+    expect(token).toBe('request-token');
+  });
+
+  it('should fall back to CIRCLECI_TOKEN when no request token is set', () => {
+    process.env.CIRCLECI_TOKEN = 'env-token';
+
+    expect(resolveCircleCIToken()).toBe('env-token');
+  });
+
+  it('should return undefined when no token is available', () => {
+    expect(resolveCircleCIToken()).toBeUndefined();
+  });
+
+  it('should throw a helpful error from requireCircleCIToken when missing', () => {
+    expect(() => requireCircleCIToken()).toThrow(MISSING_TOKEN_MESSAGE);
+  });
+
+  it('should isolate concurrent request contexts', async () => {
+    const results = await Promise.all([
+      runWithCircleCIToken('token-a', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return resolveCircleCIToken();
+      }),
+      runWithCircleCIToken('token-b', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return resolveCircleCIToken();
+      }),
+    ]);
+
+    expect(results).toEqual(['token-a', 'token-b']);
+  });
+});

--- a/src/lib/auth/resolveToken.ts
+++ b/src/lib/auth/resolveToken.ts
@@ -1,0 +1,32 @@
+import { getRequestCircleCIToken } from './requestContext.js';
+
+const MISSING_TOKEN_MESSAGE =
+  'CircleCI token is required. Provide Authorization: Bearer <token>, Circle-Token header, or set CIRCLECI_TOKEN.';
+
+/**
+ * Resolves the CircleCI token for the current request or process.
+ * Request-scoped token takes precedence over CIRCLECI_TOKEN env var.
+ */
+export function resolveCircleCIToken(): string | undefined {
+  const requestToken = getRequestCircleCIToken()?.trim();
+  if (requestToken) {
+    return requestToken;
+  }
+
+  const envToken = process.env.CIRCLECI_TOKEN?.trim();
+  if (envToken) {
+    return envToken;
+  }
+
+  return undefined;
+}
+
+export function requireCircleCIToken(): string {
+  const token = resolveCircleCIToken();
+  if (!token) {
+    throw new Error(MISSING_TOKEN_MESSAGE);
+  }
+  return token;
+}
+
+export { MISSING_TOKEN_MESSAGE };

--- a/src/lib/telemetry/config.test.ts
+++ b/src/lib/telemetry/config.test.ts
@@ -18,12 +18,12 @@ describe('getTelemetryConfig', () => {
     process.env = originalEnv;
   });
 
-  it('should return disabled config when CIRCLECI_TOKEN is not set', () => {
+  it('should return enabled config without env token for per-request auth', () => {
     delete process.env.CIRCLECI_TOKEN;
 
     const config = getTelemetryConfig();
 
-    expect(config.enabled).toBe(false);
+    expect(config.enabled).toBe(true);
     expect(config.token).toBe('');
   });
 
@@ -36,12 +36,13 @@ describe('getTelemetryConfig', () => {
     expect(config.token).toBe('pat-token-abc');
   });
 
-  it('should treat whitespace-only CIRCLECI_TOKEN as disabled', () => {
+  it('should treat whitespace-only CIRCLECI_TOKEN as empty fallback token', () => {
     process.env.CIRCLECI_TOKEN = '   ';
 
     const config = getTelemetryConfig();
 
-    expect(config.enabled).toBe(false);
+    expect(config.enabled).toBe(true);
+    expect(config.token).toBe('');
   });
 
   it('should return disabled config when DISABLE_TELEMETRY is true', () => {

--- a/src/lib/telemetry/config.ts
+++ b/src/lib/telemetry/config.ts
@@ -11,24 +11,21 @@ export const TELEMETRY_SERVICE_NAME = 'mcp-server-circleci';
 export const TELEMETRY_FLUSH_INTERVAL_MS = 60_000;
 
 export type TelemetryConfig = {
-  /** True when CIRCLECI_TOKEN is set (PAT used for metrics export via Circle-Token header). */
+  /** True when telemetry has not been opted out via DISABLE_TELEMETRY=true. */
   enabled: boolean;
-  /** CircleCI PAT for metrics endpoint auth. */
+  /** Fallback CircleCI PAT for metrics when no request-scoped token is available. */
   token: string;
 };
 
 /**
- * Telemetry is enabled when the customer has configured CIRCLECI_TOKEN and
- * has not opted out via DISABLE_TELEMETRY=true.
- * The same PAT used for CircleCI API calls authenticates metrics export.
+ * Telemetry is enabled unless DISABLE_TELEMETRY=true.
+ * Metrics are authenticated with the request-scoped token when available,
+ * otherwise CIRCLECI_TOKEN from the process environment.
  */
 export function getTelemetryConfig(): TelemetryConfig {
   if (process.env.DISABLE_TELEMETRY === 'true') {
     return { enabled: false, token: '' };
   }
-  const token = process.env.CIRCLECI_TOKEN?.trim();
-  if (!token) {
-    return { enabled: false, token: '' };
-  }
+  const token = process.env.CIRCLECI_TOKEN?.trim() || '';
   return { enabled: true, token };
 }

--- a/src/lib/telemetry/index.ts
+++ b/src/lib/telemetry/index.ts
@@ -1,8 +1,9 @@
 /**
  * Telemetry module for CircleCI MCP Server.
  *
- * Metrics for tool usage are exported to CircleCI ai-o11y when
- * CIRCLECI_TOKEN (PAT) is set.
+ * Metrics for tool usage are exported to CircleCI ai-o11y unless
+ * DISABLE_TELEMETRY=true. Metrics use the request-scoped token when
+ * available, otherwise CIRCLECI_TOKEN from the process environment.
  */
 
 export {

--- a/src/lib/telemetry/metrics.test.ts
+++ b/src/lib/telemetry/metrics.test.ts
@@ -46,7 +46,8 @@ describe('Metrics initialization', () => {
     process.env = originalEnv;
   });
 
-  it('should not throw when metrics are disabled', async () => {
+  it('should not throw when metrics are disabled via DISABLE_TELEMETRY', async () => {
+    process.env.DISABLE_TELEMETRY = 'true';
     delete process.env.CIRCLECI_TOKEN;
 
     const { initializeMetrics, isMetricsEnabled } = await import(
@@ -57,7 +58,7 @@ describe('Metrics initialization', () => {
     expect(isMetricsEnabled()).toBe(false);
   });
 
-  it('should report metrics as disabled when CIRCLECI_TOKEN is not set', async () => {
+  it('should report metrics as enabled when CIRCLECI_TOKEN is not set', async () => {
     delete process.env.CIRCLECI_TOKEN;
 
     const { initializeMetrics, isMetricsEnabled } = await import(
@@ -65,7 +66,7 @@ describe('Metrics initialization', () => {
     );
     await initializeMetrics();
 
-    expect(isMetricsEnabled()).toBe(false);
+    expect(isMetricsEnabled()).toBe(true);
   });
 });
 

--- a/src/lib/telemetry/metrics.token.test.ts
+++ b/src/lib/telemetry/metrics.token.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runWithCircleCIToken } from '../auth/requestContext.js';
+import {
+  MetricStatus,
+  initializeMetrics,
+  recordToolInvocation,
+  shutdownMetrics,
+} from './metrics.js';
+
+describe('Metrics token routing', () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.CIRCLECI_TOKEN;
+    delete process.env.DISABLE_TELEMETRY;
+  });
+
+  afterEach(async () => {
+    await shutdownMetrics();
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should flush metrics with the request-scoped token', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock;
+
+    await initializeMetrics();
+
+    runWithCircleCIToken('request-token-a', () => {
+      recordToolInvocation('test_tool', MetricStatus.SUCCESS);
+    });
+
+    await shutdownMetrics();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.headers).toMatchObject({
+      'Circle-Token': 'request-token-a',
+    });
+  });
+
+  it('should group buffered metrics by token during flush', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock;
+
+    await initializeMetrics();
+
+    runWithCircleCIToken('token-a', () => {
+      recordToolInvocation('tool_a', MetricStatus.SUCCESS);
+    });
+    runWithCircleCIToken('token-b', () => {
+      recordToolInvocation('tool_b', MetricStatus.SUCCESS);
+    });
+
+    await shutdownMetrics();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const tokens = fetchMock.mock.calls.map(
+      ([, init]) => (init?.headers as Record<string, string>)['Circle-Token'],
+    );
+    expect(tokens.sort()).toEqual(['token-a', 'token-b']);
+  });
+
+  it('should skip metrics when no token is available', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock;
+
+    await initializeMetrics();
+    recordToolInvocation('test_tool', MetricStatus.SUCCESS);
+    await shutdownMetrics();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/telemetry/metrics.ts
+++ b/src/lib/telemetry/metrics.ts
@@ -5,6 +5,7 @@
  * in the same JSON format used by test-agent.
  */
 
+import { resolveCircleCIToken } from '../auth/resolveToken.js';
 import {
   getTelemetryConfig,
   TELEMETRY_FLUSH_INTERVAL_MS,
@@ -42,10 +43,14 @@ type MetricData = {
   tags: string[];
 };
 
+type BufferedMetric = MetricData & {
+  token: string;
+};
+
 const FLUSH_TIMEOUT_MS = 10_000;
 
 let config: TelemetryConfig | null = null;
-let buffer: MetricData[] = [];
+let buffer: BufferedMetric[] = [];
 let flushTimer: ReturnType<typeof setInterval> | null = null;
 
 export async function initializeMetrics(): Promise<void> {
@@ -54,7 +59,7 @@ export async function initializeMetrics(): Promise<void> {
   if (!config.enabled) {
     if (process.env.debug === 'true') {
       console.error(
-        '[DEBUG] [Telemetry] Metrics disabled (DISABLE_TELEMETRY=true or CIRCLECI_TOKEN not set)',
+        '[DEBUG] [Telemetry] Metrics disabled (DISABLE_TELEMETRY=true)',
       );
     }
     return;
@@ -81,7 +86,11 @@ function record(
   tags: string[],
 ): void {
   if (!config?.enabled) return;
-  buffer.push({ type, name, value, tags });
+
+  const token = resolveCircleCIToken();
+  if (!token) return;
+
+  buffer.push({ type, name, value, tags, token });
 }
 
 export function recordToolInvocation(
@@ -116,33 +125,46 @@ async function flush(): Promise<void> {
   if (!config?.enabled || buffer.length === 0) return;
 
   const metrics = buffer.splice(0);
-  const body = JSON.stringify({
-    metrics,
-    tags: [`service:${TELEMETRY_SERVICE_NAME}`],
-  });
+  const metricsByToken = new Map<string, MetricData[]>();
 
-  try {
-    const response = await fetch(TELEMETRY_METRICS_URL, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        'Circle-Token': config.token,
-      },
-      body,
-      signal: AbortSignal.timeout(FLUSH_TIMEOUT_MS),
+  for (const { token, ...metricData } of metrics) {
+    const tokenMetrics = metricsByToken.get(token);
+    if (tokenMetrics) {
+      tokenMetrics.push(metricData);
+    } else {
+      metricsByToken.set(token, [metricData]);
+    }
+  }
+
+  for (const [token, tokenMetrics] of metricsByToken) {
+    const body = JSON.stringify({
+      metrics: tokenMetrics,
+      tags: [`service:${TELEMETRY_SERVICE_NAME}`],
     });
 
-    if (!response.ok && process.env.debug === 'true') {
-      console.error(
-        `[DEBUG] [Telemetry] Metric flush failed: ${response.status} ${response.statusText}`,
-      );
-    }
-  } catch (error) {
-    if (process.env.debug === 'true') {
-      console.error(
-        '[DEBUG] [Telemetry] Metric flush error:',
-        error instanceof Error ? error.message : String(error),
-      );
+    try {
+      const response = await fetch(TELEMETRY_METRICS_URL, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Circle-Token': token,
+        },
+        body,
+        signal: AbortSignal.timeout(FLUSH_TIMEOUT_MS),
+      });
+
+      if (!response.ok && process.env.debug === 'true') {
+        console.error(
+          `[DEBUG] [Telemetry] Metric flush failed: ${response.status} ${response.statusText}`,
+        );
+      }
+    } catch (error) {
+      if (process.env.debug === 'true') {
+        console.error(
+          '[DEBUG] [Telemetry] Metric flush error:',
+          error instanceof Error ? error.message : String(error),
+        );
+      }
     }
   }
 }

--- a/src/transports/unified.ts
+++ b/src/transports/unified.ts
@@ -2,7 +2,13 @@ import express from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
+
+import {
+  extractCircleCITokenFromRequest,
+  isRequestTokenRequired,
+} from '../lib/auth/extractToken.js';
+import { runWithCircleCIToken } from '../lib/auth/requestContext.js';
 
 // Debug subclass that logs every payload sent over SSE
 class DebugSSETransport extends SSEServerTransport {
@@ -15,6 +21,37 @@ class DebugSSETransport extends SSEServerTransport {
     }
     return super.send(payload);
   }
+}
+
+function sendUnauthorized(res: Response): void {
+  res.status(401).json({
+    jsonrpc: '2.0',
+    error: {
+      code: -32001,
+      message:
+        'Unauthorized: CircleCI token required via Authorization: Bearer or Circle-Token header',
+    },
+    id: null,
+  });
+}
+
+async function runWithRequestAuth<T>(
+  req: Request,
+  res: Response,
+  handler: () => Promise<T>,
+): Promise<T | undefined> {
+  const requestToken = extractCircleCITokenFromRequest(req);
+
+  if (isRequestTokenRequired() && !requestToken) {
+    sendUnauthorized(res);
+    return undefined;
+  }
+
+  if (requestToken) {
+    return runWithCircleCIToken(requestToken, handler);
+  }
+
+  return handler();
 }
 
 /**
@@ -37,22 +74,24 @@ export const createUnifiedTransport = (server: McpServer) => {
   // GET /mcp → open SSE stream, assign session if needed (stateless)
   app.get('/mcp', (req, res) => {
     (async () => {
-      if (process.env.debug === 'true') {
-        const sessionId =
-          req.header('Mcp-Session-Id') ||
-          req.header('mcp-session-id') ||
-          (req.query.sessionId as string);
-        console.error(`[DEBUG] [GET /mcp] Incoming session:`, sessionId);
-      }
-      // Create SSE transport (stateless)
-      const transport = new DebugSSETransport('/mcp', res);
-      if (process.env.debug === 'true') {
-        console.error(`[DEBUG] [GET /mcp] Created SSE transport.`);
-      }
-      await server.connect(transport);
-      // Notify newly connected client of current tool catalogue
-      await server.sendToolListChanged();
-      // SSE connection will be closed by client or on disconnect
+      await runWithRequestAuth(req, res, async () => {
+        if (process.env.debug === 'true') {
+          const sessionId =
+            req.header('Mcp-Session-Id') ||
+            req.header('mcp-session-id') ||
+            (req.query.sessionId as string);
+          console.error(`[DEBUG] [GET /mcp] Incoming session:`, sessionId);
+        }
+        // Create SSE transport (stateless)
+        const transport = new DebugSSETransport('/mcp', res);
+        if (process.env.debug === 'true') {
+          console.error(`[DEBUG] [GET /mcp] Created SSE transport.`);
+        }
+        await server.connect(transport);
+        // Notify newly connected client of current tool catalogue
+        await server.sendToolListChanged();
+        // SSE connection will be closed by client or on disconnect
+      });
     })().catch((err) => {
       console.error('GET /mcp error:', err);
       if (!res.headersSent) res.status(500).end();
@@ -63,39 +102,45 @@ export const createUnifiedTransport = (server: McpServer) => {
   app.post('/mcp', (req, res) => {
     (async () => {
       try {
-        if (process.env.debug === 'true') {
-          const names = Object.keys((server as any)._registeredTools ?? {});
-          console.error(`[DEBUG] visible tools:`, names);
-          console.error(
-            `[DEBUG] incoming request body:`,
-            JSON.stringify(req.body),
-          );
-        }
-
-        // For each POST, create a temporary, stateless transport to handle the request/response cycle.
-        const httpTransport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: undefined, // Ensures stateless operation
-        });
-
-        // Connect the server to the transport. This wires the server's internal `_handleRequest`
-        // method to the transport's `onmessage` event.
-        await server.connect(httpTransport);
-
-        // Handle the request. The transport will receive the request, pass it to the server via
-        // `onmessage`, receive the response from the server via its `send` method, and then
-        // write the response back to the client over the HTTP connection.
-        await httpTransport.handleRequest(req, res, req.body);
-
-        // After responding to initialize, send tool catalogue again so the freshly initialised
-        // client is guaranteed to see it (the first notification may have been sent before it
-        // started listening on the SSE stream).
-        if (req.body?.method === 'initialize') {
+        const handled = await runWithRequestAuth(req, res, async () => {
           if (process.env.debug === 'true') {
+            const names = Object.keys((server as any)._registeredTools ?? {});
+            console.error(`[DEBUG] visible tools:`, names);
             console.error(
-              '[DEBUG] initialize handled -> sending tools/list_changed again',
+              `[DEBUG] incoming request body:`,
+              JSON.stringify(req.body),
             );
           }
-          await server.sendToolListChanged();
+
+          // For each POST, create a temporary, stateless transport to handle the request/response cycle.
+          const httpTransport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined, // Ensures stateless operation
+          });
+
+          // Connect the server to the transport. This wires the server's internal `_handleRequest`
+          // method to the transport's `onmessage` event.
+          await server.connect(httpTransport);
+
+          // Handle the request. The transport will receive the request, pass it to the server via
+          // `onmessage`, receive the response from the server via its `send` method, and then
+          // write the response back to the client over the HTTP connection.
+          await httpTransport.handleRequest(req, res, req.body);
+
+          // After responding to initialize, send tool catalogue again so the freshly initialised
+          // client is guaranteed to see it (the first notification may have been sent before it
+          // started listening on the SSE stream).
+          if (req.body?.method === 'initialize') {
+            if (process.env.debug === 'true') {
+              console.error(
+                '[DEBUG] initialize handled -> sending tools/list_changed again',
+              );
+            }
+            await server.sendToolListChanged();
+          }
+        });
+
+        if (handled === undefined) {
+          return;
         }
       } catch (error: any) {
         console.error('Error handling MCP request:', error);


### PR DESCRIPTION
## Summary
- Accept CircleCI PATs per request on remote HTTP endpoints via `Authorization: Bearer` or `Circle-Token`
- Support `REQUIRE_REQUEST_TOKEN=true` for team deployments where each developer uses their own token
- Keep `CIRCLECI_TOKEN` as a shared-token fallback and route telemetry with the resolved request token

## Test plan
- [x] Unit tests for token resolution, auth headers, and telemetry token routing
- [x] Manual Docker remote server test (401 without token, 200 with Bearer, tool calls with real PAT)