### PR TITLE
security: fix DNS-rebinding vulnerability in remote HTTP transport (v0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-06-26
+
+### Security
+
+- Fixed a DNS-rebinding vulnerability in the remote HTTP transport. The `/mcp` routes now validate the `Host` header against an allowlist (loopback by default) and the `Origin` header when present (absent Origin is allowed — non-browser clients such as `mcp-remote` never send it). Requests with a disallowed `Host` or `Origin` receive `403 Forbidden`. **Breaking for public deployments:** operators must set `MCP_ALLOWED_HOSTS` to the hostname their clients use, or requests will be rejected.
+
+### Added
+
+- `MCP_ALLOWED_HOSTS` — comma-separated list of additional `Host` values to permit on `/mcp` routes (e.g. `my-mcp.example.com`). Loopback is always allowed.
+- `MCP_ALLOWED_ORIGINS` — comma-separated list of additional `Origin` values to permit (e.g. `https://my-app.example.com`). Loopback origins are always allowed. Only needed when a browser reaches this server directly.
+- `MCP_BIND_HOST` — network interface to bind to (default: `0.0.0.0`, unchanged). Set to `127.0.0.1` to restrict to loopback.
+
 ## [0.16.2] - 2026-06-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ Run the MCP server centrally (for example on Kubernetes or Docker) so your team 
 
 Both modes use remote HTTP mode (`start=remote`). Publish port `8000` (or your chosen port).
 
-**Per-user tokens (recommended):**
+**Per-user tokens (recommended) — accessed via `mcp-remote` from localhost:**
 
 ```bash
 docker run --rm -p 8000:8000 \
@@ -487,7 +487,18 @@ docker run --rm -p 8000:8000 \
   circleci/mcp-server-circleci
 ```
 
-**Shared token (interim):**
+**Per-user tokens (recommended) — accessed via `mcp-remote` from a public hostname:**
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e start=remote \
+  -e port=8000 \
+  -e REQUIRE_REQUEST_TOKEN=true \
+  -e MCP_ALLOWED_HOSTS=my-mcp.example.com \
+  circleci/mcp-server-circleci
+```
+
+**Shared token (interim) — accessed via `mcp-remote` from a public hostname:**
 
 ```bash
 docker run --rm -p 8000:8000 \
@@ -495,6 +506,7 @@ docker run --rm -p 8000:8000 \
   -e port=8000 \
   -e CIRCLECI_TOKEN=your-shared-circleci-pat \
   -e REQUIRE_REQUEST_TOKEN=false \
+  -e MCP_ALLOWED_HOSTS=my-mcp.example.com \
   circleci/mcp-server-circleci
 ```
 
@@ -508,6 +520,15 @@ docker run --rm -p 8000:8000 \
 | `CIRCLECI_TOKEN` | Shared fallback PAT for all requests when per-user headers are not sent |
 | `CIRCLECI_BASE_URL` | Optional — required for on-prem only (default: `https://circleci.com`) |
 | `DISABLE_TELEMETRY=true` | Opt out of usage metrics export |
+| `MCP_ALLOWED_HOSTS` | Comma-separated list of additional `Host` header values to allow (e.g. `my-mcp.example.com,my-mcp.example.com:443`). Loopback hostnames are always allowed. Required for any non-loopback deployment. |
+| `MCP_ALLOWED_ORIGINS` | Comma-separated list of additional `Origin` header values to allow (e.g. `https://my-app.example.com`). Loopback origins are always allowed. Only needed when a browser directly reaches this server (not via `mcp-remote`). |
+| `MCP_BIND_HOST` | Network interface to bind to (default: `0.0.0.0`). Set to `127.0.0.1` to restrict to loopback only (not compatible with Docker `-p` port mapping). |
+
+> **DNS-rebinding protection:** The remote transport validates the `Host` header on every `/mcp` request. By default only loopback addresses (`localhost`, `127.0.0.1`, `[::1]`) are accepted. **Public deployments must set `MCP_ALLOWED_HOSTS`** to the hostname clients use, or all `/mcp` requests will receive `403 Forbidden`. The `/ping` health-check endpoint is not guarded so load-balancer probes continue to work regardless of `Host`.
+>
+> The `Origin` header (sent by browsers) is also validated when present. Non-browser clients such as `mcp-remote` never send `Origin`, so they are unaffected by this check.
+>
+> **Behind a reverse proxy:** If your proxy rewrites `Host` to the backend address (nginx's default), add `proxy_set_header Host $host;` to pass the original hostname through, then set `MCP_ALLOWED_HOSTS` to that public hostname. Alternatively, set `MCP_ALLOWED_HOSTS` to whatever hostname the proxy does forward.
 
 The server accepts per-request tokens via:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/mcp-server-circleci",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "A Model Context Protocol (MCP) server implementation for CircleCI, enabling natural language interactions with CircleCI functionality through MCP-enabled clients",
   "type": "module",
   "access": "public",

--- a/src/lib/auth/originValidation.test.ts
+++ b/src/lib/auth/originValidation.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Request } from 'express';
+
+import {
+  getAllowedHosts,
+  getAllowedOrigins,
+  isHostAllowed,
+  isOriginAllowed,
+  validateRemoteRequest,
+} from './originValidation.js';
+
+function createRequest(headers: Record<string, string | undefined>): Request {
+  return {
+    header(name: string) {
+      const normalized = name.toLowerCase();
+      for (const [key, value] of Object.entries(headers)) {
+        if (key.toLowerCase() === normalized) return value;
+      }
+      return undefined;
+    },
+  } as Request;
+}
+
+const PORT = 8000;
+
+describe('getAllowedHosts', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.MCP_ALLOWED_HOSTS;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('includes loopback hosts by default', () => {
+    const allowed = getAllowedHosts(PORT);
+    expect(allowed.has('localhost')).toBe(true);
+    expect(allowed.has('127.0.0.1')).toBe(true);
+    expect(allowed.has('[::1]')).toBe(true);
+    expect(allowed.has('::1')).toBe(true);
+  });
+
+  it('includes loopback hosts with port by default', () => {
+    const allowed = getAllowedHosts(PORT);
+    expect(allowed.has('localhost:8000')).toBe(true);
+    expect(allowed.has('127.0.0.1:8000')).toBe(true);
+  });
+
+  it('does not include foreign hosts by default', () => {
+    const allowed = getAllowedHosts(PORT);
+    expect(allowed.has('attacker.com')).toBe(false);
+    expect(allowed.has('example.com:8000')).toBe(false);
+  });
+
+  it('adds public host from MCP_ALLOWED_HOSTS', () => {
+    process.env.MCP_ALLOWED_HOSTS = 'my-mcp.example.com,my-mcp.example.com:443';
+    const allowed = getAllowedHosts(PORT);
+    expect(allowed.has('my-mcp.example.com')).toBe(true);
+    expect(allowed.has('my-mcp.example.com:443')).toBe(true);
+  });
+
+  it('MCP_ALLOWED_HOSTS does not include unlisted hosts', () => {
+    process.env.MCP_ALLOWED_HOSTS = 'my-mcp.example.com';
+    const allowed = getAllowedHosts(PORT);
+    expect(allowed.has('other.example.com')).toBe(false);
+  });
+});
+
+describe('getAllowedOrigins', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.MCP_ALLOWED_ORIGINS;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('includes loopback origins by default', () => {
+    const allowed = getAllowedOrigins(PORT);
+    expect(allowed.has('http://localhost')).toBe(true);
+    expect(allowed.has('https://localhost')).toBe(true);
+    expect(allowed.has('http://127.0.0.1')).toBe(true);
+    expect(allowed.has('https://127.0.0.1')).toBe(true);
+  });
+
+  it('includes loopback origins with port by default', () => {
+    const allowed = getAllowedOrigins(PORT);
+    expect(allowed.has('http://localhost:8000')).toBe(true);
+    expect(allowed.has('https://127.0.0.1:8000')).toBe(true);
+  });
+
+  it('adds public origin from MCP_ALLOWED_ORIGINS', () => {
+    process.env.MCP_ALLOWED_ORIGINS = 'https://my-app.example.com';
+    const allowed = getAllowedOrigins(PORT);
+    expect(allowed.has('https://my-app.example.com')).toBe(true);
+  });
+});
+
+describe('isHostAllowed', () => {
+  it('allows loopback host', () => {
+    const allowed = getAllowedHosts(PORT);
+    expect(isHostAllowed('localhost', allowed)).toBe(true);
+  });
+
+  it('allows localhost with port', () => {
+    const allowed = getAllowedHosts(PORT);
+    expect(isHostAllowed('localhost:8000', allowed)).toBe(true);
+  });
+
+  it('denies foreign host', () => {
+    const allowed = getAllowedHosts(PORT);
+    expect(isHostAllowed('attacker.com', allowed)).toBe(false);
+  });
+
+  it('denies missing Host header', () => {
+    const allowed = getAllowedHosts(PORT);
+    expect(isHostAllowed(undefined, allowed)).toBe(false);
+  });
+
+  it('denies empty Host header', () => {
+    const allowed = getAllowedHosts(PORT);
+    expect(isHostAllowed('', allowed)).toBe(false);
+  });
+});
+
+describe('isOriginAllowed', () => {
+  it('allows absent Origin (non-browser client)', () => {
+    const allowed = getAllowedOrigins(PORT);
+    expect(isOriginAllowed(undefined, allowed)).toBe(true);
+  });
+
+  it('allows empty Origin (non-browser client)', () => {
+    const allowed = getAllowedOrigins(PORT);
+    expect(isOriginAllowed('', allowed)).toBe(true);
+  });
+
+  it('allows loopback Origin', () => {
+    const allowed = getAllowedOrigins(PORT);
+    expect(isOriginAllowed('http://localhost', allowed)).toBe(true);
+    expect(isOriginAllowed('http://localhost:8000', allowed)).toBe(true);
+  });
+
+  it('denies foreign Origin', () => {
+    const allowed = getAllowedOrigins(PORT);
+    expect(isOriginAllowed('http://attacker.com', allowed)).toBe(false);
+  });
+
+  it('allows origin added via MCP_ALLOWED_ORIGINS', () => {
+    const allowed = new Set(['https://my-app.example.com']);
+    expect(isOriginAllowed('https://my-app.example.com', allowed)).toBe(true);
+  });
+});
+
+describe('validateRemoteRequest', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.MCP_ALLOWED_HOSTS;
+    delete process.env.MCP_ALLOWED_ORIGINS;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('allows legitimate local request (no Origin)', () => {
+    const req = createRequest({ host: 'localhost:8000' });
+    expect(validateRemoteRequest(req, PORT)).toBe(true);
+  });
+
+  it('allows legitimate local request with loopback Origin', () => {
+    const req = createRequest({
+      host: 'localhost:8000',
+      origin: 'http://localhost:8000',
+    });
+    expect(validateRemoteRequest(req, PORT)).toBe(true);
+  });
+
+  it('denies DNS-rebinding shape: foreign Host + foreign Origin', () => {
+    const req = createRequest({
+      host: 'attacker.com',
+      origin: 'http://attacker.com',
+    });
+    expect(validateRemoteRequest(req, PORT)).toBe(false);
+  });
+
+  it('denies foreign Host even with no Origin', () => {
+    const req = createRequest({ host: 'attacker.com' });
+    expect(validateRemoteRequest(req, PORT)).toBe(false);
+  });
+
+  it('denies foreign Origin even with loopback Host', () => {
+    const req = createRequest({
+      host: 'localhost:8000',
+      origin: 'http://attacker.com',
+    });
+    expect(validateRemoteRequest(req, PORT)).toBe(false);
+  });
+
+  it('denies missing Host', () => {
+    const req = createRequest({});
+    expect(validateRemoteRequest(req, PORT)).toBe(false);
+  });
+
+  it('allows public host when MCP_ALLOWED_HOSTS is set', () => {
+    process.env.MCP_ALLOWED_HOSTS = 'my-mcp.example.com';
+    const req = createRequest({ host: 'my-mcp.example.com' });
+    expect(validateRemoteRequest(req, PORT)).toBe(true);
+  });
+});

