### PR TITLE
chore: release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-06-09
+
+### Added
+
+- Added per-request CircleCI token auth for remote MCP deployments. Remote HTTP servers can accept each developer's CircleCI PAT via `Authorization: Bearer` or `Circle-Token` headers, with an optional `REQUIRE_REQUEST_TOKEN=true` for team deployments and `CIRCLECI_TOKEN` retained as a shared-token fallback (#165)
+- Added optional `outputDir` parameter to the `get_build_failure_logs` tool to write full logs to a file (#162)
+
 ## [0.15.1] - 2026-04-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",


### PR DESCRIPTION
## Summary

Follow-up release PR. PR #165 was merged to `main` without bumping the package version or updating the changelog. This PR cuts the **0.16.0** release.

Two unreleased additive features have landed since 0.15.1, so a **minor** bump is appropriate:
- **#165** — per-request CircleCI token auth for remote MCP deployments
- **#162** — optional `outputDir` for the `get_build_failure_logs` tool

## Changes
- Bump `package.json` version `0.15.1` → `0.16.0`
- Add `0.16.0` entry to `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)