### PR TITLE
ci: use npm trusted publishing (OIDC) for releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,6 @@ commands:
             echo "Version: $PACKAGE_VERSION"
             echo "Full identifier: $FULL_IDENTIFIER"
 
-  login:
-    steps:
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_ACCESS_TOKEN" >> ~/.npmrc
-
   install-deps:
     steps:
       - node/install-packages:
@@ -88,17 +84,24 @@ jobs:
       - install-deps
       - attach_workspace:
           at: .
-      - login
+      - run:
+          name: Upgrade npm for trusted publishing
+          command: |
+            # Trusted publishing (OIDC) requires npm >= 11.5.1; cimg/node:22.14 ships 10.x.
+            sudo npm install -g npm@latest
+            npm --version
       - run:
           name: Publish npm Package
           command: |
             echo "Checking for published version: $FULL_IDENTIFIER..."
-            if ! pnpm view $FULL_IDENTIFIER --json > /dev/null 2>&1; then
-              echo "Publishing $FULL_IDENTIFIER…"
-              pnpm publish --no-git-checks
-            else
+            if pnpm view $FULL_IDENTIFIER --json > /dev/null 2>&1; then
               echo "$FULL_IDENTIFIER already published. Doing nothing."
+              exit 0
             fi
+            echo "Publishing $FULL_IDENTIFIER…"
+            # OIDC trusted publishing: npm exchanges NPM_ID_TOKEN for a short-lived publish token.
+            export NPM_ID_TOKEN="$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')"
+            npm publish --access public
 
   publish-docker-image:
     executor: docker-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,8 @@ jobs:
       - run:
           name: Upgrade npm for trusted publishing
           command: |
-            # Trusted publishing (OIDC) requires npm >= 11.5.1; cimg/node:22.14 ships 10.x.
+            # pnpm 10 delegates `pnpm publish` to the npm CLI on PATH, and OIDC
+            # trusted publishing requires npm >= 11.5.1; cimg/node:22.14 ships 10.x.
             sudo npm install -g npm@latest
             npm --version
       - run:
@@ -99,9 +100,10 @@ jobs:
               exit 0
             fi
             echo "Publishing $FULL_IDENTIFIER…"
-            # OIDC trusted publishing: npm exchanges NPM_ID_TOKEN for a short-lived publish token.
+            # OIDC trusted publishing: pnpm shells out to npm, which exchanges
+            # NPM_ID_TOKEN for a short-lived publish token.
             export NPM_ID_TOKEN="$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')"
-            npm publish --access public
+            pnpm publish --no-git-checks
 
   publish-docker-image:
     executor: docker-executor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] - 2026-06-16
+
+### Changed
+
+- npm releases now use trusted publishing (OIDC) instead of a static `NPM_ACCESS_TOKEN`. The publish job exchanges a CircleCI OIDC token for a short-lived npm token via `NPM_ID_TOKEN` (#170)
+
 ## [0.16.1] - 2026-06-09
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the contributor guidelines (conventional commits).
- [ ] Tests for the changes — N/A, CI config change.
- [ ] Documentation — N/A.

## PR Type

- [x] CI related changes

## What issues are resolved by this PR?

N/A — follows the npm-side trusted publisher setup.

## Describe the new behavior.

Publishes to npm via [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC) instead of a static `NPM_ACCESS_TOKEN`.

`pnpm publish` is kept — pnpm 10 delegates publishing to the `npm` CLI on PATH, so npm performs the `NPM_ID_TOKEN` exchange. The job upgrades npm to `latest` since OIDC needs npm >= 11.5.1 (`cimg/node:22.14` ships 10.x).

Follows [CircleCI-Public/sign-and-publish-examples](https://github.com/CircleCI-Public/sign-and-publish-examples/blob/main/.circleci/npm-publish.yml).

## Does this PR introduce a breaking change?

- [x] No