### PR TITLE
fix: resolve project slug via CircleCI API instead of followed-projects list

### DIFF
--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -249,11 +249,6 @@ describe('identifyProjectSlug', () => {
     );
   });
 
-  // Regression: identifyProjectSlug used to only match against
-  // getFollowedProjects(), so an unfollowed-but-accessible project could
-  // never resolve even with a correct git remote URL. It now validates a
-  // directly-constructed slug against the CircleCI API instead, which also
-  // means SSH- and HTTPS-form remotes must resolve identically.
   it.each([
     {
       form: 'SSH',

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -279,6 +279,13 @@ describe('identifyProjectSlug', () => {
     },
   );
 
+  it('returns undefined without calling the CircleCI API for a remote URL with no owner/repo', async () => {
+    const slug = await identifyProjectSlug({ gitRemoteURL: 'not-a-url' });
+
+    expect(mockCircleCIClient.projects.getProject).not.toHaveBeenCalled();
+    expect(slug).toBeUndefined();
+  });
+
   it('throws for an unhandled VCS host', async () => {
     await expect(
       identifyProjectSlug({
@@ -299,5 +306,17 @@ describe('identifyProjectSlug', () => {
     });
 
     expect(slug).toBeUndefined();
+  });
+
+  it('rethrows a non-404 error instead of treating it as project-not-found', async () => {
+    mockCircleCIClient.projects.getProject.mockRejectedValue(
+      new Error('CircleCI API Error: 401 \nURL: /project/gh/organization/project'),
+    );
+
+    await expect(
+      identifyProjectSlug({
+        gitRemoteURL: 'https://github.com/organization/project.git',
+      }),
+    ).rejects.toThrow('CircleCI API Error: 401');
   });
 });

--- a/src/lib/project-detection/index.test.ts
+++ b/src/lib/project-detection/index.test.ts
@@ -3,8 +3,12 @@ import {
   getProjectSlugFromURL,
   getBranchFromURL,
   getJobNumberFromURL,
+  identifyProjectSlug,
 } from './index.js';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as clientModule from '../../clients/client.js';
+
+vi.mock('../../clients/client.js');
 
 describe('getPipelineNumberFromURL', () => {
   it.each([
@@ -228,5 +232,72 @@ describe('getJobNumberFromURL', () => {
         'https://app.circleci.com/pipelines/gh/organization/project/123/workflows/abc123de-f456-78gh-90ij-klmnopqrstuv/jobs/abc',
       ),
     ).toThrow('Job number in URL is not a valid number');
+  });
+});
+
+describe('identifyProjectSlug', () => {
+  const mockCircleCIClient = {
+    projects: {
+      getProject: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(clientModule, 'getCircleCIClient').mockReturnValue(
+      mockCircleCIClient as any,
+    );
+  });
+
+  // Regression: identifyProjectSlug used to only match against
+  // getFollowedProjects(), so an unfollowed-but-accessible project could
+  // never resolve even with a correct git remote URL. It now validates a
+  // directly-constructed slug against the CircleCI API instead, which also
+  // means SSH- and HTTPS-form remotes must resolve identically.
+  it.each([
+    {
+      form: 'SSH',
+      gitRemoteURL: 'git@github.com:organization/project.git',
+    },
+    {
+      form: 'HTTPS',
+      gitRemoteURL: 'https://github.com/organization/project.git',
+    },
+  ])(
+    'resolves a slug from an $form-form remote by validating it against the CircleCI API',
+    async ({ gitRemoteURL }) => {
+      mockCircleCIClient.projects.getProject.mockResolvedValue({
+        slug: 'gh/organization/project',
+      });
+
+      const slug = await identifyProjectSlug({ gitRemoteURL });
+
+      expect(mockCircleCIClient.projects.getProject).toHaveBeenCalledWith({
+        projectSlug: 'gh/organization/project',
+      });
+      expect(slug).toBe('gh/organization/project');
+    },
+  );
+
+  it('throws for an unhandled VCS host', async () => {
+    await expect(
+      identifyProjectSlug({
+        gitRemoteURL: 'git@gitlab.com:organization/project.git',
+      }),
+    ).rejects.toThrow('VCS with host gitlab.com is not handled');
+  });
+
+  it('returns undefined when the CircleCI API has no matching project', async () => {
+    mockCircleCIClient.projects.getProject.mockRejectedValue(
+      new Error(
+        'CircleCI API Error: 404 \nURL: /project/gh/no-such-org/no-such-project',
+      ),
+    );
+
+    const slug = await identifyProjectSlug({
+      gitRemoteURL: 'https://github.com/no-such-org/no-such-project.git',
+    });
+
+    expect(slug).toBeUndefined();
   });
 });

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -4,8 +4,7 @@ import gitUrlParse from 'parse-github-url';
 
 /**
  * Identify the project slug from the git remote URL, validating it against
- * the CircleCI API rather than the caller's followed-projects list, so it
- * also resolves projects the caller has access to but hasn't followed.
+ * the CircleCI API.
  * @param {string} gitRemoteURL - eg: https://github.com/organization/project.git
  * @returns {string | undefined} project slug (eg: gh/organization/project), or
  * undefined if the remote URL couldn't be parsed or no matching CircleCI

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -1,4 +1,4 @@
-import { getCircleCIPrivateClient } from '../../clients/client.js';
+import { getCircleCIClient } from '../../clients/client.js';
 import { getVCSFromHost, vcses } from './vcsTool.js';
 import gitUrlParse from 'parse-github-url';
 
@@ -12,10 +12,8 @@ export const identifyProjectSlug = async ({
 }: {
   gitRemoteURL: string;
 }) => {
-  const cciPrivateClients = getCircleCIPrivateClient();
-
   const parsedGitURL = gitUrlParse(gitRemoteURL);
-  if (!parsedGitURL?.host) {
+  if (!parsedGitURL?.host || !parsedGitURL.owner || !parsedGitURL.name) {
     return undefined;
   }
 
@@ -24,19 +22,18 @@ export const identifyProjectSlug = async ({
     throw new Error(`VCS with host ${parsedGitURL.host} is not handled`);
   }
 
-  const { projects: followedProjects } =
-    await cciPrivateClients.me.getFollowedProjects();
-  if (!followedProjects) {
-    throw new Error('Failed to get followed projects');
+  const projectSlug = `${vcs.short}/${parsedGitURL.owner}/${parsedGitURL.name}`;
+
+  try {
+    await getCircleCIClient().projects.getProject({ projectSlug });
+    return projectSlug;
+  } catch (error) {
+    console.error(
+      `[identifyProjectSlug] Could not find project ${projectSlug}:`,
+      error,
+    );
+    return undefined;
   }
-
-  const project = followedProjects.find(
-    (followedProject) =>
-      followedProject.name === parsedGitURL.name &&
-      followedProject.vcs_type === vcs.name,
-  );
-
-  return project?.slug;
 };
 
 /**

--- a/src/lib/project-detection/index.ts
+++ b/src/lib/project-detection/index.ts
@@ -3,9 +3,16 @@ import { getVCSFromHost, vcses } from './vcsTool.js';
 import gitUrlParse from 'parse-github-url';
 
 /**
- * Identify the project slug from the git remote URL
+ * Identify the project slug from the git remote URL, validating it against
+ * the CircleCI API rather than the caller's followed-projects list, so it
+ * also resolves projects the caller has access to but hasn't followed.
  * @param {string} gitRemoteURL - eg: https://github.com/organization/project.git
- * @returns {string} project slug - eg: gh/organization/project
+ * @returns {string | undefined} project slug (eg: gh/organization/project), or
+ * undefined if the remote URL couldn't be parsed or no matching CircleCI
+ * project exists
+ * @throws if the git remote's host is not a supported VCS, or if the
+ * CircleCI API call fails for a reason other than the project not existing
+ * (e.g. an invalid token, rate limiting, or a network error)
  */
 export const identifyProjectSlug = async ({
   gitRemoteURL,
@@ -28,11 +35,11 @@ export const identifyProjectSlug = async ({
     await getCircleCIClient().projects.getProject({ projectSlug });
     return projectSlug;
   } catch (error) {
-    console.error(
-      `[identifyProjectSlug] Could not find project ${projectSlug}:`,
-      error,
-    );
-    return undefined;
+    if (error instanceof Error && error.message.includes('404')) {
+      console.error(`Project ${projectSlug} not found:`, error);
+      return undefined;
+    }
+    throw error;
   }
 };
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our contributor [guidelines](https://github.com/CircleCI-Public/mcp-server-circleci/blob/main/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added or updated where needed.

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix

## What issues are resolved by this PR?

- Fixes #174

## Describe the new behavior.

Before this PR, `identifyProjectSlug` resolved a project slug by matching the parsed git remote against the caller's `me.getFollowedProjects()` list. A project the caller had API access to, but had not explicitly "followed" in the CircleCI UI, could never resolve — even with a fully correct `gitRemoteURL` — so callers of `get_latest_pipeline_status`, `run_pipeline`, `run_evaluation_tests`, `get_build_failure_logs`, `get_job_test_results`, `list_artifacts`, and `get_flaky_tests` would incorrectly report "Project not found."

With this PR, `identifyProjectSlug` constructs the slug directly from the parsed git remote and validates it against the CircleCI API (`GET /project/{slug}`), so it resolves any project the caller has access to, regardless of followed status. A confirmed 404 from that call still returns `undefined` (preserving the existing "Project not found" behavior for callers), but other failures — an invalid token, rate limiting, a network error — now propagate instead of being silently reported as a missing project.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

None of the 7 callers of `identifyProjectSlug` needed changes — the function's `undefined`-on-not-found / throw-on-other-errors contract is preserved.