--- a/src/lib/auth/originValidation.ts
+++ b/src/lib/auth/originValidation.ts
@@ -1,0 +1,39 @@
+import type { Request } from 'express';
+
+function parseEnvList(env: string | undefined): string[] {
+  return env ? env.split(',').map(s => s.trim().toLowerCase()).filter(Boolean) : [];
+}
+
+export function getAllowedHosts(port: string | number): Set<string> {
+  const loopback = ['localhost', '127.0.0.1', '[::1]', '::1'];
+  const result = new Set(loopback.flatMap(h => [h, `${h}:${port}`]));
+  for (const h of parseEnvList(process.env.MCP_ALLOWED_HOSTS)) result.add(h);
+  return result;
+}
+
+export function getAllowedOrigins(port: string | number): Set<string> {
+  const result = new Set(
+    ['http', 'https'].flatMap(s =>
+      ['localhost', '127.0.0.1'].flatMap(h => [`${s}://${h}`, `${s}://${h}:${port}`]),
+    ),
+  );
+  for (const o of parseEnvList(process.env.MCP_ALLOWED_ORIGINS)) result.add(o);
+  return result;
+}
+
+export function isHostAllowed(host: string | undefined, allowed: Set<string>): boolean {
+  return !!host?.trim() && allowed.has(host.trim().toLowerCase());
+}
+
+export function isOriginAllowed(origin: string | undefined, allowed: Set<string>): boolean {
+  // Non-browser clients (mcp-remote, curl) send no Origin — allow them.
+  if (!origin?.trim()) return true;
+  return allowed.has(origin.trim().toLowerCase());
+}
+
+export function validateRemoteRequest(req: Request, port: string | number): boolean {
+  return (
+    isHostAllowed(req.header('host'), getAllowedHosts(port)) &&
+    isOriginAllowed(req.header('origin'), getAllowedOrigins(port))
+  );
+}

