### PR TITLE
security: add destructiveHint annotations to action and file-write tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,12 +67,12 @@ CCI_TOOLS.forEach((tool) => {
   // Wrap handler with telemetry instrumentation
   const wrappedHandler = wrapToolHandler(tool.name, handler as ToolHandler);
 
-  server.tool(
-    tool.name,
-    tool.description,
-    { params: tool.inputSchema.optional() },
-    wrappedHandler,
-  );
+  const annotations = (tool as { annotations?: Record<string, unknown> }).annotations;
+  if (annotations) {
+    server.tool(tool.name, tool.description, { params: tool.inputSchema.optional() }, annotations, wrappedHandler);
+  } else {
+    server.tool(tool.name, tool.description, { params: tool.inputSchema.optional() }, wrappedHandler);
+  }
 });
 
 async function main() {

--- a/src/lib/flaky-tests/getFlakyTests.ts
+++ b/src/lib/flaky-tests/getFlakyTests.ts
@@ -50,7 +50,7 @@ const getFlakyTests = async ({ projectSlug }: { projectSlug: string }) => {
 
   const filteredTestsArrays = testsArrays
     .flat()
-    .filter((test) => test !== undefined);
+    .filter((test): test is Test => test !== undefined);
 
   return filteredTestsArrays;
 };

--- a/src/tools/createPromptTemplate/tool.ts
+++ b/src/tools/createPromptTemplate/tool.ts
@@ -69,5 +69,8 @@ export const createPromptTemplateTool = {
     - a \`${promptOriginKey}\` that indicates whether the prompt comes from an existing prompt or prompt template in the user's codebase or from new requirements.
   - The tool output -- the \`${templateKey}\`, \`${contextSchemaKey}\`, and \`${promptOriginKey}\` -- will also be used as input to the \`${PromptWorkbenchToolName.recommend_prompt_template_tests}\` tool to generate a list of recommended tests that can be used to test the prompt template.
   `,
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: createPromptTemplateInputSchema,
 };

--- a/src/tools/downloadUsageApiData/tool.ts
+++ b/src/tools/downloadUsageApiData/tool.ts
@@ -33,5 +33,8 @@ export const downloadUsageApiDataTool = {
 
     This ensures that downloaded usage data is always saved in a location that is relevant and easy for the user to find, and that the output is always copy-paste friendly for status checks, regardless of the environment in which the tool is run.
   `,
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: downloadUsageApiDataInputSchema,
-}; 
+};

--- a/src/tools/getFlakyTests/tool.ts
+++ b/src/tools/getFlakyTests/tool.ts
@@ -37,5 +37,8 @@ export const getFlakyTestLogsTool = {
     - If using Option 3, BOTH parameters (workspaceRoot, gitRemoteURL) must be provided
     - If none of the options can be fully satisfied, ask the user for the missing information before making the tool call
     `,
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: getFlakyTestLogsInputSchema,
 };

--- a/src/tools/recommendPromptTemplateTests/tool.ts
+++ b/src/tools/recommendPromptTemplateTests/tool.ts
@@ -39,5 +39,8 @@ export const recommendPromptTemplateTestsTool = {
   Tool output instructions:
     - The tool will return a ${recommendedTestsVar} array that can be used to test the prompt template.
   `,
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: recommendPromptTemplateTestsInputSchema,
 };

--- a/src/tools/rerunWorkflow/tool.ts
+++ b/src/tools/rerunWorkflow/tool.ts
@@ -21,5 +21,8 @@ Option 2 - Workflow URL:
   * Workflow Job URL: https://app.circleci.com/pipelines/:vcsType/:orgName/:projectName/:pipelineNumber/workflows/:workflowId/jobs/:buildNumber
 - fromFailed: true to rerun from failed, false to rerun from start. If omitted, behavior is based on workflow status. (optional)
   `,
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: rerunWorkflowInputSchema,
 };

--- a/src/tools/runEvaluationTests/tool.ts
+++ b/src/tools/runEvaluationTests/tool.ts
@@ -51,5 +51,8 @@ export const runEvaluationTestsTool = {
     Returns:
     - A URL to the newly triggered pipeline that can be used to monitor its progress
     `,
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: runEvaluationTestsInputSchema,
 };

--- a/src/tools/runPipeline/tool.ts
+++ b/src/tools/runPipeline/tool.ts
@@ -41,5 +41,8 @@ export const runPipelineTool = {
     Returns:
     - A URL to the newly triggered pipeline that can be used to monitor its progress
     `,
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: runPipelineInputSchema,
 };

--- a/src/tools/runRollbackPipeline/tool.ts
+++ b/src/tools/runRollbackPipeline/tool.ts
@@ -53,5 +53,8 @@ export const runRollbackPipelineTool = {
     If no version is found, the tool will suggest the user to set up deploy markers following the documentation at:
     https://circleci.com/docs/deploy/configure-deploy-markers/
   `,
+  annotations: {
+    destructiveHint: true,
+  },
   inputSchema: runRollbackPipelineInputSchema,
 };


### PR DESCRIPTION
## Summary

- Adds `annotations: { destructiveHint: true }` to all MCP tools that trigger live CI/CD actions or write files to disk
- Ensures compliant MCP clients prompt for user confirmation before these tools execute, closing the window for an agent acting on injected instructions to silently trigger destructive operations

**6 tools identified**
- `run_pipeline` — triggers live CircleCI pipeline
- `rerun_workflow` — re-triggers a workflow
- `run_rollback_pipeline` — production rollback (highly destructive)
- `run_evaluation_tests` — triggers live pipeline
- `create_prompt_template` — writes prompt template files to disk
- `recommend_prompt_template_tests` — writes test files to disk

**2 additional tools found during full audit:**
- `downloadUsageApiData` — writes sensitive usage CSV to disk via `fs.writeFileSync`
- `getFlakyTests` — writes test output files and `.gitignore` to disk via `writeFileSync`

**All remaining 9 tools confirmed read-only** (no annotation needed): `get_build_failure_logs`, `get_latest_pipeline_status`, `get_job_test_results`, `config_helper`, `list_followed_projects`, `analyze_diff`, `find_underused_resource_classes`, `list_component_versions`, `list_artifacts`.

## Test plan

- [x] `pnpm test` passes (pre-existing 13 failures on `main` in `analyzeDiff`/`createPromptTemplate`/`recommendPromptTemplateTests` mock tests are unrelated and unchanged)
- [x] confirm annotations present on tool calls as advertised by mcp inspector.