--- a/src/transports/unified.ts
+++ b/src/transports/unified.ts
@@ -8,6 +8,7 @@ import {
   extractCircleCITokenFromRequest,
   isRequestTokenRequired,
 } from '../lib/auth/extractToken.js';
+import { validateRemoteRequest } from '../lib/auth/originValidation.js';
 import { runWithCircleCIToken } from '../lib/auth/requestContext.js';
 
 // Debug subclass that logs every payload sent over SSE
@@ -64,11 +65,24 @@ export const createUnifiedTransport = (server: McpServer) => {
   const app = express();
   app.use(express.json());
 
+  const port = process.env.port || 8000;
+
   // Stateless: No in-memory session or transport store
 
-  // Health check
+  // Health check — intentionally unguarded so any load-balancer probes always pass.
   app.get('/ping', (_req, res) => {
     res.json({ result: 'pong' });
+  });
+
+  // DNS-rebinding guard for all /mcp routes.
+  // Validates Host (always required) and Origin (only when present — absent means
+  // a non-browser client like mcp-remote, which is always allowed).
+  app.use('/mcp', (req, res, next) => {
+    if (!validateRemoteRequest(req, port)) {
+      res.status(403).end();
+      return;
+    }
+    next();
   });
 
   // GET /mcp → open SSE stream, assign session if needed (stateless)
@@ -174,10 +188,10 @@ export const createUnifiedTransport = (server: McpServer) => {
     res.status(204).end();
   });
 
-  const port = process.env.port || 8000;
-  app.listen(port, () => {
+  const bindHost = process.env.MCP_BIND_HOST || '0.0.0.0';
+  app.listen(Number(port), bindHost, () => {
     console.error(
-      `CircleCI MCP unified HTTP+SSE server listening on http://0.0.0.0:${port}`,
+      `CircleCI MCP unified HTTP+SSE server listening on http://${bindHost}:${port}`,
     );
   });
 };


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our contributor [guidelines](https://github.com/CircleCI-Public/mcp-server-circleci/blob/main/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added or updated where needed.

## PR Type

- [x] Bug fix

## What issues are resolved by this PR?

- #[00]

## Describe the new behavior.

The remote HTTP transport now validates `Host` and `Origin` headers on all `/mcp` routes to prevent DNS-rebinding attacks. Loopback addresses are always allowed; operators running the server on a public hostname must set `MCP_ALLOWED_HOSTS`. Three new environment variables are introduced: `MCP_ALLOWED_HOSTS`, `MCP_ALLOWED_ORIGINS`, and `MCP_BIND_HOST`. README and CHANGELOG updated accordingly.

## Does this PR introduce a breaking change?

- [x] Yes

Public deployments not running on loopback must set `MCP_ALLOWED_HOSTS` to their public hostname, otherwise `/mcp` requests will receive `403 Forbidden`.

## Other information

> More information (optional)